### PR TITLE
Change package name and repo location.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "core_foundation"
+name = "core-foundation"
 description = "Bindings to Core Foundation for OS X"
-homepage = "https://github.com/servo/rust-core-foundation"
-repository = "https://github.com/servo/rust-core-foundation"
+homepage = "https://github.com/servo/core-foundation-rs"
+repository = "https://github.com/servo/core-foundation-rs"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 
 [lib]
-name = "core_foundation"
+name = "core-foundation"
 crate-type = ["rlib"]
 
 [dependencies]


### PR DESCRIPTION
This brings us into line with the prevailing Rust conventions.