### PR TITLE
    Upgrade to latest Rust.

### DIFF
--- a/array.rs
+++ b/array.rs
@@ -9,7 +9,8 @@
 
 //! Heterogeneous immutable arrays.
 
-use base::{CFAllocatorRef, CFIndex, CFIndexConvertible, CFRelease, CFType, CFTypeID, CFTypeRef, TCFType};
+use base::{CFAllocatorRef, CFIndex, CFIndexConvertible, CFRelease, CFRetain};
+use base::{CFType, CFTypeID, CFTypeRef, TCFType};
 use base::{kCFAllocatorDefault};
 use libc::c_void;
 use std::mem;
@@ -26,6 +27,7 @@ pub type CFArrayCopyDescriptionCallBack = *u8;
 /// FIXME(pcwalton): This is wrong.
 pub type CFArrayEqualCallBack = *u8;
 
+#[allow(dead_code)]
 pub struct CFArrayCallBacks {
     version: CFIndex,
     retain: CFArrayRetainCallBack,
@@ -74,6 +76,19 @@ impl TCFType<CFArrayRef> for CFArray {
     #[inline]
     fn as_concrete_TypeRef(&self) -> CFArrayRef {
         self.obj
+    }
+
+    #[inline]
+    unsafe fn wrap_under_get_rule(reference: CFArrayRef) -> CFArray {
+        let reference: CFArrayRef = mem::transmute(CFRetain(mem::transmute(reference)));
+        TCFType::wrap_under_create_rule(reference)
+    }
+
+    #[inline]
+    fn as_CFTypeRef(&self) -> CFTypeRef {
+        unsafe {
+            mem::transmute(self.as_concrete_TypeRef())
+        }
     }
 
     #[inline]

--- a/boolean.rs
+++ b/boolean.rs
@@ -9,7 +9,8 @@
 
 //! A Boolean type.
 
-use base::{CFRelease, CFTypeID, TCFType};
+use base::{CFRelease, CFRetain, CFTypeID, CFTypeRef, TCFType};
+use std::mem;
 
 pub type Boolean = u32;
 
@@ -33,8 +34,22 @@ impl Drop for CFBoolean {
 }
 
 impl TCFType<CFBooleanRef> for CFBoolean {
+    #[inline]
     fn as_concrete_TypeRef(&self) -> CFBooleanRef {
         self.obj
+    }
+
+    #[inline]
+    unsafe fn wrap_under_get_rule(reference: CFBooleanRef) -> CFBoolean {
+        let reference: CFBooleanRef = mem::transmute(CFRetain(mem::transmute(reference)));
+        TCFType::wrap_under_create_rule(reference)
+    }
+
+    #[inline]
+    fn as_CFTypeRef(&self) -> CFTypeRef {
+        unsafe {
+            mem::transmute(self.as_concrete_TypeRef())
+        }
     }
 
     unsafe fn wrap_under_create_rule(obj: CFBooleanRef) -> CFBoolean {

--- a/data.rs
+++ b/data.rs
@@ -9,8 +9,8 @@
 
 //! Core Foundation byte buffers.
 
-use base::{CFAllocatorRef, CFIndex, CFIndexConvertible, CFRelease, CFTypeID, TCFType};
-use base::{kCFAllocatorDefault};
+use base::{CFAllocatorRef, CFIndex, CFIndexConvertible, CFRelease, CFRetain};
+use base::{CFTypeID, CFTypeRef, TCFType, kCFAllocatorDefault};
 
 use std::mem;
 
@@ -34,8 +34,22 @@ impl Drop for CFData {
 }
 
 impl TCFType<CFDataRef> for CFData {
+    #[inline]
     fn as_concrete_TypeRef(&self) -> CFDataRef {
         self.obj
+    }
+
+    #[inline]
+    unsafe fn wrap_under_get_rule(reference: CFDataRef) -> CFData {
+        let reference: CFDataRef = mem::transmute(CFRetain(mem::transmute(reference)));
+        TCFType::wrap_under_create_rule(reference)
+    }
+
+    #[inline]
+    fn as_CFTypeRef(&self) -> CFTypeRef {
+        unsafe {
+            mem::transmute(self.as_concrete_TypeRef())
+        }
     }
 
     unsafe fn wrap_under_create_rule(obj: CFDataRef) -> CFData {

--- a/dictionary.rs
+++ b/dictionary.rs
@@ -9,8 +9,8 @@
 
 //! Dictionaries of key-value pairs.
 
-use base::{Boolean, CFAllocatorRef, CFIndex, CFIndexConvertible, CFRelease, CFType, CFTypeID};
-use base::{CFTypeRef, TCFType, kCFAllocatorDefault};
+use base::{Boolean, CFAllocatorRef, CFIndex, CFIndexConvertible, CFRelease, CFRetain};
+use base::{CFType, CFTypeID, CFTypeRef, TCFType, kCFAllocatorDefault};
 
 use libc::c_void;
 use std::mem;
@@ -24,6 +24,7 @@ pub type CFDictionaryHashCallBack = *u8;
 pub type CFDictionaryReleaseCallBack = *u8;
 pub type CFDictionaryRetainCallBack = *u8;
 
+#[allow(dead_code)]
 pub struct CFDictionaryKeyCallBacks {
     version: CFIndex,
     retain: CFDictionaryRetainCallBack,
@@ -33,6 +34,7 @@ pub struct CFDictionaryKeyCallBacks {
     hash: CFDictionaryHashCallBack
 }
 
+#[allow(dead_code)]
 pub struct CFDictionaryValueCallBacks {
     version: CFIndex,
     retain: CFDictionaryRetainCallBack,
@@ -61,8 +63,22 @@ impl Drop for CFDictionary {
 }
 
 impl TCFType<CFDictionaryRef> for CFDictionary {
+    #[inline]
     fn as_concrete_TypeRef(&self) -> CFDictionaryRef {
         self.obj
+    }
+
+    #[inline]
+    unsafe fn wrap_under_get_rule(reference: CFDictionaryRef) -> CFDictionary {
+        let reference: CFDictionaryRef = mem::transmute(CFRetain(mem::transmute(reference)));
+        TCFType::wrap_under_create_rule(reference)
+    }
+
+    #[inline]
+    fn as_CFTypeRef(&self) -> CFTypeRef {
+        unsafe {
+            mem::transmute(self.as_concrete_TypeRef())
+        }
     }
 
     unsafe fn wrap_under_create_rule(obj: CFDictionaryRef) -> CFDictionary {

--- a/lib.rs
+++ b/lib.rs
@@ -12,6 +12,8 @@
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 
+#![allow(non_snake_case_functions)]
+
 extern crate libc;
 extern crate std;
 extern crate debug;

--- a/number.rs
+++ b/number.rs
@@ -11,7 +11,8 @@
 
 #![allow(non_uppercase_statics)]
 
-use base::{CFAllocatorRef, CFRelease, CFTypeID, TCFType, kCFAllocatorDefault};
+use base::{CFAllocatorRef, CFRelease, CFRetain, CFTypeID, CFTypeRef};
+use base::{TCFType, kCFAllocatorDefault};
 
 use libc::c_void;
 use std::mem;
@@ -57,8 +58,22 @@ impl Drop for CFNumber {
 }
 
 impl TCFType<CFNumberRef> for CFNumber {
+    #[inline]
     fn as_concrete_TypeRef(&self) -> CFNumberRef {
         self.obj
+    }
+
+    #[inline]
+    unsafe fn wrap_under_get_rule(reference: CFNumberRef) -> CFNumber {
+        let reference: CFNumberRef = mem::transmute(CFRetain(mem::transmute(reference)));
+        TCFType::wrap_under_create_rule(reference)
+    }
+
+    #[inline]
+    fn as_CFTypeRef(&self) -> CFTypeRef {
+        unsafe {
+            mem::transmute(self.as_concrete_TypeRef())
+        }
     }
 
     unsafe fn wrap_under_create_rule(obj: CFNumberRef) -> CFNumber {

--- a/set.rs
+++ b/set.rs
@@ -9,8 +9,8 @@
 
 //! An immutable bag of elements.
 
-use base::{CFAllocatorRef, CFIndex, CFIndexConvertible, CFRelease, CFType, CFTypeID, CFTypeRef};
-use base::{TCFType, kCFAllocatorDefault};
+use base::{CFAllocatorRef, CFIndex, CFIndexConvertible, CFRelease, CFRetain};
+use base::{CFType, CFTypeID, CFTypeRef, TCFType, kCFAllocatorDefault};
 
 use libc::c_void;
 use std::mem;
@@ -21,6 +21,7 @@ pub type CFSetCopyDescriptionCallBack = *u8;
 pub type CFSetEqualCallBack = *u8;
 pub type CFSetHashCallBack = *u8;
 
+#[allow(dead_code)]
 pub struct CFSetCallBacks {
     version: CFIndex,
     retain: CFSetRetainCallBack,
@@ -50,8 +51,22 @@ impl Drop for CFSet {
 }
 
 impl TCFType<CFSetRef> for CFSet {
+    #[inline]
     fn as_concrete_TypeRef(&self) -> CFSetRef {
         self.obj
+    }
+
+    #[inline]
+    unsafe fn wrap_under_get_rule(reference: CFSetRef) -> CFSet {
+        let reference: CFSetRef = mem::transmute(CFRetain(mem::transmute(reference)));
+        TCFType::wrap_under_create_rule(reference)
+    }
+
+    #[inline]
+    fn as_CFTypeRef(&self) -> CFTypeRef {
+        unsafe {
+            mem::transmute(self.as_concrete_TypeRef())
+        }
     }
 
     unsafe fn wrap_under_create_rule(obj: CFSetRef) -> CFSet {

--- a/string.rs
+++ b/string.rs
@@ -12,11 +12,13 @@
 #![allow(non_uppercase_statics)]
 
 use base::{Boolean, CFAllocatorRef, CFIndex, CFIndexConvertible, CFOptionFlags, CFRange};
-use base::{CFRelease, CFTypeID, TCFType, kCFAllocatorDefault, kCFAllocatorNull};
+use base::{CFRelease, CFRetain, CFTypeID, CFTypeRef, TCFType};
+use base::{kCFAllocatorDefault, kCFAllocatorNull};
 
 use libc;
 use std::fmt;
 use std::from_str::FromStr;
+use std::mem;
 use std::ptr;
 use std::vec::Vec;
 
@@ -226,8 +228,22 @@ impl Drop for CFString {
 
 
 impl TCFType<CFStringRef> for CFString {
+    #[inline]
     fn as_concrete_TypeRef(&self) -> CFStringRef {
         self.obj
+    }
+
+    #[inline]
+    unsafe fn wrap_under_get_rule(reference: CFStringRef) -> CFString {
+        let reference: CFStringRef = mem::transmute(CFRetain(mem::transmute(reference)));
+        TCFType::wrap_under_create_rule(reference)
+    }
+
+    #[inline]
+    fn as_CFTypeRef(&self) -> CFTypeRef {
+        unsafe {
+            mem::transmute(self.as_concrete_TypeRef())
+        }
     }
 
     unsafe fn wrap_under_create_rule(obj: CFStringRef) -> CFString {

--- a/url.rs
+++ b/url.rs
@@ -11,9 +11,11 @@
 
 #![allow(non_uppercase_statics)]
 
-use base::{CFOptionFlags, CFRelease, CFTypeID, TCFType};
-use std::fmt;
+use base::{CFOptionFlags, CFRelease, CFRetain, CFTypeID, CFTypeRef, TCFType};
 use string::{CFString, CFStringRef};
+
+use std::fmt;
+use std::mem;
 
 struct __CFURL;
 
@@ -32,8 +34,22 @@ impl Drop for CFURL {
 }
 
 impl TCFType<CFURLRef> for CFURL {
+    #[inline]
     fn as_concrete_TypeRef(&self) -> CFURLRef {
         self.obj
+    }
+
+    #[inline]
+    unsafe fn wrap_under_get_rule(reference: CFURLRef) -> CFURL {
+        let reference: CFURLRef = mem::transmute(CFRetain(mem::transmute(reference)));
+        TCFType::wrap_under_create_rule(reference)
+    }
+
+    #[inline]
+    fn as_CFTypeRef(&self) -> CFTypeRef {
+        unsafe {
+            mem::transmute(self.as_concrete_TypeRef())
+        }
     }
 
     unsafe fn wrap_under_create_rule(obj: CFURLRef) -> CFURL {


### PR DESCRIPTION
We can no longer transmute from type params, so we must expand the
default methods that do this into all the places that implement the
trait. Yuck.
