### PR TITLE
Add CFSetApplyFunction and CFSetGetCount

### DIFF
--- a/core-foundation-sys/src/set.rs
+++ b/core-foundation-sys/src/set.rs
@@ -11,6 +11,8 @@ use libc::c_void;
 
 use base::{CFAllocatorRef, CFIndex, CFTypeID};
 
+pub type CFSetApplierFunction = extern "C" fn (value: *const c_void,
+                                               context: *const c_void);
 pub type CFSetRetainCallBack = *const u8;
 pub type CFSetReleaseCallBack = *const u8;
 pub type CFSetCopyDescriptionCallBack = *const u8;
@@ -45,7 +47,11 @@ extern {
                        callBacks: *const CFSetCallBacks) -> CFSetRef;
 
     /* Applying a Function to Set Members */
-    //fn CFSetApplyFunction
+    pub fn CFSetApplyFunction(theSet: CFSetRef,
+                              applier: CFSetApplierFunction,
+                              context: *const c_void);
+
+    pub fn CFSetGetCount(theSet: CFSetRef) -> CFIndex;
 
     pub fn CFSetGetTypeID() -> CFTypeID;
 }


### PR DESCRIPTION
I'm needing these CFSet functions for some USB HID interactions with IOKit, so here's the external references.

They are defined in CoreFoundation:

- [CFSetApplyFunction](https://developer.apple.com/reference/corefoundation/1520450-cfsetapplyfunction?language=objc) and 
- [CFSetGetCount](https://developer.apple.com/reference/corefoundation/1520419-cfsetgetcount?language=objc)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/99)
<!-- Reviewable:end -->
