### PR TITLE
Consistently use std::os::raw::c_void instead of libc::c_void

### DIFF
--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -4,7 +4,7 @@ name = "cocoa"
 description = "Bindings to Cocoa for OS X"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 
@@ -16,5 +16,5 @@ crate-type = ["rlib"]
 block = "0.1"
 bitflags = "1.0"
 libc = "0.2"
-core-graphics = { path = "../core-graphics", version = "0.14" }
+core-graphics = { path = "../core-graphics", version = "0.15" }
 objc = "0.2"

--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -24,8 +24,9 @@ pub use self::NSBackingStoreType::*;
 pub use self::NSOpenGLPixelFormatAttribute::*;
 pub use self::NSOpenGLPFAOpenGLProfiles::*;
 pub use self::NSEventType::*;
+use std::os::raw::c_void;
 
-pub type CGLContextObj = *mut libc::c_void;
+pub type CGLContextObj = *mut c_void;
 
 pub type GLint = libc::int32_t;
 
@@ -2239,7 +2240,7 @@ pub trait NSEvent: Sized {
         context: id /* (NSGraphicsContext *) */,
         eventNumber: NSInteger,
         trackingNumber: NSInteger,
-        userData: *mut libc::c_void) -> id /* (NSEvent *) */;
+        userData: *mut c_void) -> id /* (NSEvent *) */;
     unsafe fn otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2_(
         _: Self,
         eventType: NSEventType,
@@ -2251,8 +2252,8 @@ pub trait NSEvent: Sized {
         subtype: NSEventSubtype,
         data1: NSInteger,
         data2: NSInteger) -> id /* (NSEvent *) */;
-    unsafe fn eventWithEventRef_(_: Self, eventRef: *const libc::c_void) -> id;
-    unsafe fn eventWithCGEvent_(_: Self, cgEvent: *mut libc::c_void /* CGEventRef */) -> id;
+    unsafe fn eventWithEventRef_(_: Self, eventRef: *const c_void) -> id;
+    unsafe fn eventWithCGEvent_(_: Self, cgEvent: *mut c_void /* CGEventRef */) -> id;
 
     // Getting General Event Information
     unsafe fn context(self) -> id /* (NSGraphicsContext *) */;
@@ -2263,8 +2264,8 @@ pub trait NSEvent: Sized {
     unsafe fn eventType(self) -> NSEventType;
     unsafe fn window(self) -> id /* (NSWindow *) */;
     unsafe fn windowNumber(self) -> NSInteger;
-    unsafe fn eventRef(self) -> *const libc::c_void;
-    unsafe fn CGEvent(self) -> *mut libc::c_void /* CGEventRef */;
+    unsafe fn eventRef(self) -> *const c_void;
+    unsafe fn CGEvent(self) -> *mut c_void /* CGEventRef */;
 
     // Getting Key Event Information
     // NOTE: renamed from `+ modifierFlags` due to conflict with `- modifierFlags`
@@ -2290,7 +2291,7 @@ pub trait NSEvent: Sized {
     unsafe fn eventNumber(self) -> NSInteger;
     unsafe fn trackingNumber(self) -> NSInteger;
     unsafe fn trackingArea(self) -> id /* (NSTrackingArea *) */;
-    unsafe fn userData(self) -> *const libc::c_void;
+    unsafe fn userData(self) -> *const c_void;
 
     // Getting Custom Event Information
     unsafe fn data1(self) -> NSInteger;
@@ -2411,7 +2412,7 @@ impl NSEvent for id {
         context: id /* (NSGraphicsContext *) */,
         eventNumber: NSInteger,
         trackingNumber: NSInteger,
-        userData: *mut libc::c_void) -> id /* (NSEvent *) */
+        userData: *mut c_void) -> id /* (NSEvent *) */
     {
         msg_send![class("NSEvent"), enterExitEventWithType:eventType
                                                   location:location
@@ -2447,11 +2448,11 @@ impl NSEvent for id {
                                                  data2:data2]
     }
 
-    unsafe fn eventWithEventRef_(_: Self, eventRef: *const libc::c_void) -> id {
+    unsafe fn eventWithEventRef_(_: Self, eventRef: *const c_void) -> id {
         msg_send![class("NSEvent"), eventWithEventRef:eventRef]
     }
 
-    unsafe fn eventWithCGEvent_(_: Self, cgEvent: *mut libc::c_void /* CGEventRef */) -> id {
+    unsafe fn eventWithCGEvent_(_: Self, cgEvent: *mut c_void /* CGEventRef */) -> id {
         msg_send![class("NSEvent"), eventWithCGEvent:cgEvent]
     }
 
@@ -2486,11 +2487,11 @@ impl NSEvent for id {
         msg_send![self, windowNumber]
     }
 
-    unsafe fn eventRef(self) -> *const libc::c_void {
+    unsafe fn eventRef(self) -> *const c_void {
         msg_send![self, eventRef]
     }
 
-    unsafe fn CGEvent(self) -> *mut libc::c_void /* CGEventRef */ {
+    unsafe fn CGEvent(self) -> *mut c_void /* CGEventRef */ {
         msg_send![self, CGEvent]
     }
 
@@ -2574,7 +2575,7 @@ impl NSEvent for id {
         msg_send![self, trackingArea]
     }
 
-    unsafe fn userData(self) -> *const libc::c_void {
+    unsafe fn userData(self) -> *const c_void {
         msg_send![self, userData]
     }
 

--- a/cocoa/src/foundation.rs
+++ b/cocoa/src/foundation.rs
@@ -10,6 +10,7 @@
 #![allow(non_upper_case_globals)]
 
 use std::ptr;
+use std::os::raw::c_void;
 use base::{id, class, BOOL, NO, SEL, nil};
 use block::Block;
 use libc;
@@ -705,15 +706,15 @@ pub trait NSData: Sized {
         msg_send![class("NSData"), data]
     }
 
-    unsafe fn dataWithBytes_length_(_: Self, bytes: *const libc::c_void, length: NSUInteger) -> id {
+    unsafe fn dataWithBytes_length_(_: Self, bytes: *const c_void, length: NSUInteger) -> id {
         msg_send![class("NSData"), dataWithBytes:bytes length:length]
     }
 
-    unsafe fn dataWithBytesNoCopy_length_(_: Self, bytes: *const libc::c_void, length: NSUInteger) -> id {
+    unsafe fn dataWithBytesNoCopy_length_(_: Self, bytes: *const c_void, length: NSUInteger) -> id {
         msg_send![class("NSData"), dataWithBytesNoCopy:bytes length:length]
     }
 
-    unsafe fn dataWithBytesNoCopy_length_freeWhenDone_(_: Self, bytes: *const libc::c_void,
+    unsafe fn dataWithBytesNoCopy_length_freeWhenDone_(_: Self, bytes: *const c_void,
                                                       length: NSUInteger, freeWhenDone: BOOL) -> id {
         msg_send![class("NSData"), dataWithBytesNoCopy:bytes length:length freeWhenDone:freeWhenDone]
     }
@@ -744,12 +745,12 @@ pub trait NSData: Sized {
                                                  -> id;
     unsafe fn initWithBase64EncodedString_options_(self, base64String: id, options: NSDataBase64DecodingOptions)
                                                    -> id;
-    unsafe fn initWithBytes_length_(self, bytes: *const libc::c_void, length: NSUInteger) -> id;
-    unsafe fn initWithBytesNoCopy_length_(self, bytes: *const libc::c_void, length: NSUInteger) -> id;
-    unsafe fn initWithBytesNoCopy_length_deallocator_(self, bytes: *const libc::c_void, length: NSUInteger,
-                                                      deallocator: *mut Block<(*const libc::c_void, NSUInteger), ()>)
+    unsafe fn initWithBytes_length_(self, bytes: *const c_void, length: NSUInteger) -> id;
+    unsafe fn initWithBytesNoCopy_length_(self, bytes: *const c_void, length: NSUInteger) -> id;
+    unsafe fn initWithBytesNoCopy_length_deallocator_(self, bytes: *const c_void, length: NSUInteger,
+                                                      deallocator: *mut Block<(*const c_void, NSUInteger), ()>)
                                                       -> id;
-    unsafe fn initWithBytesNoCopy_length_freeWhenDone_(self, bytes: *const libc::c_void,
+    unsafe fn initWithBytesNoCopy_length_freeWhenDone_(self, bytes: *const c_void,
                                                        length: NSUInteger, freeWhenDone: BOOL) -> id;
     unsafe fn initWithContentsOfFile_(self, path: id) -> id;
     unsafe fn initWithContentsOfFile_options_error(self, path: id, mask: NSDataReadingOptions, errorPtr: *mut id)
@@ -759,11 +760,11 @@ pub trait NSData: Sized {
                                                    -> id;
     unsafe fn initWithData_(self, data: id) -> id;
 
-    unsafe fn bytes(self) -> *const libc::c_void;
+    unsafe fn bytes(self) -> *const c_void;
     unsafe fn description(self) -> id;
-    unsafe fn enumerateByteRangesUsingBlock_(self, block: *mut Block<(*const libc::c_void, NSRange, *mut BOOL), ()>);
-    unsafe fn getBytes_length_(self, buffer: *mut libc::c_void, length: NSUInteger);
-    unsafe fn getBytes_range_(self, buffer: *mut libc::c_void, range: NSRange);
+    unsafe fn enumerateByteRangesUsingBlock_(self, block: *mut Block<(*const c_void, NSRange, *mut BOOL), ()>);
+    unsafe fn getBytes_length_(self, buffer: *mut c_void, length: NSUInteger);
+    unsafe fn getBytes_range_(self, buffer: *mut c_void, range: NSRange);
     unsafe fn subdataWithRange_(self, range: NSRange) -> id;
     unsafe fn rangeOfData_options_range_(self, dataToFind: id, options: NSDataSearchOptions, searchRange: NSRange)
                                          -> NSRange;
@@ -791,21 +792,21 @@ impl NSData for id {
         msg_send![self, initWithBase64EncodedString:base64String options:options]
     }
 
-    unsafe fn initWithBytes_length_(self, bytes: *const libc::c_void, length: NSUInteger) -> id {
+    unsafe fn initWithBytes_length_(self, bytes: *const c_void, length: NSUInteger) -> id {
         msg_send![self,initWithBytes:bytes length:length]
     }
 
-    unsafe fn initWithBytesNoCopy_length_(self, bytes: *const libc::c_void, length: NSUInteger) -> id {
+    unsafe fn initWithBytesNoCopy_length_(self, bytes: *const c_void, length: NSUInteger) -> id {
         msg_send![self, initWithBytesNoCopy:bytes length:length]
     }
 
-    unsafe fn initWithBytesNoCopy_length_deallocator_(self, bytes: *const libc::c_void, length: NSUInteger,
-                                                      deallocator: *mut Block<(*const libc::c_void, NSUInteger), ()>)
+    unsafe fn initWithBytesNoCopy_length_deallocator_(self, bytes: *const c_void, length: NSUInteger,
+                                                      deallocator: *mut Block<(*const c_void, NSUInteger), ()>)
                                                       -> id {
         msg_send![self, initWithBytesNoCopy:bytes length:length deallocator:deallocator]
     }
 
-    unsafe fn initWithBytesNoCopy_length_freeWhenDone_(self, bytes: *const libc::c_void,
+    unsafe fn initWithBytesNoCopy_length_freeWhenDone_(self, bytes: *const c_void,
                                                        length: NSUInteger, freeWhenDone: BOOL) -> id {
         msg_send![self, initWithBytesNoCopy:bytes length:length freeWhenDone:freeWhenDone]
     }
@@ -832,7 +833,7 @@ impl NSData for id {
         msg_send![self, initWithData:data]
     }
 
-    unsafe fn bytes(self) -> *const libc::c_void {
+    unsafe fn bytes(self) -> *const c_void {
         msg_send![self, bytes]
     }
 
@@ -840,15 +841,15 @@ impl NSData for id {
         msg_send![self, description]
     }
 
-    unsafe fn enumerateByteRangesUsingBlock_(self, block: *mut Block<(*const libc::c_void, NSRange, *mut BOOL), ()>) {
+    unsafe fn enumerateByteRangesUsingBlock_(self, block: *mut Block<(*const c_void, NSRange, *mut BOOL), ()>) {
         msg_send![self, enumerateByteRangesUsingBlock:block]
     }
 
-    unsafe fn getBytes_length_(self, buffer: *mut libc::c_void, length: NSUInteger) {
+    unsafe fn getBytes_length_(self, buffer: *mut c_void, length: NSUInteger) {
         msg_send![self, getBytes:buffer length:length]
     }
 
-    unsafe fn getBytes_range_(self, buffer: *mut libc::c_void, range: NSRange) {
+    unsafe fn getBytes_range_(self, buffer: *mut c_void, range: NSRange) {
         msg_send![self, getBytes:buffer range:range]
     }
 

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics"
 description = "Bindings to Core Graphics for OS X"
 homepage = "https://github.com/servo/core-graphics-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 

--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -12,7 +12,8 @@ use color_space::CGColorSpace;
 use core_foundation::base::{CFRelease, CFRetain, CFTypeID};
 use font::{CGFont, CGGlyph};
 use geometry::CGPoint;
-use libc::{c_void, c_int, size_t};
+use libc::{c_int, size_t};
+use std::os::raw::c_void;
 
 use std::cmp;
 use std::ptr;

--- a/core-graphics/src/data_provider.rs
+++ b/core-graphics/src/data_provider.rs
@@ -10,9 +10,10 @@
 use core_foundation::base::{CFRelease, CFRetain, CFTypeID, TCFType};
 use core_foundation::data::{CFData, CFDataRef};
 
-use libc::{c_void, size_t, off_t};
+use libc::{size_t, off_t};
 use std::mem;
 use std::sync::Arc;
+use std::os::raw::c_void;
 
 use foreign_types::{ForeignType, ForeignTypeRef};
 

--- a/core-graphics/src/path.rs
+++ b/core-graphics/src/path.rs
@@ -10,7 +10,7 @@
 use core_foundation::base::{CFRelease, CFRetain, CFTypeID};
 use foreign_types::ForeignType;
 use geometry::CGPoint;
-use libc::c_void;
+use std::os::raw::c_void;
 use std::fmt::{self, Debug, Formatter};
 use std::marker::PhantomData;
 use std::ops::Deref;

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -16,4 +16,4 @@ mountainlion = []
 foreign-types = "0.3"
 libc = "0.2"
 core-foundation = { path = "../core-foundation", version = "0.6" }
-core-graphics = { path = "../core-graphics", version = "0.14" }
+core-graphics = { path = "../core-graphics", version = "0.15" }

--- a/core-text/src/font.rs
+++ b/core-text/src/font.rs
@@ -27,7 +27,8 @@ use core_graphics::geometry::{CGAffineTransform, CGPoint, CGRect, CGSize};
 use core_graphics::path::CGPath;
 
 use foreign_types::ForeignType;
-use libc::{self, size_t, c_void};
+use libc::{self, size_t};
+use std::os::raw::c_void;
 use std::ptr;
 
 type CGContextRef = *mut <CGContext as ForeignType>::CType;

--- a/core-text/src/font_collection.rs
+++ b/core-text/src/font_collection.rs
@@ -18,7 +18,7 @@ use core_foundation::number::CFNumber;
 use core_foundation::set::CFSet;
 use core_foundation::string::{CFString, CFStringRef};
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 #[repr(C)]
 pub struct __CTFontCollection(c_void);

--- a/core-text/src/font_descriptor.rs
+++ b/core-text/src/font_descriptor.rs
@@ -18,7 +18,7 @@ use core_foundation::string::{CFString, CFStringRef};
 use core_foundation::url::CFURL;
 use core_graphics::base::CGFloat;
 
-use libc::c_void;
+use std::os::raw::c_void;
 use std::mem;
 use std::path::PathBuf;
 

--- a/io-surface/src/lib.rs
+++ b/io-surface/src/lib.rs
@@ -23,7 +23,8 @@ use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::string::CFStringRef;
 use cgl::{kCGLNoError, CGLGetCurrentContext, CGLTexImageIOSurface2D, CGLErrorString};
 use gleam::gl::{BGRA, GLenum, RGBA, TEXTURE_RECTANGLE_ARB, UNSIGNED_INT_8_8_8_8_REV};
-use libc::{c_int, c_void, size_t};
+use libc::{c_int, size_t};
+use std::os::raw::c_void;
 use leaky_cow::LeakyCow;
 use std::mem;
 use std::slice;
@@ -36,7 +37,7 @@ use std::ffi::CStr;
 type IOReturn = c_int;
 
 #[repr(C)]
-pub struct __IOSurface(libc::c_void);
+pub struct __IOSurface(c_void);
 
 pub type IOSurfaceRef = *const __IOSurface;
 


### PR DESCRIPTION
The major versions of cocoa and core-graphics are bumped as I believe
they are the only crates that meaningfully expose c_void.

Fixes #212

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/214)
<!-- Reviewable:end -->
