### PR TITLE
Add CFPropertyList and methods for casting to subclasses

### DIFF
--- a/core-foundation/src/propertylist.rs
+++ b/core-foundation/src/propertylist.rs
@@ -60,9 +60,13 @@ pub fn create_data(property_list: *const c_void, format: CFPropertyListFormat) -
 }
 
 
-/// Trait for all subclasses of CFPropertyList.
+/// Trait for all subclasses of [`CFPropertyList`].
+///
+/// [`CFPropertyList`]: struct.CFPropertyList.html
 pub trait CFPropertyListSubClass<Raw>: TCFType<*const Raw> {
-    /// Create an instance of the superclass type `CFPropertyList` for this instance.
+    /// Create an instance of the superclass type [`CFPropertyList`] for this instance.
+    ///
+    /// [`CFPropertyList`]: struct.CFPropertyList.html
     fn to_CFPropertyList(&self) -> CFPropertyList {
         unsafe { CFPropertyList::wrap_under_get_rule(self.as_concrete_TypeRef() as *const c_void) }
     }
@@ -76,12 +80,22 @@ impl CFPropertyListSubClass<::date::__CFDate> for ::date::CFDate {}
 impl CFPropertyListSubClass<::number::__CFBoolean> for ::boolean::CFBoolean {}
 impl CFPropertyListSubClass<::number::__CFNumber> for ::number::CFNumber {}
 
-/// A CFPropertyList struct. This is superclass to CFData, CFString, CFArray, CFDictionary,
-/// CFDate, CFBoolean, and CFNumber.
+/// A CFPropertyList struct. This is superclass to [`CFData`], [`CFString`], [`CFArray`],
+/// [`CFDictionary`], [`CFDate`], [`CFBoolean`], and [`CFNumber`].
 ///
-/// This superclass type does not have its own CFTypeID, instead each instance has the CFTypeID of
-/// the subclass it is an instance of. Thus, this type cannot implement the `TCFType` trait, since
-/// it cannot implement the static `TCFType::type_id()` method.
+/// This superclass type does not have its own `CFTypeID`, instead each instance has the `CFTypeID`
+/// of the subclass it is an instance of. Thus, this type cannot implement the [`TCFType`] trait,
+/// since it cannot implement the static [`TCFType::type_id()`] method.
+///
+/// [`CFData`]: ../data/struct.CFData.html
+/// [`CFString`]: ../string/struct.CFString.html
+/// [`CFArray`]: ../array/struct.CFArray.html
+/// [`CFDictionary`]: ../dictionary/struct.CFDictionary.html
+/// [`CFDate`]: ../date/struct.CFDate.html
+/// [`CFBoolean`]: ../boolean/struct.CFBoolean.html
+/// [`CFNumber`]: ../number/struct.CFNumber.html
+/// [`TCFType`]: ../base/trait.TCFType.html
+/// [`TCFType::type_id()`]: ../base/trait.TCFType.html#method.type_of
 pub struct CFPropertyList(CFPropertyListRef);
 
 impl Drop for CFPropertyList {
@@ -162,9 +176,9 @@ impl PartialEq for CFPropertyList {
 impl Eq for CFPropertyList {}
 
 impl CFPropertyList {
-    /// Try to downcast the CFPropertyList to a subclass. Checking if the instance is the correct
+    /// Try to downcast the [`CFPropertyList`] to a subclass. Checking if the instance is the correct
     /// subclass happens at runtime and an error is returned if it is not the correct type.
-    /// Works similar to `Box::downcast`.
+    /// Works similar to [`Box::downcast`].
     ///
     /// # Examples
     ///
@@ -179,6 +193,9 @@ impl CFPropertyList {
     /// // Cast it down again.
     /// assert!(propertylist.downcast::<_, CFString>().unwrap().to_string() == "FooBar");
     /// ```
+    ///
+    /// [`CFPropertyList`]: struct.CFPropertyList.html
+    /// [`Box::downcast`]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method.downcast
     pub fn downcast<Raw, T: CFPropertyListSubClass<Raw>>(&self) -> Result<T, CFPropertyListCastError> {
         if self.instance_of::<_, T>() {
             Ok(unsafe { T::wrap_under_get_rule(self.0 as *const Raw) })


### PR DESCRIPTION
https://developer.apple.com/documentation/corefoundation/cfpropertylist-rif specifies the following types as valid subclasess of a property list:
CFData, CFString, CFArray, CFDictionary, CFDate, CFBoolean, and CFNumber.

So I add a trait, `CFPropertyListSubClass`, and implement it for the valid types. Then add the `CFPropertyList` type and make it work as much as possible as the other `TCFType`s. However, it can't implement that trait, since it can't implement the static method `type_id`.

The main point of adding this was to then get to the convenience methods `to_CFPropertyList` and `downcast` that allows safe casting between the subclasses and the superclass. This is handy in calls such as `SCDynamicStoreSetValue` and `SCDynamicStoreCopyValue` where the methods either accept or return a `CFPropertyListRef`. With this addition it becomes easy to write safe wrappers around those functions and make them accept proper, constrained types.

Disclaimer: I'm not yet super familiar with CF. So I can only hope this is safe and sound, but I think it is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/131)
<!-- Reviewable:end -->
