### PR TITLE
Expose CTFontCopyVariationAxes.

### DIFF
--- a/core-text/src/font.rs
+++ b/core-text/src/font.rs
@@ -14,7 +14,7 @@ use font_descriptor::{CTFontDescriptor, CTFontDescriptorRef, CTFontOrientation};
 use font_descriptor::{CTFontSymbolicTraits, CTFontTraits, SymbolicTraitAccessors, TraitAccessors};
 
 use core_foundation::array::{CFArray, CFArrayRef};
-use core_foundation::base::{CFIndex, CFOptionFlags, CFTypeID, CFTypeRef, TCFType};
+use core_foundation::base::{CFIndex, CFOptionFlags, CFType, CFTypeID, CFTypeRef, TCFType};
 use core_foundation::data::{CFData, CFDataRef};
 use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::number::CFNumber;
@@ -316,6 +316,16 @@ impl CTFont {
         }
     }
 
+    pub fn get_variation_axes(&self) -> Option<CFArray<CFDictionary<CFString, CFType>>> {
+        unsafe {
+            let axes = CTFontCopyVariationAxes(self.0);
+            if axes.is_null() {
+                return None;
+            }
+            Some(TCFType::wrap_under_create_rule(axes))
+        }
+    }
+
     pub fn create_path_for_glyph(&self, glyph: CGGlyph, matrix: &CGAffineTransform)
                                  -> Result<CGPath, ()> {
         unsafe {
@@ -491,7 +501,7 @@ extern {
     //fn CTFontGetVerticalTranslationsForGlyphs
 
     /* Working With Font Variations */
-    //fn CTFontCopyVariationAxes
+    fn CTFontCopyVariationAxes(font: CTFontRef) -> CFArrayRef;
     //fn CTFontCopyVariation
 
     /* Getting Font Features */


### PR DESCRIPTION
WebRender uses this function so it's probably useful to expose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/213)
<!-- Reviewable:end -->
