### PR TITLE
Higher level dictionary find/contains_key

### DIFF
--- a/core-foundation/src/dictionary.rs
+++ b/core-foundation/src/dictionary.rs
@@ -70,6 +70,13 @@ impl CFDictionary {
         }
     }
 
+    /// Similar to `contains_key` but acts on a higher level, automatically converting from any
+    /// `TCFType` to the raw pointer of its concrete TypeRef.
+    #[inline]
+    pub fn contains_key2<X, K: TCFType<*const X>>(&self, key: &K) -> bool {
+        self.contains_key(key.as_concrete_TypeRef() as *const c_void)
+    }
+
     #[inline]
     pub fn find(&self, key: *const c_void) -> Option<*const c_void> {
         unsafe {
@@ -80,6 +87,13 @@ impl CFDictionary {
                 None
             }
         }
+    }
+
+    /// Similar to `find` but acts on a higher level, automatically converting from any `TCFType`
+    /// to the raw pointer of its concrete TypeRef.
+    #[inline]
+    pub fn find2<X, K: TCFType<*const X>>(&self, key: &K) -> Option<*const c_void> {
+        self.find(key.as_concrete_TypeRef() as *const c_void)
     }
 
     #[inline]

--- a/core-foundation/src/dictionary.rs
+++ b/core-foundation/src/dictionary.rs
@@ -96,13 +96,16 @@ impl CFDictionary {
         self.find(key.as_concrete_TypeRef() as *const c_void)
     }
 
+    /// # Panics
+    ///
+    /// Panics if the key is not present in the dictionary. Use `find` to get an `Option` instead
+    /// of panicking.
     #[inline]
     pub fn get(&self, key: *const c_void) -> *const c_void {
-        let value = self.find(key);
-        if value.is_none() {
-            panic!("No entry found for key {:p}", key);
+        match self.find(key) {
+            None => panic!("No entry found for key {:p}", key),
+            Some(value) => value
         }
-        value.unwrap()
     }
 
     /// A convenience function to retrieve `CFType` instances.

--- a/core-foundation/src/dictionary.rs
+++ b/core-foundation/src/dictionary.rs
@@ -102,10 +102,7 @@ impl CFDictionary {
     /// of panicking.
     #[inline]
     pub fn get(&self, key: *const c_void) -> *const c_void {
-        match self.find(key) {
-            None => panic!("No entry found for key {:p}", key),
-            Some(value) => value
-        }
+        self.find(key).expect(&format!("No entry found for key {:p}", key))
     }
 
     /// A convenience function to retrieve `CFType` instances.


### PR DESCRIPTION
I'm not very familiar with Core Foundation yet, so tell me if this is not a very helpful addition.

Adding versions of find and contains_key that can take any `TCFType` and automatically converts it to the raw pointer of its corresponding ref type. It looks like dictionaries will mostly contain types implementing this trait, and thus these versions of the methods can make it a bit more ergonomic to use the dictionary. The best would of course be if we could return the correct type as well, but I guess that is not possible with the available information.

Better suggestions for the names are welcome :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/129)
<!-- Reviewable:end -->
