### PR TITLE
Add consuming cheap cast

### DIFF
--- a/core-foundation/src/array.rs
+++ b/core-foundation/src/array.rs
@@ -47,9 +47,7 @@ unsafe impl FromVoid for CFType {
 
 impl<T> Drop for CFArray<T> {
     fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
+        unsafe { CFRelease(self.as_CFTypeRef()) }
     }
 }
 

--- a/core-foundation/src/array.rs
+++ b/core-foundation/src/array.rs
@@ -207,27 +207,25 @@ mod tests {
                                         n4.as_CFTypeRef(),
                                         n5.as_CFTypeRef()]);
 
-        unsafe {
-            let mut sum = 0;
+        let mut sum = 0;
 
-            let mut iter = arr.iter();
-            assert_eq!(iter.len(), 6);
-            assert!(iter.next().is_some());
-            assert_eq!(iter.len(), 5);
+        let mut iter = arr.iter();
+        assert_eq!(iter.len(), 6);
+        assert!(iter.next().is_some());
+        assert_eq!(iter.len(), 5);
 
-            for elem in iter {
-                let number: CFNumber = TCFType::wrap_under_get_rule(mem::transmute(elem));
-                sum += number.to_i64().unwrap()
-            }
-
-            assert!(sum == 15);
-
-            for elem in arr.iter() {
-                let number: CFNumber = TCFType::wrap_under_get_rule(mem::transmute(elem));
-                sum += number.to_i64().unwrap()
-            }
-
-            assert!(sum == 30);
+        for elem in iter {
+            let number: CFNumber = elem.downcast::<_, CFNumber>().unwrap();
+            sum += number.to_i64().unwrap()
         }
+
+        assert!(sum == 15);
+
+        for elem in arr.iter() {
+            let number: CFNumber = elem.downcast::<_, CFNumber>().unwrap();
+            sum += number.to_i64().unwrap()
+        }
+
+        assert!(sum == 30);
     }
 }

