### PR TITLE
Reduce usage of libc crate.

### DIFF
--- a/core-foundation-sys/Cargo.toml
+++ b/core-foundation-sys/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT / Apache-2.0"
 build = "build.rs"
 
 [dependencies]
-libc = "0.2"
 
 [features]
 mac_os_10_7_support = [] # backwards compatibility

--- a/core-foundation-sys/src/array.rs
+++ b/core-foundation-sys/src/array.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 use base::{CFRange, CFIndex, CFAllocatorRef, CFTypeID, Boolean};
 use string::CFStringRef;

--- a/core-foundation-sys/src/base.rs
+++ b/core-foundation-sys/src/base.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use std::cmp::Ordering;
-use libc::{c_uint, c_long, c_ulong, c_void, c_int};
+use std::os::raw::{c_uint, c_long, c_ulong, c_void, c_int};
 use string::CFStringRef;
 
 pub type Boolean = u8;

--- a/core-foundation-sys/src/bundle.rs
+++ b/core-foundation-sys/src/bundle.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 use base::{CFTypeID, CFAllocatorRef};
 use url::CFURLRef;

--- a/core-foundation-sys/src/data.rs
+++ b/core-foundation-sys/src/data.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 use base::{CFAllocatorRef, CFTypeID, CFIndex};
 

--- a/core-foundation-sys/src/date.rs
+++ b/core-foundation-sys/src/date.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 use base::{CFAllocatorRef, CFComparisonResult, CFTypeID};
 

--- a/core-foundation-sys/src/dictionary.rs
+++ b/core-foundation-sys/src/dictionary.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::{c_void};
+use std::os::raw::c_void;
 
 use base::{CFAllocatorRef, CFHashCode, CFIndex, CFTypeID, Boolean};
 use string::CFStringRef;

--- a/core-foundation-sys/src/error.rs
+++ b/core-foundation-sys/src/error.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 use base::{CFTypeID, CFIndex};
 use string::CFStringRef;

--- a/core-foundation-sys/src/filedescriptor.rs
+++ b/core-foundation-sys/src/filedescriptor.rs
@@ -7,7 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::{c_void, c_int};
+use std::os::raw::{c_int, c_void};
+
 use base::{Boolean, CFIndex, CFTypeID, CFOptionFlags, CFAllocatorRef};
 use string::CFStringRef;
 use runloop::CFRunLoopSourceRef;

--- a/core-foundation-sys/src/lib.rs
+++ b/core-foundation-sys/src/lib.rs
@@ -10,8 +10,6 @@
 
 #![cfg_attr(all(feature="mac_os_10_7_support", feature="mac_os_10_8_features"), feature(linkage))] // back-compat requires weak linkage
 
-extern crate libc;
-
 pub mod array;
 pub mod base;
 pub mod bundle;

--- a/core-foundation-sys/src/messageport.rs
+++ b/core-foundation-sys/src/messageport.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 use base::{CFAllocatorRef, CFIndex, CFTypeID, Boolean};
 use data::CFDataRef;

--- a/core-foundation-sys/src/number.rs
+++ b/core-foundation-sys/src/number.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 use base::{CFAllocatorRef, CFTypeID, CFComparisonResult};
 

--- a/core-foundation-sys/src/runloop.rs
+++ b/core-foundation-sys/src/runloop.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 use array::CFArrayRef;
 use base::{Boolean, CFIndex, CFTypeID, CFAllocatorRef, CFOptionFlags, CFHashCode, mach_port_t};

--- a/core-foundation-sys/src/set.rs
+++ b/core-foundation-sys/src/set.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 use base::{CFAllocatorRef, CFIndex, CFTypeID};
 

--- a/core-foundation-sys/src/string.rs
+++ b/core-foundation-sys/src/string.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::{c_char, c_ushort, c_void};
+use std::os::raw::{c_char, c_ushort, c_void};
 
 use base::{Boolean, CFOptionFlags, CFIndex, CFAllocatorRef, CFRange, CFTypeID};
 

