### PR TITLE
Implement From<&str> for CFString

### DIFF
--- a/core-foundation/src/string.rs
+++ b/core-foundation/src/string.rs
@@ -43,6 +43,13 @@ impl FromStr for CFString {
     }
 }
 
+impl<'a> From<&'a str> for CFString {
+    #[inline]
+    fn from(string: &'a str) -> CFString {
+        CFString::new(string)
+    }
+}
+
 impl fmt::Display for CFString {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         unsafe {


### PR DESCRIPTION
I'm not sure if you have any strict policies on what types you usually accept as parameters to the safe wrappers. So I'm not sure if you want this or not. But my reasons are:

I create `system-configuration` and `system-configuration-sys` crates as bindings to that API. In the [`SCDynamicStore`] module a lot of the functions take a `CFStringRef` as argument. It would be more ergonomic if this safe wrapper type could deal with Rust strings directly, so I can do:
```rust
let store = SCDynamicStore::create("my-dynamic-store");
let dict = store.find("State:/Network/Global/IPv4");
```
But at the same time I don't want to make it harder to use for people who already sit on `CFString` objects. So with this new `From<&str>` impl my API can be used both with `&str` and `CFString` if I implement the methods as `<S: Into<CFString>>`.


[`SCDynamicStore`]: https://developer.apple.com/documentation/systemconfiguration/scdynamicstore?language=objc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/128)
<!-- Reviewable:end -->
