### PR TITLE
core-text: Remove unused imports.

### DIFF
--- a/core-text/src/font_descriptor.rs
+++ b/core-text/src/font_descriptor.rs
@@ -15,7 +15,7 @@ use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::number::{CFNumber, CFNumberRef};
 use core_foundation::set::CFSetRef;
 use core_foundation::string::{CFString, CFStringRef};
-use core_foundation::url::{CFURLCopyFileSystemPath, kCFURLPOSIXPathStyle, CFURL};
+use core_foundation::url::CFURL;
 use core_graphics::base::CGFloat;
 
 use libc::c_void;


### PR DESCRIPTION
This warning was introduced due to the changes made in
21f20e2f93895fae364a2a208282169cc1a20b6b.