### PR TITLE
Additions to CFURL and CFBundle

### DIFF
--- a/core-foundation-sys/src/bundle.rs
+++ b/core-foundation-sys/src/bundle.rs
@@ -9,7 +9,8 @@
 
 use libc::c_void;
 
-use base::CFTypeID;
+use base::{CFTypeID, CFAllocatorRef};
+use url::CFURLRef;
 use dictionary::CFDictionaryRef;
 use string::CFStringRef;
 
@@ -22,10 +23,13 @@ extern {
     /*
      * CFBundle.h
      */
+    pub fn CFBundleCreate(allocator: CFAllocatorRef, bundleURL: CFURLRef) -> CFBundleRef;
+
     pub fn CFBundleGetBundleWithIdentifier(bundleID: CFStringRef) -> CFBundleRef;
     pub fn CFBundleGetFunctionPointerForName(bundle: CFBundleRef, function_name: CFStringRef) -> *const c_void;
     pub fn CFBundleGetMainBundle() -> CFBundleRef;
     pub fn CFBundleGetInfoDictionary(bundle: CFBundleRef) -> CFDictionaryRef;
 
     pub fn CFBundleGetTypeID() -> CFTypeID;
+    pub fn CFBundleCopyExecutableURL(bundle: CFBundleRef) -> CFURLRef;
 }

