### PR TITLE
Make info_dictionary return mutable dictionary

### DIFF
--- a/core-foundation/src/bundle.rs
+++ b/core-foundation/src/bundle.rs
@@ -14,7 +14,7 @@ use core_foundation_sys::base::{CFRelease, kCFAllocatorDefault};
 
 use base::TCFType;
 use url::CFURL;
-use dictionary::CFDictionary;
+use dictionary::CFMutableDictionary;
 
 
 declare_TCFType!{
@@ -42,7 +42,7 @@ impl CFBundle {
         }
     }
 
-    pub fn info_dictionary(&self) -> CFDictionary {
+    pub fn info_dictionary(&self) -> CFMutableDictionary {
         unsafe {
             let info_dictionary = CFBundleGetInfoDictionary(self.0);
             TCFType::wrap_under_get_rule(info_dictionary)


### PR DESCRIPTION
The problem is that glutin sets a value in an **immutable** dict here: https://github.com/servo/glutin/blob/servo/src/api/cocoa/mod.rs#L403. That does not work any longer after #135, since `set_value` is gone.

`CFBundleGetInfoDictionary` returns a `CFDictionaryRef` (not a `CFMutableDictionaryRef`) and the docs on that function does not mention the returned dictionary being mutable. So if going by that information, this PR changes into something wrong. But if the code in glutin is correct (which I know nothing about, only have to assume), then it can obviously set a value in the dict. So is it mutable?

One way to solve it is in the way done in this PR at the moment. Because then glutin can continue to set the value in the dict. But if we think the returned dict should be immutable in general (as the Apple docs seems to indicate?), then we could keep this crate as is, but instead make glutin step down one level and call `CFDictionarySetValue` unsafely by itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/146)
<!-- Reviewable:end -->
