### PR TITLE
Update for rustc

### DIFF
--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -147,7 +147,7 @@ impl CFDictionary {
     pub fn get(&self, key: *const c_void) -> *const c_void {
         let value = self.find(key);
         if value.is_none() {
-            fail!("No entry found for key: {:?}", key);
+            fail!("No entry found for key: {}", key);
         }
         value.unwrap()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 #![allow(non_snake_case_functions)]
 
 extern crate libc;
-extern crate debug;
 
 #[cfg(target_os="macos")]
 pub mod array;


### PR DESCRIPTION
The `debug` crate no longer exists.

Note that since I don't have a mac, this is a blind fix. I can't test if it works.
