### PR TITLE
Use stronger types in the core-text CFDictionaries

### DIFF
--- a/core-text/src/font.rs
+++ b/core-text/src/font.rs
@@ -98,7 +98,7 @@ pub fn new_from_CGFont(cgfont: &CGFont, pt_size: f64) -> CTFont {
 
 pub fn new_from_CGFont_with_variations(cgfont: &CGFont,
                                        pt_size: f64,
-                                       variations: &CFDictionary<CFType, CFType>)
+                                       variations: &CFDictionary<CFString, CFType>)
                                        -> CTFont {
     unsafe {
         let font_desc = font_descriptor::new_from_variations(variations);

--- a/core-text/src/font_collection.rs
+++ b/core-text/src/font_collection.rs
@@ -72,7 +72,7 @@ pub fn create_for_family(family: &str) -> Option<CTFontCollection> {
         let family_attr = CFString::wrap_under_get_rule(kCTFontFamilyNameAttribute);
         let family_name: CFString = family.parse().unwrap();
         let specified_attrs = CFDictionary::from_CFType_pairs(&[
-            (family_attr.as_CFType(), family_name.as_CFType())
+            (family_attr.clone(), family_name.as_CFType())
         ]);
 
         let wildcard_desc: CTFontDescriptor =

--- a/core-text/src/font_descriptor.rs
+++ b/core-text/src/font_descriptor.rs
@@ -265,7 +265,7 @@ impl CTFontDescriptor {
     }
 }
 
-pub fn new_from_attributes(attributes: &CFDictionary<CFType, CFType>) -> CTFontDescriptor {
+pub fn new_from_attributes(attributes: &CFDictionary<CFString, CFType>) -> CTFontDescriptor {
     unsafe {
         let result: CTFontDescriptorRef =
             CTFontDescriptorCreateWithAttributes(attributes.as_concrete_TypeRef());
@@ -273,9 +273,9 @@ pub fn new_from_attributes(attributes: &CFDictionary<CFType, CFType>) -> CTFontD
     }
 }
 
-pub fn new_from_variations(variations: &CFDictionary<CFType, CFType>) -> CTFontDescriptor {
+pub fn new_from_variations(variations: &CFDictionary<CFString, CFType>) -> CTFontDescriptor {
     unsafe {
-        let var_key = CFType::wrap_under_get_rule(mem::transmute(kCTFontVariationAttribute));
+        let var_key = CFString::wrap_under_get_rule(kCTFontVariationAttribute);
         let var_val = CFType::wrap_under_get_rule(variations.as_CFTypeRef());
         let attributes = CFDictionary::from_CFType_pairs(&[(var_key, var_val)]);
         new_from_attributes(&attributes)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/196)
<!-- Reviewable:end -->