--- a/core-foundation-sys/src/timezone.rs
+++ b/core-foundation-sys/src/timezone.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 use base::{CFAllocatorRef, CFTypeID};
 use date::{CFTimeInterval, CFAbsoluteTime};

--- a/core-foundation-sys/src/url.rs
+++ b/core-foundation-sys/src/url.rs
@@ -6,7 +6,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use libc::c_void;
+
+use std::os::raw::c_void;
 
 use base::{CFOptionFlags, CFIndex, CFAllocatorRef, Boolean, CFTypeID, CFTypeRef, SInt32};
 use string::{CFStringRef, CFStringEncoding};

--- a/core-foundation-sys/src/uuid.rs
+++ b/core-foundation-sys/src/uuid.rs
@@ -6,7 +6,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use libc::c_void;
+
+use std::os::raw::c_void;
 
 use base::{CFAllocatorRef, CFTypeID};
 

--- a/core-foundation/src/array.rs
+++ b/core-foundation/src/array.rs
@@ -12,12 +12,12 @@
 pub use core_foundation_sys::array::*;
 pub use core_foundation_sys::base::CFIndex;
 use core_foundation_sys::base::{CFTypeRef, CFRelease, kCFAllocatorDefault};
-use libc::c_void;
 use std::mem;
 use std::mem::ManuallyDrop;
 use std::marker::PhantomData;
 use std;
 use std::ops::Deref;
+use std::os::raw::c_void;
 use std::fmt::{Debug, Formatter};
 
 use base::{CFIndexConvertible, TCFType, TCFTypeRef, CFRange};

--- a/core-foundation/src/dictionary.rs
+++ b/core-foundation/src/dictionary.rs
@@ -12,8 +12,8 @@
 pub use core_foundation_sys::dictionary::*;
 
 use core_foundation_sys::base::{CFTypeRef, kCFAllocatorDefault};
-use libc::c_void;
 use std::mem;
+use std::os::raw::c_void;
 use std::ptr;
 
 use base::{CFType, CFIndexConvertible, TCFType, TCFTypeRef};

--- a/core-foundation/src/filedescriptor.rs
+++ b/core-foundation/src/filedescriptor.rs
@@ -107,9 +107,10 @@ mod test {
 
     use super::*;
     use std::ffi::CString;
-    use libc::{c_void, O_RDWR};
+    use std::os::raw::c_void;
     use core_foundation_sys::base::{CFOptionFlags};
     use core_foundation_sys::runloop::{kCFRunLoopDefaultMode};
+    use libc::O_RDWR;
     use runloop::{CFRunLoop};
 
     #[test]

--- a/core-foundation/src/propertylist.rs
+++ b/core-foundation/src/propertylist.rs
@@ -11,8 +11,7 @@
 
 use std::ptr;
 use std::mem;
-
-use libc::c_void;
+use std::os::raw::c_void;
 
 use error::CFError;
 use data::CFData;

--- a/core-foundation/src/runloop.rs
+++ b/core-foundation/src/runloop.rs
@@ -152,7 +152,7 @@ mod test {
     use super::*;
     use date::{CFDate, CFAbsoluteTime};
     use std::mem;
-    use libc::c_void;
+    use std::os::raw::c_void;
     use std::sync::mpsc;
 
     #[test]

--- a/core-foundation/tests/use_macro_outside_crate.rs
+++ b/core-foundation/tests/use_macro_outside_crate.rs
@@ -1,9 +1,8 @@
 #[macro_use]
 extern crate core_foundation;
-extern crate libc;
 
 use core_foundation::base::{CFComparisonResult, TCFType};
-use libc::c_void;
+use std::os::raw::c_void;
 
 // sys equivalent stuff that must be declared
 


### PR DESCRIPTION
Switch from using `libc` types to `::std::os::raw`. This is a breaking
change due to the differences in how `c_void` is defined.

`core-foundation-sys` no longer needs the `libc` dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/156)
<!-- Reviewable:end -->
