### PR TITLE
Add a ConcreteCFType trait

### DIFF
--- a/core-foundation/src/array.rs
+++ b/core-foundation/src/array.rs
@@ -19,6 +19,7 @@ use std::marker::PhantomData;
 use std;
 use std::ops::Deref;
 use std::fmt::{Debug, Formatter};
+use ConcreteCFType;
 
 use base::{CFIndexConvertible, TCFType, TCFTypeRef, CFRange};
 
@@ -101,6 +102,8 @@ impl<'a, T: FromVoid> ExactSizeIterator for CFArrayIterator<'a, T> {
 
 impl_TCFTypeGeneric!(CFArray, CFArrayRef, CFArrayGetTypeID);
 impl_CFTypeDescriptionGeneric!(CFArray);
+
+unsafe impl ConcreteCFType for CFArray<*const c_void> {}
 
 impl<T> CFArray<T> {
     /// Creates a new `CFArray` with the given elements, which must be `CFType` objects.

--- a/core-foundation/src/base.rs
+++ b/core-foundation/src/base.rs
@@ -13,6 +13,7 @@ use std::mem;
 pub use core_foundation_sys::base::*;
 
 use string::CFString;
+use ConcreteCFType;
 
 pub trait CFIndexConvertible {
     /// Always use this method to construct a `CFIndex` value. It performs bounds checking to
@@ -61,7 +62,7 @@ impl CFType {
     /// [`Box::downcast`]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method.downcast
     /// [`CFPropertyList::downcast`]: ../propertylist/struct.CFPropertyList.html#method.downcast
     #[inline]
-    pub fn downcast<T: TCFType>(&self) -> Option<T> {
+    pub fn downcast<T: ConcreteCFType>(&self) -> Option<T> {
         if self.instance_of::<T>() {
             unsafe {
                 let reference = T::Ref::from_void_ptr(self.0);

--- a/core-foundation/src/lib.rs
+++ b/core-foundation/src/lib.rs
@@ -14,6 +14,10 @@ extern crate libc;
 #[cfg(feature = "with-chrono")]
 extern crate chrono;
 
+use base::TCFType;
+
+pub unsafe trait ConcreteCFType: TCFType {}
+
 #[macro_export]
 macro_rules! declare_TCFType {
     (
@@ -86,6 +90,8 @@ macro_rules! impl_TCFType {
         }
 
         impl Eq for $ty { }
+
+        unsafe impl $crate::ConcreteCFType for $ty { }
     }
 }
 


### PR DESCRIPTION
We'll use this to distinguish between generic and concrete CFTypes.
This lets us prevent downcast()ing to arbitrary generic types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/159)
<!-- Reviewable:end -->
