### PR TITLE
Use full path to mem::transmute in macro

### DIFF
--- a/core-foundation/src/boolean.rs
+++ b/core-foundation/src/boolean.rs
@@ -11,7 +11,6 @@
 
 use core_foundation_sys::base::{CFRelease};
 pub use core_foundation_sys::number::{CFBooleanRef, CFBooleanGetTypeID, kCFBooleanTrue, kCFBooleanFalse};
-use std::mem;
 
 use base::TCFType;
 

--- a/core-foundation/src/bundle.rs
+++ b/core-foundation/src/bundle.rs
@@ -11,7 +11,6 @@
 
 pub use core_foundation_sys::bundle::*;
 use core_foundation_sys::base::CFRelease;
-use std::mem;
 
 use base::{TCFType};
 

--- a/core-foundation/src/data.rs
+++ b/core-foundation/src/data.rs
@@ -12,7 +12,6 @@
 pub use core_foundation_sys::data::*;
 use core_foundation_sys::base::{CFIndex, CFRelease};
 use core_foundation_sys::base::{kCFAllocatorDefault};
-use std::mem;
 use std::ops::Deref;
 use std::slice;
 

--- a/core-foundation/src/lib.rs
+++ b/core-foundation/src/lib.rs
@@ -22,14 +22,14 @@ macro_rules! impl_TCFType {
 
             #[inline]
             unsafe fn wrap_under_get_rule(reference: $raw) -> $ty {
-                let reference = mem::transmute(::core_foundation_sys::base::CFRetain(mem::transmute(reference)));
+                let reference = ::std::mem::transmute(::core_foundation_sys::base::CFRetain(::std::mem::transmute(reference)));
                 $crate::base::TCFType::wrap_under_create_rule(reference)
             }
 
             #[inline]
             fn as_CFTypeRef(&self) -> ::core_foundation_sys::base::CFTypeRef {
                 unsafe {
-                    mem::transmute(self.as_concrete_TypeRef())
+                    ::std::mem::transmute(self.as_concrete_TypeRef())
                 }
             }
 

--- a/core-foundation/src/runloop.rs
+++ b/core-foundation/src/runloop.rs
@@ -14,7 +14,6 @@ use core_foundation_sys::base::{CFIndex, CFRelease};
 use core_foundation_sys::base::{kCFAllocatorDefault, CFOptionFlags};
 use core_foundation_sys::string::CFStringRef;
 use core_foundation_sys::date::{CFAbsoluteTime, CFTimeInterval};
-use std::mem;
 
 use base::{TCFType};
 use string::{CFString};

--- a/core-foundation/src/string.rs
+++ b/core-foundation/src/string.rs
@@ -17,7 +17,6 @@ use core_foundation_sys::base::{Boolean, CFIndex, CFRange, CFRelease};
 use core_foundation_sys::base::{kCFAllocatorDefault, kCFAllocatorNull};
 use std::fmt;
 use std::str::{self, FromStr};
-use std::mem;
 use std::ptr;
 use std::vec::Vec;
 use std::ffi::CStr;

--- a/core-foundation/src/url.rs
+++ b/core-foundation/src/url.rs
@@ -16,7 +16,6 @@ use string::{CFString};
 
 use core_foundation_sys::base::{kCFAllocatorDefault, CFRelease};
 use std::fmt;
-use std::mem;
 
 pub struct CFURL(CFURLRef);
 


### PR DESCRIPTION
Also removes now unused `std::mem` uses.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/74)
<!-- Reviewable:end -->