--- a/core-foundation-sys/src/url.rs
+++ b/core-foundation-sys/src/url.rs
@@ -80,7 +80,7 @@ extern {
     // static kCFURLFileResourceTypeKey: CFStringRef;
 
     /* Creating a CFURL */
-    //fn CFURLCopyAbsoluteURL
+    pub fn CFURLCopyAbsoluteURL(anURL: CFURLRef) -> CFURLRef;
     //fn CFURLCreateAbsoluteURLWithBytes
     //fn CFURLCreateByResolvingBookmarkData
     //fn CFURLCreateCopyAppendingPathComponent
@@ -95,7 +95,7 @@ extern {
     //fn CFURLCreateWithBytes
     //fn CFURLCreateWithFileSystemPath
     pub fn CFURLCreateWithFileSystemPath(allocator: CFAllocatorRef, filePath: CFStringRef, pathStyle: CFURLPathStyle, isDirectory: Boolean) -> CFURLRef;
-    //fn CFURLCreateWithFileSystemPathRelativeToBase
+    pub fn CFURLCreateWithFileSystemPathRelativeToBase(allocator: CFAllocatorRef, filePath: CFStringRef, pathStyle: CFURLPathStyle, isDirectory: Boolean, baseURL: CFURLRef) -> CFURLRef;
     //fn CFURLCreateWithString(allocator: CFAllocatorRef, urlString: CFStringRef,
     //                         baseURL: CFURLRef) -> CFURLRef;
 

--- a/core-foundation/src/bundle.rs
+++ b/core-foundation/src/bundle.rs
@@ -53,7 +53,7 @@ impl CFBundle {
         }
     }
 
-    pub fn exectuable_url(&self) -> Option<CFURL> {
+    pub fn executable_url(&self) -> Option<CFURL> {
         unsafe {
             let exe_url = CFBundleCopyExecutableURL(self.0);
             if exe_url.is_null() {
@@ -68,13 +68,13 @@ impl CFBundle {
 impl_TCFType!(CFBundle, CFBundleRef, CFBundleGetTypeID);
 
 #[test]
-fn safari_exectuable_url() {
+fn safari_executable_url() {
     use string::CFString;
     use url::{CFURL, kCFURLPOSIXPathStyle};
 
     let cfstr_path = CFString::from_static_string("/Applications/Safari.app");
     let cfurl_path = CFURL::from_file_system_path(cfstr_path, kCFURLPOSIXPathStyle, true);
-    let cfurl_executable = CFBundle::new(cfurl_path).expect("Safari not present").exectuable_url();
+    let cfurl_executable = CFBundle::new(cfurl_path).expect("Safari not present").executable_url();
     assert!(cfurl_executable.is_some());
     assert_eq!(cfurl_executable.unwrap().absolute().get_file_system_path(kCFURLPOSIXPathStyle).to_string(),
         "/Applications/Safari.app/Contents/MacOS/Safari");

--- a/core-foundation/src/bundle.rs
+++ b/core-foundation/src/bundle.rs
@@ -10,9 +10,10 @@
 //! Core Foundation Bundle Type
 
 pub use core_foundation_sys::bundle::*;
-use core_foundation_sys::base::CFRelease;
+use core_foundation_sys::base::{CFRelease, kCFAllocatorDefault};
 
-use base::{TCFType};
+use base::TCFType;
+use url::CFURL;
 use dictionary::CFDictionary;
 
 /// A Bundle type.
@@ -27,6 +28,17 @@ impl Drop for CFBundle {
 }
 
 impl CFBundle {
+    pub fn new(bundleURL: CFURL) -> Option<CFBundle> {
+        unsafe {
+            let bundle_ref = CFBundleCreate(kCFAllocatorDefault, bundleURL.as_concrete_TypeRef());
+            if bundle_ref.is_null() {
+                None
+            } else {
+                Some(TCFType::wrap_under_create_rule(bundle_ref))
+            }
+        }
+    }
+
     pub fn main_bundle() -> CFBundle {
         unsafe {
             let bundle_ref = CFBundleGetMainBundle();
@@ -40,7 +52,40 @@ impl CFBundle {
             TCFType::wrap_under_get_rule(info_dictionary)
         }
     }
+
+    pub fn exectuable_url(&self) -> Option<CFURL> {
+        unsafe {
+            let exe_url = CFBundleCopyExecutableURL(self.0);
+            if exe_url.is_null() {
+                None
+            } else {
+                Some(TCFType::wrap_under_create_rule(exe_url))
+            }
+        }
+    }
 }
 
 impl_TCFType!(CFBundle, CFBundleRef, CFBundleGetTypeID);
 
+#[test]
+fn safari_exectuable_url() {
+    use string::CFString;
+    use url::{CFURL, kCFURLPOSIXPathStyle};
+
+    let cfstr_path = CFString::from_static_string("/Applications/Safari.app");
+    let cfurl_path = CFURL::from_file_system_path(cfstr_path, kCFURLPOSIXPathStyle, true);
+    let cfurl_executable = CFBundle::new(cfurl_path).expect("Safari not present").exectuable_url();
+    assert!(cfurl_executable.is_some());
+    assert_eq!(cfurl_executable.unwrap().absolute().get_file_system_path(kCFURLPOSIXPathStyle).to_string(),
+        "/Applications/Safari.app/Contents/MacOS/Safari");
+}
+
+#[test]
+fn non_existant_bundle() {
+    use string::CFString;
+    use url::{CFURL, kCFURLPOSIXPathStyle};
+
+    let cfstr_path = CFString::from_static_string("/usr/local/foo");
+    let cfurl_path = CFURL::from_file_system_path(cfstr_path, kCFURLPOSIXPathStyle, true);
+    assert!(CFBundle::new(cfurl_path).is_none());
+}

--- a/core-foundation/src/url.rs
+++ b/core-foundation/src/url.rs
@@ -52,6 +52,18 @@ impl CFURL {
             TCFType::wrap_under_get_rule(CFURLGetString(self.0))
         }
     }
+
+    pub fn get_file_system_path(&self, pathStyle: CFURLPathStyle) -> CFString {
+        unsafe {
+            TCFType::wrap_under_create_rule(CFURLCopyFileSystemPath(self.as_concrete_TypeRef(), pathStyle))
+        }
+    }
+
+    pub fn absolute(&self) -> CFURL {
+        unsafe {
+            TCFType::wrap_under_create_rule(CFURLCopyAbsoluteURL(self.as_concrete_TypeRef()))
+        }
+    }
 }
 
 #[test]
@@ -59,5 +71,33 @@ fn file_url_from_path() {
     let path = "/usr/local/foo/";
     let cfstr_path = CFString::from_static_string(path);
     let cfurl = CFURL::from_file_system_path(cfstr_path, kCFURLPOSIXPathStyle, true);
-    assert!(cfurl.get_string().to_string() == "file:///usr/local/foo/");
+    assert_eq!(cfurl.get_string().to_string(), "file:///usr/local/foo/");
+}
+
+#[test]
+fn absolute_file_url() {
+    use core_foundation_sys::url::CFURLCreateWithFileSystemPathRelativeToBase;
+    use std::path::PathBuf;
+
+    let path = "/usr/local/foo";
+    let file = "bar";
+
+    let cfstr_path = CFString::from_static_string(path);
+    let cfstr_file = CFString::from_static_string(file);
+    let cfurl_base = CFURL::from_file_system_path(cfstr_path, kCFURLPOSIXPathStyle, true);
+    let cfurl_relative: CFURL = unsafe {
+        let url_ref = CFURLCreateWithFileSystemPathRelativeToBase(kCFAllocatorDefault,
+            cfstr_file.as_concrete_TypeRef(),
+            kCFURLPOSIXPathStyle,
+            false as u8,
+            cfurl_base.as_concrete_TypeRef());
+        TCFType::wrap_under_create_rule(url_ref)
+    };
+
+    let mut absolute_path = PathBuf::from(path);
+    absolute_path.push(file);
+
+    assert_eq!(cfurl_relative.get_file_system_path(kCFURLPOSIXPathStyle).to_string(), "bar");
+    assert_eq!(cfurl_relative.absolute().get_file_system_path(kCFURLPOSIXPathStyle).to_string(),
+        absolute_path.to_str().unwrap());
 }

--- a/core-foundation/src/url.rs
+++ b/core-foundation/src/url.rs
@@ -97,7 +97,7 @@ fn absolute_file_url() {
     let mut absolute_path = PathBuf::from(path);
     absolute_path.push(file);
 
-    assert_eq!(cfurl_relative.get_file_system_path(kCFURLPOSIXPathStyle).to_string(), "bar");
+    assert_eq!(cfurl_relative.get_file_system_path(kCFURLPOSIXPathStyle).to_string(), file);
     assert_eq!(cfurl_relative.absolute().get_file_system_path(kCFURLPOSIXPathStyle).to_string(),
         absolute_path.to_str().unwrap());
 }


### PR DESCRIPTION
I propose a few additions to CFBundle and CFURL APIs. Not sure how general they are, but they would be nice to have out of the box.

The `CFURL::absolute_file_url` test is a bit big, but it demonstrates the need for `CFURL::absolute()`.

I think `CFBundle::main_bundle()` should return an `Option` since `CFBundleGetMainBundle` can return NULL but that is a breaking change and I decided not to include it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/101)
<!-- Reviewable:end -->
