### PR TITLE
Only allow CFNumber font variations.

### DIFF
--- a/core-graphics/src/font.rs
+++ b/core-graphics/src/font.rs
@@ -8,9 +8,10 @@
 // except according to those terms.
 
 use std::ptr;
-use core_foundation::base::{CFRelease, CFRetain, CFTypeID, TCFType, CFType};
+use core_foundation::base::{CFRelease, CFRetain, CFTypeID, TCFType};
 use core_foundation::array::{CFArray, CFArrayRef};
 use core_foundation::data::{CFData, CFDataRef};
+use core_foundation::number::CFNumber;
 use core_foundation::string::{CFString, CFStringRef};
 use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use data_provider::CGDataProvider;
@@ -63,7 +64,7 @@ impl CGFont {
         }
     }
 
-    pub fn create_copy_from_variations(&self, vars: &CFDictionary<CFType, CFType>) -> Result<CGFont, ()> {
+    pub fn create_copy_from_variations(&self, vars: &CFDictionary<CFString, CFNumber>) -> Result<CGFont, ()> {
         unsafe {
             let font_ref = CGFontCreateCopyWithVariations(self.as_ptr(),
                                                           vars.as_concrete_TypeRef());

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "9.1.2"
+version = "10.0.0"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"

--- a/core-text/src/font.rs
+++ b/core-text/src/font.rs
@@ -14,9 +14,10 @@ use font_descriptor::{CTFontDescriptor, CTFontDescriptorRef, CTFontOrientation};
 use font_descriptor::{CTFontSymbolicTraits, CTFontTraits, SymbolicTraitAccessors, TraitAccessors};
 
 use core_foundation::array::{CFArray, CFArrayRef};
-use core_foundation::base::{CFIndex, CFOptionFlags, CFType, CFTypeID, CFTypeRef, TCFType};
+use core_foundation::base::{CFIndex, CFOptionFlags, CFTypeID, CFTypeRef, TCFType};
 use core_foundation::data::{CFData, CFDataRef};
 use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
+use core_foundation::number::CFNumber;
 use core_foundation::string::{CFString, CFStringRef, UniChar};
 use core_foundation::url::{CFURL, CFURLRef};
 use core_graphics::base::CGFloat;
@@ -98,7 +99,7 @@ pub fn new_from_CGFont(cgfont: &CGFont, pt_size: f64) -> CTFont {
 
 pub fn new_from_CGFont_with_variations(cgfont: &CGFont,
                                        pt_size: f64,
-                                       variations: &CFDictionary<CFString, CFType>)
+                                       variations: &CFDictionary<CFString, CFNumber>)
                                        -> CTFont {
     unsafe {
         let font_desc = font_descriptor::new_from_variations(variations);

--- a/core-text/src/font_descriptor.rs
+++ b/core-text/src/font_descriptor.rs
@@ -273,7 +273,7 @@ pub fn new_from_attributes(attributes: &CFDictionary<CFString, CFType>) -> CTFon
     }
 }
 
-pub fn new_from_variations(variations: &CFDictionary<CFString, CFType>) -> CTFontDescriptor {
+pub fn new_from_variations(variations: &CFDictionary<CFString, CFNumber>) -> CTFontDescriptor {
     unsafe {
         let var_key = CFString::wrap_under_get_rule(kCTFontVariationAttribute);
         let var_val = CFType::wrap_under_get_rule(variations.as_CFTypeRef());


### PR DESCRIPTION
Until #201 this seems like a worthwhile improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/202)
<!-- Reviewable:end -->
