### PR TITLE
Implement From<_> for CFNumber

### DIFF
--- a/core-foundation/src/array.rs
+++ b/core-foundation/src/array.rs
@@ -152,14 +152,14 @@ impl<'a, T: FromVoid> IntoIterator for &'a CFArray<T> {
 
 #[test]
 fn should_box_and_unbox() {
-    use number::{CFNumber, number};
+    use number::CFNumber;
 
-    let n0 = number(0);
-    let n1 = number(1);
-    let n2 = number(2);
-    let n3 = number(3);
-    let n4 = number(4);
-    let n5 = number(5);
+    let n0 = CFNumber::from(0);
+    let n1 = CFNumber::from(1);
+    let n2 = CFNumber::from(2);
+    let n3 = CFNumber::from(3);
+    let n4 = CFNumber::from(4);
+    let n5 = CFNumber::from(5);
 
     let arr = CFArray::from_CFTypes(&[
         n0.as_CFType(),

--- a/core-foundation/src/lib.rs
+++ b/core-foundation/src/lib.rs
@@ -193,7 +193,7 @@ pub mod test {
     fn test_stuff() {
         use base::TCFType;
         use boolean::CFBoolean;
-        use number::number;
+        use number::CFNumber;
         use dictionary::CFDictionary;
         use string::CFString;
 
@@ -206,7 +206,7 @@ pub mod test {
         let boo = CFString::from_static_string("Boo");
         let foo = CFString::from_static_string("Foo");
         let tru = CFBoolean::true_value();
-        let n42 = number(42);
+        let n42 = CFNumber::from(42);
 
         let d = CFDictionary::from_CFType_pairs(&[
             (bar.as_CFType(), boo.as_CFType()),

--- a/core-foundation/src/number.rs
+++ b/core-foundation/src/number.rs
@@ -32,16 +32,6 @@ impl_CFComparison!(CFNumber, CFNumberCompare);
 
 impl CFNumber {
     #[inline]
-    pub fn from_i32(value: i32) -> CFNumber {
-        unsafe {
-            let number_ref = CFNumberCreate(kCFAllocatorDefault,
-                                            kCFNumberSInt32Type,
-                                            mem::transmute(&value));
-            TCFType::wrap_under_create_rule(number_ref)
-        }
-    }
-
-    #[inline]
     pub fn to_i64(&self) -> Option<i64> {
         unsafe {
             let mut value: i64 = 0;
@@ -68,38 +58,89 @@ impl CFNumber {
         }
     }
 
+    #[deprecated(note = "please use `CFNumber::from` instead")]
+    #[inline]
+    pub fn from_i32(value: i32) -> CFNumber {
+        CFNumber::from(value)
+    }
+
+    #[deprecated(note = "please use `CFNumber::from` instead")]
     #[inline]
     pub fn from_i64(value: i64) -> CFNumber {
-        unsafe {
-            let number_ref = CFNumberCreate(kCFAllocatorDefault,
-                                            kCFNumberSInt64Type,
-                                            mem::transmute(&value));
-            TCFType::wrap_under_create_rule(number_ref)
-        }
+        Self::from(value)
     }
 
+    #[deprecated(note = "please use `CFNumber::from` instead")]
     #[inline]
     pub fn from_f32(value: f32) -> CFNumber {
+        Self::from(value)
+    }
+
+    #[deprecated(note = "please use `CFNumber::from` instead")]
+    #[inline]
+    pub fn from_f64(value: f64) -> CFNumber {
+        Self::from(value)
+    }
+}
+
+impl From<i32> for CFNumber {
+    #[inline]
+    fn from(value: i32) -> Self {
         unsafe {
-            let number_ref = CFNumberCreate(kCFAllocatorDefault,
-                                            kCFNumberFloat32Type,
-                                            mem::transmute(&value));
+            let number_ref = CFNumberCreate(
+                kCFAllocatorDefault,
+                kCFNumberSInt32Type,
+                mem::transmute(&value),
+            );
             TCFType::wrap_under_create_rule(number_ref)
         }
     }
+}
 
+impl From<i64> for CFNumber {
     #[inline]
-    pub fn from_f64(value: f64) -> CFNumber {
+    fn from(value: i64) -> Self {
         unsafe {
-            let number_ref = CFNumberCreate(kCFAllocatorDefault,
-                                            kCFNumberFloat64Type,
-                                            mem::transmute(&value));
+            let number_ref = CFNumberCreate(
+                kCFAllocatorDefault,
+                kCFNumberSInt64Type,
+                mem::transmute(&value),
+            );
+            TCFType::wrap_under_create_rule(number_ref)
+        }
+    }
+}
+
+impl From<f32> for CFNumber {
+    #[inline]
+    fn from(value: f32) -> Self {
+        unsafe {
+            let number_ref = CFNumberCreate(
+                kCFAllocatorDefault,
+                kCFNumberFloat32Type,
+                mem::transmute(&value),
+            );
+            TCFType::wrap_under_create_rule(number_ref)
+        }
+    }
+}
+
+impl From<f64> for CFNumber {
+    #[inline]
+    fn from(value: f64) -> Self {
+        unsafe {
+            let number_ref = CFNumberCreate(
+                kCFAllocatorDefault,
+                kCFNumberFloat64Type,
+                mem::transmute(&value),
+            );
             TCFType::wrap_under_create_rule(number_ref)
         }
     }
 }
 
 /// A convenience function to create CFNumbers.
+#[deprecated(note = "please use `CFNumber::from` instead")]
 pub fn number(value: i64) -> CFNumber {
-    CFNumber::from_i64(value)
+    CFNumber::from(value)
 }

--- a/core-foundation/src/propertylist.rs
+++ b/core-foundation/src/propertylist.rs
@@ -216,7 +216,7 @@ pub mod test {
     fn test_property_list_serialization() {
         use base::{TCFType, CFEqual};
         use boolean::CFBoolean;
-        use number::number;
+        use number::CFNumber;
         use dictionary::CFDictionary;
         use string::CFString;
         use super::*;
@@ -226,7 +226,7 @@ pub mod test {
         let boo = CFString::from_static_string("Boo");
         let foo = CFString::from_static_string("Foo");
         let tru = CFBoolean::true_value();
-        let n42 = number(42);
+        let n42 = CFNumber::from(42);
 
         let dict1 = CFDictionary::from_CFType_pairs(&[(bar.as_CFType(), boo.as_CFType()),
                                                       (baz.as_CFType(), tru.as_CFType()),


### PR DESCRIPTION
All the `from_` methods on `CFNumber` can be expressed with implementing the `From` trait and thus enable it to be used a bit more ergonomic in some cases. And feels more idiomatic IMO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/137)
<!-- Reviewable:end -->
