### PR TITLE
Revamp and modernize the Core Foundation APIs.

### DIFF
--- a/array.rs
+++ b/array.rs
@@ -7,23 +7,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use base::{
-    AbstractCFTypeRef,
-    CFAllocatorRef,
-    CFIndex,
-    CFTypeID,
-    CFTypeRef,
-    CFWrapper,
-    kCFAllocatorDefault,
-};
+//! Heterogeneous immutable arrays.
+
+use base::{CFAllocatorRef, CFIndex, CFIndexConvertible, CFRelease, CFType, CFTypeID, TCFType};
+use base::{kCFAllocatorDefault};
 use std::cast;
 use std::libc::c_void;
-use std::ptr;
 use std::vec;
 
+/// FIXME(pcwalton): This is wrong.
 pub type CFArrayRetainCallBack = *u8;
+
+/// FIXME(pcwalton): This is wrong.
 pub type CFArrayReleaseCallBack = *u8;
+
+/// FIXME(pcwalton): This is wrong.
 pub type CFArrayCopyDescriptionCallBack = *u8;
+
+/// FIXME(pcwalton): This is wrong.
 pub type CFArrayEqualCallBack = *u8;
 
 pub struct CFArrayCallBacks {
@@ -34,71 +35,86 @@ pub struct CFArrayCallBacks {
     equal: CFArrayEqualCallBack,
 }
 
-struct __CFArray { private: () }
+struct __CFArray;
+
 pub type CFArrayRef = *__CFArray;
 
-impl AbstractCFTypeRef for CFArrayRef {
-    fn as_type_ref(&self) -> CFTypeRef { *self as CFTypeRef }
+/// A heterogeneous immutable array.
+///
+/// FIXME(pcwalton): Should be a newtype struct, but that fails due to a Rust compiler bug.
+pub struct CFArray {
+    priv obj: CFArrayRef,
+}
+
+impl Drop for CFArray {
     #[fixed_stack_segment]
-    fn type_id(_dummy: Option<CFArrayRef>) -> CFTypeID { unsafe { CFArrayGetTypeID() } }
+    fn drop(&mut self) {
+        unsafe {
+            CFRelease(self.as_CFTypeRef())
+        }
+    }
 }
 
-// FIXME: Should be a newtype struct, but that fails due to a Rust compiler bug.
-pub struct CFArray<ElemRefType> {
-    contents: CFWrapper<CFArrayRef, ElemRefType, ()>
+pub struct CFArrayIterator<'self> {
+    priv array: &'self CFArray,
+    priv index: CFIndex,
 }
 
-pub struct CFArrayIterator<'self, ElemRefType> {
-    priv array: &'self CFArray<ElemRefType>,
-    priv index: uint,
-}
-
-impl<'self, ElemRefType: AbstractCFTypeRef> Iterator<ElemRefType> for CFArrayIterator<'self, ElemRefType> {
-    fn next(&mut self) -> Option<ElemRefType> {
+impl<'self> Iterator<*c_void> for CFArrayIterator<'self> {
+    fn next(&mut self) -> Option<*c_void> {
         if self.index >= self.array.len() {
             None
         } else {
-            let v = self.array[self.index];
+            let value = self.array[self.index];
             self.index += 1;
-            Some(v)
+            Some(value)
         }
     }
 }
 
-impl<ElemRefType:AbstractCFTypeRef> CFArray<ElemRefType> {
-    pub fn wrap_shared(array: CFArrayRef) -> CFArray<ElemRefType> {
-        CFArray {
-            contents: CFWrapper::wrap_shared(array)
-        }
+impl TCFType<CFArrayRef> for CFArray {
+    #[inline]
+    fn as_concrete_TypeRef(&self) -> CFArrayRef {
+        self.obj
     }
 
-    pub fn wrap_owned(array: CFArrayRef) -> CFArray<ElemRefType> {
+    #[inline]
+    unsafe fn wrap_under_create_rule(obj: CFArrayRef) -> CFArray {
         CFArray {
-            contents: CFWrapper::wrap_owned(array)
+            obj: obj,
         }
     }
 
     #[fixed_stack_segment]
-    pub fn new(elems: &[ElemRefType]) -> CFArray<ElemRefType> {
-        let array_ref: CFArrayRef;
-        let elems_refs = do elems.map |e: &ElemRefType| { e.as_type_ref() };
-
+    #[inline]
+    fn type_id(_: Option<CFArray>) -> CFTypeID {
         unsafe {
-            array_ref = CFArrayCreate(kCFAllocatorDefault,
-                                      cast::transmute::<*CFTypeRef, **c_void>(vec::raw::to_ptr(elems_refs)),
-                                      elems.len() as CFIndex,
-                                      ptr::to_unsafe_ptr(&kCFTypeArrayCallBacks));
+            CFArrayGetTypeID()
         }
+    }
+}
 
-        CFArray {
-            contents: CFWrapper::wrap_owned(array_ref)
+impl CFArray {
+    /// Creates a new `CFArray` with the given elements, which must be `CFType` objects.
+    #[fixed_stack_segment]
+    pub fn from_CFTypes(elems: &[CFType]) -> CFArray {
+        unsafe {
+            let elems = elems.map(|elem| elem.as_CFTypeRef());
+            let array_ref = CFArrayCreate(kCFAllocatorDefault,
+                                          cast::transmute(vec::raw::to_ptr(elems)),
+                                          elems.len().to_CFIndex(),
+                                          &kCFTypeArrayCallBacks);
+            TCFType::wrap_under_create_rule(array_ref)
         }
     }
 
-    // Careful; the loop body must wrap the reference properly.
-    // Generally, when array elements are Core Foundation objects (not
-    // always true), they need to be wrapped with CFWrapper::wrap_shared.
-    pub fn iter<'t>(&'t self) -> CFArrayIterator<'t, ElemRefType> {
+    /// Iterates over the elements of this `CFArray`.
+    ///
+    /// Careful; the loop body must wrap the reference properly. Generally, when array elements are
+    /// Core Foundation objects (not always true), they need to be wrapped with
+    /// `TCFType::wrap_under_get_rule()`. The safer `iter_CFTypes` method will do this for you.
+    #[inline]
+    pub fn iter<'a>(&'a self) -> CFArrayIterator<'a> {
         CFArrayIterator {
             array: self,
             index: 0
@@ -106,25 +122,24 @@ impl<ElemRefType:AbstractCFTypeRef> CFArray<ElemRefType> {
     }
 
     #[fixed_stack_segment]
-    pub fn len(&self) -> uint {
+    #[inline]
+    pub fn len(&self) -> CFIndex {
         unsafe {
-            return CFArrayGetCount(*self.contents.borrow_ref()) as uint;
+            CFArrayGetCount(self.obj)
         }
     }
 }
 
-impl<ElemRefType:AbstractCFTypeRef> Index<uint,ElemRefType> for CFArray<ElemRefType> {
-    // Careful; the caller must wrap any returned reference properly.
-    // Generally, when array elements are Core Foundation objects (not
-    // always true), they need to be wrapped with CFWrapper::wrap_shared.
+impl Index<i64,*c_void> for CFArray {
+    /// Careful; the loop body must wrap the reference properly. Generally, when array elements are
+    /// Core Foundation objects (not always true), they need to be wrapped with
+    /// `TCFType::wrap_under_get_rule()`. The safer `iter_CFTypes` method will do this for you.
     #[fixed_stack_segment]
-    fn index(&self, idx: &uint) -> ElemRefType {
-        assert!(*idx < self.len());
-        unsafe { 
-            let elem = CFArrayGetValueAtIndex(*self.contents.borrow_ref(), *idx as CFIndex);
-            // Don't return a wrapped thing, since we don't know whether
-            // it needs base::wrap_shared() or base::wrap_owned()
-            cast::transmute::<*c_void,ElemRefType>(elem)
+    #[inline]
+    fn index(&self, index: &CFIndex) -> *c_void {
+        assert!(*index < self.len());
+        unsafe {
+            CFArrayGetValueAtIndex(self.obj, *index)
         }
     }
 }
@@ -154,33 +169,31 @@ extern {
 
 #[test]
 fn should_box_and_unbox() {
-    use number::CFNumber;
+    use number::{CFNumber, number};
 
-    let one = CFNumber::new(1 as i32);
-    let two = CFNumber::new(2 as i32);
-    let thr = CFNumber::new(3 as i32);
-    let fou = CFNumber::new(4 as i32);
-    let fiv = CFNumber::new(5 as i32);
-
-    let arr = CFArray::new([
-        *one.contents.borrow_ref(),
-        *two.contents.borrow_ref(),
-        *thr.contents.borrow_ref(),
-        *fou.contents.borrow_ref(),
-        *fiv.contents.borrow_ref()
+    let arr = CFArray::from_CFTypes([
+        number(1).as_CFType(),
+        number(2).as_CFType(),
+        number(3).as_CFType(),
+        number(4).as_CFType(),
+        number(5).as_CFType(),
     ]);
 
-    let mut sum = 0i32;
+    unsafe {
+        let mut sum = 0i32;
 
-    for elem in arr.iter() {
-        sum += CFNumber::wrap_shared(elem).to_i32();
+        for elem in arr.iter() {
+            let number: CFNumber = TCFType::wrap_under_get_rule(cast::transmute(elem));
+            sum += number.to_i32().unwrap()
+        }
+
+        assert!(sum == 15);
+
+        for elem in arr.iter() {
+            let number: CFNumber = TCFType::wrap_under_get_rule(cast::transmute(elem));
+            sum += number.to_i32().unwrap()
+        }
+
+        assert!(sum == 30);
     }
-
-    assert!(sum == 15);
-
-    for elem in arr.iter() {
-        sum += CFNumber::wrap_shared(elem).to_i32();
-    }
-
-    assert!(sum == 30);
 }


### PR DESCRIPTION
This change redoes the way Core Foundation works to make the API
smaller, safer, and easier to use. In particular:
- Deriving custom types is now based on `struct`s, not on making a
  type alias of `CFWrapper`.
- The attempts at type safety for `CFArray` and `CFDictionary` were
  removed as not pulling their weight (IMHO).
- Methods that are really unsafe (in particular `wrap_owned` and
  `wrap_shared`) are now marked `unsafe`.
- `wrap_owned` has been renamed to `wrap_under_create_rule` and
  `wrap_shared` has been renamed to `wrap_under_get_rule`, to match
  Apple's documentation.
- `borrow_ref` and friends have been simplified into
  `as_concrete_TypeRef()` and `as_TypeRef()`.
- Dictionaries, arrays, and sets now assume that their elements are
  Core Foundation objects. The old code tried not to assume that,
  but ended up assuming that anyway in a couple of places.
- `CFString`s can be converted from Rust types with the `FromStr`
  trait. `CFNumber`s can be converted to and from Rust types with
  `ToPrimitive` and `FromPrimitive`, eliminating the duplication of
  functionality inside this module.

r? @metajack