--- a/core-foundation/src/base.rs
+++ b/core-foundation/src/base.rs
@@ -37,6 +37,30 @@ declare_TCFType!{
 }
 
 impl CFType {
+    /// Try to downcast the `CFType` to a subclass. Checking if the instance is the
+    /// correct subclass happens at runtime and `None` is returned if it is not the correct type.
+    /// Works similar to [`Box::downcast`] and [`CFPropertyList::downcast`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use core_foundation::string::CFString;
+    /// # use core_foundation::boolean::CFBoolean;
+    /// # use core_foundation::base::{CFType, TCFType};
+    /// #
+    /// // Create a string.
+    /// let string: CFString = CFString::from_static_string("FooBar");
+    /// // Cast it up to a CFType.
+    /// let cf_type: CFType = string.as_CFType();
+    /// // Cast it down again.
+    /// assert!(cf_type.downcast::<_, CFString>().unwrap().to_string() == "FooBar");
+    /// // Casting it to some other type will yield `None`
+    /// assert!(cf_type.downcast::<_, CFBoolean>().is_none());
+    /// ```
+    ///
+    /// [`Box::downcast`]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method.downcast
+    /// [`CFPropertyList::downcast`]: ../propertylist/struct.CFPropertyList.html#method.downcast
+    #[inline]
     pub fn downcast<Raw, T: TCFType<*const Raw>>(&self) -> Option<T> {
         if self.instance_of::<_, T>() {
             unsafe {
@@ -47,6 +71,10 @@ impl CFType {
         }
     }
 
+    /// Similar to [`downcast`], but consumes self and can thus avoid touching the retain count.
+    ///
+    /// [`downcast`]: #method.downcast
+    #[inline]
     pub fn downcast_into<Raw, T: TCFType<*const Raw>>(self) -> Option<T> {
         if self.instance_of::<_, T>() {
             let reference = self.0 as *const Raw;

--- a/core-foundation/src/base.rs
+++ b/core-foundation/src/base.rs
@@ -30,8 +30,10 @@ impl CFIndexConvertible for usize {
     }
 }
 
-/// Superclass of all Core Foundation objects.
-pub struct CFType(CFTypeRef);
+declare_TCFType!{
+    /// Superclass of all Core Foundation objects.
+    CFType, CFTypeRef
+}
 
 impl fmt::Debug for CFType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -60,25 +62,7 @@ impl PartialEq for CFType {
     }
 }
 
-impl Drop for CFType {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.0)
-        }
-    }
-}
-
-/// An allocator for Core Foundation objects.
-pub struct CFAllocator(CFAllocatorRef);
-
-impl Drop for CFAllocator {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
-}
-
+declare_TCFType!(CFAllocator, CFAllocatorRef);
 impl_TCFType!(CFAllocator, CFAllocatorRef, CFAllocatorGetTypeID);
 
 impl CFAllocator {

--- a/core-foundation/src/boolean.rs
+++ b/core-foundation/src/boolean.rs
@@ -14,19 +14,13 @@ pub use core_foundation_sys::number::{CFBooleanRef, CFBooleanGetTypeID, kCFBoole
 
 use base::TCFType;
 
-/// A Boolean type.
-///
-/// FIXME(pcwalton): Should be a newtype struct, but that fails due to a Rust compiler bug.
-pub struct CFBoolean(CFBooleanRef);
 
-impl Drop for CFBoolean {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
+declare_TCFType!{
+    /// A Boolean type.
+    ///
+    /// FIXME(pcwalton): Should be a newtype struct, but that fails due to a Rust compiler bug.
+    CFBoolean, CFBooleanRef
 }
-
 impl_TCFType!(CFBoolean, CFBooleanRef, CFBooleanGetTypeID);
 impl_CFTypeDescription!(CFBoolean);
 

--- a/core-foundation/src/bundle.rs
+++ b/core-foundation/src/bundle.rs
@@ -16,16 +16,12 @@ use base::TCFType;
 use url::CFURL;
 use dictionary::CFDictionary;
 
-/// A Bundle type.
-pub struct CFBundle(CFBundleRef);
 
-impl Drop for CFBundle {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
+declare_TCFType!{
+    /// A Bundle type.
+    CFBundle, CFBundleRef
 }
+impl_TCFType!(CFBundle, CFBundleRef, CFBundleGetTypeID);
 
 impl CFBundle {
     pub fn new(bundleURL: CFURL) -> Option<CFBundle> {
@@ -76,7 +72,6 @@ impl CFBundle {
     }
 }
 
-impl_TCFType!(CFBundle, CFBundleRef, CFBundleGetTypeID);
 
 #[test]
 fn safari_executable_url() {

--- a/core-foundation/src/data.rs
+++ b/core-foundation/src/data.rs
@@ -17,17 +17,11 @@ use std::slice;
 
 use base::{CFIndexConvertible, TCFType};
 
-/// A byte buffer.
-pub struct CFData(CFDataRef);
 
-impl Drop for CFData {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
+declare_TCFType!{
+    /// A byte buffer.
+    CFData, CFDataRef
 }
-
 impl_TCFType!(CFData, CFDataRef, CFDataGetTypeID);
 impl_CFTypeDescription!(CFData);
 

--- a/core-foundation/src/date.rs
+++ b/core-foundation/src/date.rs
@@ -17,17 +17,11 @@ use base::TCFType;
 #[cfg(feature = "with-chrono")]
 use chrono::NaiveDateTime;
 
-/// A date.
-pub struct CFDate(CFDateRef);
 
-impl Drop for CFDate {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
+declare_TCFType!{
+    /// A date.
+    CFDate, CFDateRef
 }
-
 impl_TCFType!(CFDate, CFDateRef, CFDateGetTypeID);
 impl_CFTypeDescription!(CFDate);
 impl_CFComparison!(CFDate, CFDateCompare);

--- a/core-foundation/src/dictionary.rs
+++ b/core-foundation/src/dictionary.rs
@@ -121,15 +121,9 @@ impl CFDictionary {
     }
 }
 
-/// An mutable dictionary of key-value pairs.
-pub struct CFMutableDictionary(CFMutableDictionaryRef);
-
-impl Drop for CFMutableDictionary {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
+declare_TCFType!{
+    /// An mutable dictionary of key-value pairs.
+    CFMutableDictionary, CFMutableDictionaryRef
 }
 
 impl_TCFType!(CFMutableDictionary, CFMutableDictionaryRef, CFDictionaryGetTypeID);

--- a/core-foundation/src/dictionary.rs
+++ b/core-foundation/src/dictionary.rs
@@ -18,17 +18,11 @@ use std::ptr;
 
 use base::{CFType, CFIndexConvertible, TCFType};
 
-/// An immutable dictionary of key-value pairs.
-pub struct CFDictionary(CFDictionaryRef);
 
-impl Drop for CFDictionary {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
+declare_TCFType!{
+    /// An immutable dictionary of key-value pairs.
+    CFDictionary, CFDictionaryRef
 }
-
 impl_TCFType!(CFDictionary, CFDictionaryRef, CFDictionaryGetTypeID);
 impl_CFTypeDescription!(CFDictionary);
 

--- a/core-foundation/src/error.rs
+++ b/core-foundation/src/error.rs
@@ -17,17 +17,11 @@ use std::fmt;
 use base::{CFIndex, TCFType};
 use string::CFString;
 
-/// An error value.
-pub struct CFError(CFErrorRef);
 
-impl Drop for CFError {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
+declare_TCFType!{
+    /// An error value.
+    CFError, CFErrorRef
 }
-
 impl_TCFType!(CFError, CFErrorRef, CFErrorGetTypeID);
 
 impl fmt::Debug for CFError {

--- a/core-foundation/src/lib.rs
+++ b/core-foundation/src/lib.rs
@@ -15,6 +15,23 @@ extern crate libc;
 extern crate chrono;
 
 #[macro_export]
+macro_rules! declare_TCFType {
+    (
+        $(#[$doc:meta])*
+        $ty:ident, $raw:ident
+    ) => {
+        $(#[$doc])*
+        pub struct $ty($raw);
+
+        impl Drop for $ty {
+            fn drop(&mut self) {
+                unsafe { CFRelease(self.as_CFTypeRef()) }
+            }
+        }
+    }
+}
+
+#[macro_export]
 macro_rules! impl_TCFType {
     ($ty:ident, $raw:ident, $ty_id:ident) => {
         impl $crate::base::TCFType<$raw> for $ty {

--- a/core-foundation/src/number.rs
+++ b/core-foundation/src/number.rs
@@ -13,19 +13,13 @@ use core_foundation_sys::base::{CFRelease, kCFAllocatorDefault};
 pub use core_foundation_sys::number::*;
 use std::mem;
 
-use base::{TCFType};
+use base::TCFType;
 
-/// An immutable numeric value.
-pub struct CFNumber(CFNumberRef);
 
-impl Drop for CFNumber {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
+declare_TCFType!{
+    /// An immutable numeric value.
+    CFNumber, CFNumberRef
 }
-
 impl_TCFType!(CFNumber, CFNumberRef, CFNumberGetTypeID);
 impl_CFTypeDescription!(CFNumber);
 impl_CFComparison!(CFNumber, CFNumberCompare);

--- a/core-foundation/src/propertylist.rs
+++ b/core-foundation/src/propertylist.rs
@@ -66,10 +66,15 @@ pub trait CFPropertyListSubClass<Raw>: TCFType<*const Raw> {
     /// Create an instance of the superclass type [`CFPropertyList`] for this instance.
     ///
     /// [`CFPropertyList`]: struct.CFPropertyList.html
+    #[inline]
     fn to_CFPropertyList(&self) -> CFPropertyList {
         unsafe { CFPropertyList::wrap_under_get_rule(self.as_concrete_TypeRef() as *const c_void) }
     }
 
+    /// Equal to [`to_CFPropertyList`], but consumes self and avoids changing the reference count.
+    ///
+    /// [`to_CFPropertyList`]: #method.to_CFPropertyList
+    #[inline]
     fn into_CFPropertyList(self) -> CFPropertyList
     where Self: Sized
     {
@@ -189,9 +194,9 @@ impl PartialEq for CFPropertyList {
 impl Eq for CFPropertyList {}
 
 impl CFPropertyList {
-    /// Try to downcast the [`CFPropertyList`] to a subclass. Checking if the instance is the correct
-    /// subclass happens at runtime and an error is returned if it is not the correct type.
-    /// Works similar to [`Box::downcast`].
+    /// Try to downcast the [`CFPropertyList`] to a subclass. Checking if the instance is the
+    /// correct subclass happens at runtime and `None` is returned if it is not the correct type.
+    /// Works similar to [`Box::downcast`] and [`CFType::downcast`].
     ///
     /// # Examples
     ///
@@ -209,6 +214,7 @@ impl CFPropertyList {
     ///
     /// [`CFPropertyList`]: struct.CFPropertyList.html
     /// [`Box::downcast`]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method.downcast
+    /// [`CFType::downcast`]: ../base/struct.CFType.html#method.downcast
     pub fn downcast<Raw, T: CFPropertyListSubClass<Raw>>(&self) -> Option<T> {
         if self.instance_of::<_, T>() {
             Some(unsafe { T::wrap_under_get_rule(self.0 as *const Raw) })
@@ -218,6 +224,8 @@ impl CFPropertyList {
     }
 
     /// Similar to [`downcast`], but consumes self and can thus avoid touching the retain count.
+    ///
+    /// [`downcast`]: #method.downcast
     pub fn downcast_into<Raw, T: CFPropertyListSubClass<Raw>>(self) -> Option<T> {
         if self.instance_of::<_, T>() {
             let reference = self.0 as *const Raw;

--- a/core-foundation/src/propertylist.rs
+++ b/core-foundation/src/propertylist.rs
@@ -79,28 +79,25 @@ impl CFPropertyListSubClass<::date::__CFDate> for ::date::CFDate {}
 impl CFPropertyListSubClass<::number::__CFBoolean> for ::boolean::CFBoolean {}
 impl CFPropertyListSubClass<::number::__CFNumber> for ::number::CFNumber {}
 
-/// A CFPropertyList struct. This is superclass to [`CFData`], [`CFString`], [`CFArray`],
-/// [`CFDictionary`], [`CFDate`], [`CFBoolean`], and [`CFNumber`].
-///
-/// This superclass type does not have its own `CFTypeID`, instead each instance has the `CFTypeID`
-/// of the subclass it is an instance of. Thus, this type cannot implement the [`TCFType`] trait,
-/// since it cannot implement the static [`TCFType::type_id()`] method.
-///
-/// [`CFData`]: ../data/struct.CFData.html
-/// [`CFString`]: ../string/struct.CFString.html
-/// [`CFArray`]: ../array/struct.CFArray.html
-/// [`CFDictionary`]: ../dictionary/struct.CFDictionary.html
-/// [`CFDate`]: ../date/struct.CFDate.html
-/// [`CFBoolean`]: ../boolean/struct.CFBoolean.html
-/// [`CFNumber`]: ../number/struct.CFNumber.html
-/// [`TCFType`]: ../base/trait.TCFType.html
-/// [`TCFType::type_id()`]: ../base/trait.TCFType.html#method.type_of
-pub struct CFPropertyList(CFPropertyListRef);
 
-impl Drop for CFPropertyList {
-    fn drop(&mut self) {
-        unsafe { CFRelease(self.as_CFTypeRef()) }
-    }
+declare_TCFType!{
+    /// A CFPropertyList struct. This is superclass to [`CFData`], [`CFString`], [`CFArray`],
+    /// [`CFDictionary`], [`CFDate`], [`CFBoolean`], and [`CFNumber`].
+    ///
+    /// This superclass type does not have its own `CFTypeID`, instead each instance has the `CFTypeID`
+    /// of the subclass it is an instance of. Thus, this type cannot implement the [`TCFType`] trait,
+    /// since it cannot implement the static [`TCFType::type_id()`] method.
+    ///
+    /// [`CFData`]: ../data/struct.CFData.html
+    /// [`CFString`]: ../string/struct.CFString.html
+    /// [`CFArray`]: ../array/struct.CFArray.html
+    /// [`CFDictionary`]: ../dictionary/struct.CFDictionary.html
+    /// [`CFDate`]: ../date/struct.CFDate.html
+    /// [`CFBoolean`]: ../boolean/struct.CFBoolean.html
+    /// [`CFNumber`]: ../number/struct.CFNumber.html
+    /// [`TCFType`]: ../base/trait.TCFType.html
+    /// [`TCFType::type_id()`]: ../base/trait.TCFType.html#method.type_of
+    CFPropertyList, CFPropertyListRef
 }
 
 impl CFPropertyList {

--- a/core-foundation/src/runloop.rs
+++ b/core-foundation/src/runloop.rs
@@ -20,16 +20,8 @@ use string::{CFString};
 
 pub type CFRunLoopMode = CFStringRef;
 
-pub struct CFRunLoop(CFRunLoopRef);
 
-impl Drop for CFRunLoop {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
-}
-
+declare_TCFType!(CFRunLoop, CFRunLoopRef);
 impl_TCFType!(CFRunLoop, CFRunLoopRef, CFRunLoopGetTypeID);
 impl_CFTypeDescription!(CFRunLoop);
 
@@ -128,16 +120,8 @@ impl CFRunLoop {
 
 }
 
-pub struct CFRunLoopTimer(CFRunLoopTimerRef);
 
-impl Drop for CFRunLoopTimer {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
-}
-
+declare_TCFType!(CFRunLoopTimer, CFRunLoopTimerRef);
 impl_TCFType!(CFRunLoopTimer, CFRunLoopTimerRef, CFRunLoopTimerGetTypeID);
 
 impl CFRunLoopTimer {
@@ -150,29 +134,10 @@ impl CFRunLoopTimer {
 }
 
 
-pub struct CFRunLoopSource(CFRunLoopSourceRef);
-
-impl Drop for CFRunLoopSource {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
-}
-
+declare_TCFType!(CFRunLoopSource, CFRunLoopSourceRef);
 impl_TCFType!(CFRunLoopSource, CFRunLoopSourceRef, CFRunLoopSourceGetTypeID);
 
-
-pub struct CFRunLoopObserver(CFRunLoopObserverRef);
-
-impl Drop for CFRunLoopObserver {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
-}
-
+declare_TCFType!(CFRunLoopObserver, CFRunLoopObserverRef);
 impl_TCFType!(CFRunLoopObserver, CFRunLoopObserverRef, CFRunLoopObserverGetTypeID);
 
 #[cfg(test)]

--- a/core-foundation/src/set.rs
+++ b/core-foundation/src/set.rs
@@ -17,17 +17,11 @@ use base::{CFIndexConvertible, TCFType};
 
 use std::mem;
 
-/// An immutable bag of elements.
-pub struct CFSet(CFSetRef);
 
-impl Drop for CFSet {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
+declare_TCFType!{
+    /// An immutable bag of elements.
+    CFSet, CFSetRef
 }
-
 impl_TCFType!(CFSet, CFSetRef, CFSetGetTypeID);
 impl_CFTypeDescription!(CFSet);
 

--- a/core-foundation/src/string.rs
+++ b/core-foundation/src/string.rs
@@ -20,17 +20,11 @@ use std::str::{self, FromStr};
 use std::ptr;
 use std::ffi::CStr;
 
-/// An immutable string in one of a variety of encodings.
-pub struct CFString(CFStringRef);
 
-impl Drop for CFString {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
+declare_TCFType!{
+    /// An immutable string in one of a variety of encodings.
+    CFString, CFStringRef
 }
-
 impl_TCFType!(CFString, CFStringRef, CFStringGetTypeID);
 
 impl FromStr for CFString {

--- a/core-foundation/src/timezone.rs
+++ b/core-foundation/src/timezone.rs
@@ -18,17 +18,11 @@ use date::{CFDate, CFTimeInterval};
 #[cfg(feature = "with-chrono")]
 use chrono::{FixedOffset, NaiveDateTime};
 
-/// A time zone.
-pub struct CFTimeZone(CFTimeZoneRef);
 
-impl Drop for CFTimeZone {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
+declare_TCFType!{
+    /// A time zone.
+    CFTimeZone, CFTimeZoneRef
 }
-
 impl_TCFType!(CFTimeZone, CFTimeZoneRef, CFTimeZoneGetTypeID);
 impl_CFTypeDescription!(CFTimeZone);
 

--- a/core-foundation/src/url.rs
+++ b/core-foundation/src/url.rs
@@ -27,16 +27,8 @@ use std::os::unix::ffi::OsStrExt;
 #[cfg(unix)]
 use std::ffi::OsStr;
 
-pub struct CFURL(CFURLRef);
 
-impl Drop for CFURL {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
-}
-
+declare_TCFType!(CFURL, CFURLRef);
 impl_TCFType!(CFURL, CFURLRef, CFURLGetTypeID);
 
 impl fmt::Debug for CFURL {

--- a/core-foundation/src/uuid.rs
+++ b/core-foundation/src/uuid.rs
@@ -20,17 +20,11 @@ use base::TCFType;
 #[cfg(feature = "with-uuid")]
 use self::uuid::Uuid;
 
-/// A UUID.
-pub struct CFUUID(CFUUIDRef);
 
-impl Drop for CFUUID {
-    fn drop(&mut self) {
-        unsafe {
-            CFRelease(self.as_CFTypeRef())
-        }
-    }
+declare_TCFType! {
+    /// A UUID.
+    CFUUID, CFUUIDRef
 }
-
 impl_TCFType!(CFUUID, CFUUIDRef, CFUUIDGetTypeID);
 impl_CFTypeDescription!(CFUUID);
 


### PR DESCRIPTION
There are a lot of places where we increment and decrement the retain count when we would not have to. For example, a very common use-case with PropertyLists is to just directly cast them to their correct sub type and then throw the PropertyList away (because there is nothing you can do with the PropertyList instance directly.)

The reason we do this, I guess, is mostly because all `Drop` implementations force a retain count decrement. So we have to keep incrementing it to keep it correct. But if we add a flag to types that can be used to disable the decrement, then we can also get rid of the increment when we virtually just want to cast a pointer between two types.

This PR implements this by adding a boolean flag to all CF structs that is used by the `Drop` impl to determine if it should `CFRelease` the instance or not. Then this flag is modified in appropriate places where we cast to other types and consume ourselves.

I added some benchmarks locally. I did not want to commit them since benchmarking only works on nighty, and I did not feel like adding a feature flag for it etc. Anyhow, the following benchmarks:
```rust
#[bench]
fn bench_before(b: &mut Bencher) {
   let string = CFString::from_static_string("Bar");
    b.iter(|| unsafe {
        string.clone()
            .to_CFPropertyList()
            .downcast::<_, CFString>()
            .unwrap()
            .disable_release();
    })
}

#[bench]
fn bench_after(b: &mut Bencher) {
    let string = CFString::from_static_string("Bar");
    b.iter(|| unsafe {
        string.clone()
            .into_CFPropertyList()
            .downcast_into::<_, CFString>()
            .unwrap()
            .disable_release();
    })
}
```
Given the following results:
```
test propertylist::test::bench_after         ... bench:          16 ns/iter (+/- 3)
test propertylist::test::bench_before        ... bench:          73 ns/iter (+/- 14)
```
The final call to `disable_release()` in the benchmarks are to prevent the type coming out of the `unwrap()` from calling `CFRelease` on drop, and thus avoid measuring that. I want to try to measure only `{to,into}_CFPropertyList`, `downcast` and `downcast_into`. The `clone` is needed because the `into` version requires it and it would then not be fair to not have it on both.

I would say that speeding it up by a factor of ~4 can be well worth it? (Well, that 4 is of course no good measurement of anything, microbenchmarks etc. etc.. The benchmark mostly shows that a lot can be gained from avoiding some retain counting.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/142)
<!-- Reviewable:end -->
