### PR TITLE
Add conversion to and from bool for CFBoolean

### DIFF
--- a/core-foundation/src/boolean.rs
+++ b/core-foundation/src/boolean.rs
@@ -43,3 +43,35 @@ impl CFBoolean {
         }
     }
 }
+
+impl From<bool> for CFBoolean {
+    fn from(value: bool) -> CFBoolean {
+        if value {
+            CFBoolean::true_value()
+        } else {
+            CFBoolean::false_value()
+        }
+    }
+}
+
+impl From<CFBoolean> for bool {
+    fn from(value: CFBoolean) -> bool {
+        value.0 == unsafe { kCFBooleanTrue }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_and_from_bool() {
+        let b_false = CFBoolean::from(false);
+        let b_true = CFBoolean::from(true);
+        assert_ne!(b_false, b_true);
+        assert_eq!(b_false, CFBoolean::false_value());
+        assert_eq!(b_true, CFBoolean::true_value());
+        assert!(!bool::from(b_false));
+        assert!(bool::from(b_true));
+    }
+}


### PR DESCRIPTION
Make it possible to convert back and fourth between Rust booleans and `CFBoolean`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/136)
<!-- Reviewable:end -->
