### PR TITLE
Enable cargo doc/check on non-Darwin platforms

### DIFF
--- a/core-foundation-sys/build.rs
+++ b/core-foundation-sys/build.rs
@@ -7,6 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::env;
+
 fn main() {
-    println!("cargo:rustc-link-lib=framework=CoreFoundation");
+    let target = env::var("TARGET").unwrap();
+
+    if target.ends_with("apple-darwin") || target.ends_with("apple-ios") {
+        println!("cargo:rustc-link-lib=framework=CoreFoundation");
+    }
 }


### PR DESCRIPTION
core-foundation-sys's build script causes `cargo doc` to fail on Linux, Windows, etc. by attempting to like with CoreFoundation.framework. This adds a target check to prevent attempting to link to the framework on platforms where it will not be present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/105)
<!-- Reviewable:end -->
