### PR TITLE
main-crate 0.2.1 requires v0.2.1 of sys-crate.

### DIFF
--- a/core-foundation/Cargo.toml
+++ b/core-foundation/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT / Apache-2.0"
 
 [dependencies.core-foundation-sys]
 path = "../core-foundation-sys"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 libc = "0.2"


### PR DESCRIPTION
After https://github.com/servo/core-foundation-rs/pull/77.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/79)
<!-- Reviewable:end -->
