### PR TITLE
Add NSViewFullScreenModeOptionKey keys

### DIFF
--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -84,6 +84,12 @@ extern {
     // NSAppearance names. (NSString *)
     pub static NSAppearanceNameVibrantDark: id;
     pub static NSAppearanceNameVibrantLight: id;
+
+    // Fullscreen mode options - OS X v10.5 and later. (NSString *)
+    pub static NSFullScreenModeAllScreens: id;
+    pub static NSFullScreenModeSetting: id;
+    pub static NSFullScreenModeWindowLevel: id;
+    pub static NSFullScreenModeApplicationPresentationOptions: id;
 }
 
 pub const NSAppKitVersionNumber10_0: f64 = 577.0;


### PR DESCRIPTION
This PR added NSViewFullScreenModeOptionKey values described in [here](https://developer.apple.com/documentation/appkit/nsviewfullscreenmodeoptionkey?language=objc)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/208)
<!-- Reviewable:end -->
