### PR TITLE
Update for rustc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,7 @@ pub mod url;
 #[cfg(target_os="macos")]
 pub mod bundle;
 
-#[cfg(target_os="macos")]
-#[cfg(test)]
+#[cfg(all(target_os="macos", test))]
 pub mod test {
     #[test]
     fn test_stuff() {


### PR DESCRIPTION
Rust now longer allows multiple `#[cfg]` attributes on the same item

I'm not sure whether the old code means `test OR macos` or `test AND macos`, but putting an `OR` here doesn't really make sense.
