### PR TITLE
Add bindings for `CFFileDescriptor`

### DIFF
--- a/core-foundation-sys/src/filedescriptor.rs
+++ b/core-foundation-sys/src/filedescriptor.rs
@@ -1,0 +1,48 @@
+use libc::{c_void, c_int};
+use base::{Boolean, CFIndex, CFTypeID, CFOptionFlags, CFAllocatorRef};
+use string::CFStringRef;
+use runloop::CFRunLoopSourceRef;
+
+pub type CFFileDescriptorNativeDescriptor = c_int;
+
+#[repr(C)]
+pub struct __CFFileDescriptor(c_void);
+
+pub type CFFileDescriptorRef = *const __CFFileDescriptor;
+
+/* Callback Reason Types */
+pub const kCFFileDescriptorReadCallBack: CFOptionFlags  = 1 << 0;
+pub const kCFFileDescriptorWriteCallBack: CFOptionFlags = 1 << 1;
+
+pub type CFFileDescriptorCallBack = extern "C" fn (f: CFFileDescriptorRef, callBackTypes: CFOptionFlags, info: *mut c_void);
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CFFileDescriptorContext {
+    pub version: CFIndex,
+    pub info: *mut c_void,
+    pub retain: Option<extern "C" fn (info: *const c_void) -> *const c_void>,
+    pub release: Option<extern "C" fn (info: *const c_void)>,
+    pub copyDescription: Option<extern "C" fn (info: *const c_void) -> CFStringRef>,
+}
+
+extern {
+    /*
+     * CFFileDescriptor.h
+     */
+    pub fn CFFileDescriptorGetTypeID() -> CFTypeID;
+
+    pub fn CFFileDescriptorCreate(allocator: CFAllocatorRef, fd: CFFileDescriptorNativeDescriptor, closeOnInvalidate: Boolean, callout: CFFileDescriptorCallBack, context: *const CFFileDescriptorContext) -> CFFileDescriptorRef;
+
+    pub fn CFFileDescriptorGetNativeDescriptor(f: CFFileDescriptorRef) -> CFFileDescriptorNativeDescriptor;
+
+    pub fn CFFileDescriptorGetContext(f: CFFileDescriptorRef, context: *mut CFFileDescriptorContext);
+
+    pub fn CFFileDescriptorEnableCallBacks(f: CFFileDescriptorRef, callBackTypes: CFOptionFlags);
+    pub fn CFFileDescriptorDisableCallBacks(f: CFFileDescriptorRef, callBackTypes: CFOptionFlags);
+
+    pub fn CFFileDescriptorInvalidate(f: CFFileDescriptorRef);
+    pub fn CFFileDescriptorIsValid(f: CFFileDescriptorRef) -> Boolean;
+
+    pub fn CFFileDescriptorCreateRunLoopSource(allocator: CFAllocatorRef, f: CFFileDescriptorRef, order: CFIndex) -> CFRunLoopSourceRef;
+}

--- a/core-foundation-sys/src/lib.rs
+++ b/core-foundation-sys/src/lib.rs
@@ -19,6 +19,7 @@ pub mod data;
 pub mod date;
 pub mod dictionary;
 pub mod error;
+pub mod filedescriptor;
 pub mod messageport;
 pub mod number;
 pub mod propertylist;

--- a/core-foundation/src/filedescriptor.rs
+++ b/core-foundation/src/filedescriptor.rs
@@ -81,6 +81,17 @@ impl AsRawFd for CFFileDescriptor {
     }
 }
 
+use runloop::{CFRunLoopSource};
+
+impl CFRunLoopSource {
+    pub fn from_file_descriptor(fd: &CFFileDescriptor, order: CFIndex) -> CFRunLoopSource {
+        unsafe {
+            let source_ref = CFFileDescriptorCreateRunLoopSource(kCFAllocatorDefault, fd.0, order);
+            TCFType::wrap_under_create_rule(source_ref)
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/core-foundation/src/filedescriptor.rs
+++ b/core-foundation/src/filedescriptor.rs
@@ -1,0 +1,71 @@
+pub use core_foundation_sys::filedescriptor::*;
+
+use core_foundation_sys::base::{Boolean, CFIndex, CFRelease};
+use core_foundation_sys::base::{kCFAllocatorDefault, CFOptionFlags};
+
+use base::{TCFType};
+
+use std::os::unix::io::{AsRawFd, RawFd};
+
+pub struct CFFileDescriptor(CFFileDescriptorRef);
+
+impl Drop for CFFileDescriptor {
+    fn drop(&mut self) {
+        unsafe {
+            CFRelease(self.as_CFTypeRef())
+        }
+    }
+}
+
+impl_TCFType!(CFFileDescriptor, CFFileDescriptorRef, CFFileDescriptorGetTypeID);
+
+impl CFFileDescriptor {
+    pub unsafe fn new(fd: RawFd,
+                      closeOnInvalidate: bool,
+                      callout: CFFileDescriptorCallBack,
+                      context: *const CFFileDescriptorContext) -> CFFileDescriptor {
+        let fd_ref = CFFileDescriptorCreate(kCFAllocatorDefault,
+                                            fd,
+                                            closeOnInvalidate as Boolean,
+                                            callout,
+                                            context);
+        TCFType::wrap_under_create_rule(fd_ref)
+    }
+
+    pub fn enable_callbacks(&self, callback_types: CFOptionFlags) {
+        unsafe {
+            CFFileDescriptorEnableCallBacks(self.0, callback_types)
+        }
+    }
+
+    pub fn disable_callbacks(&self, callback_types: CFOptionFlags) {
+        unsafe {
+            CFFileDescriptorDisableCallBacks(self.0, callback_types)
+        }
+    }
+
+    pub fn valid(&self) -> bool {
+        unsafe {
+            CFFileDescriptorIsValid(self.0) != 0
+        }
+    }
+
+    pub fn invalidate(&self) {
+        unsafe {
+            CFFileDescriptorInvalidate(self.0)
+        }
+    }
+}
+
+impl AsRawFd for CFFileDescriptor {
+    fn as_raw_fd(&self) -> RawFd {
+        unsafe {
+            CFFileDescriptorGetNativeDescriptor(self.0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+}

--- a/core-foundation/src/lib.rs
+++ b/core-foundation/src/lib.rs
@@ -177,6 +177,7 @@ pub mod data;
 pub mod date;
 pub mod dictionary;
 pub mod error;
+pub mod filedescriptor;
 pub mod number;
 pub mod set;
 pub mod string;


### PR DESCRIPTION
This pull request adds implementation of `CFFileDescriptor` and `CFRunLoopSource` related API.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/84)

<!-- Reviewable:end -->
