### PR TITLE
Additional functions for `CGImage` and `CGDataProvider`

### DIFF
--- a/core-graphics/src/base.rs
+++ b/core-graphics/src/base.rs
@@ -42,6 +42,12 @@ pub const kCGBitmapByteOrder32Little: u32 = (2 << 12);
 pub const kCGBitmapByteOrder16Big: u32 = (3 << 12);
 pub const kCGBitmapByteOrder32Big: u32 = (4 << 12);
 
+pub const kCGRenderingIntentDefault: u32 = 0;
+pub const kCGRenderingIntentAbsoluteColorimetric: u32 = 1;
+pub const kCGRenderingIntentRelativeColorimetric: u32 = 2;
+pub const kCGRenderingIntentPerceptual: u32 = 3;
+pub const kCGRenderingIntentSaturation: u32 = 4;
+
 #[cfg(target_endian = "big")]
 pub const kCGBitmapByteOrder16Host: u32 = kCGBitmapByteOrder16Big;
 #[cfg(target_endian = "big")]

--- a/core-graphics/src/data_provider.rs
+++ b/core-graphics/src/data_provider.rs
@@ -12,6 +12,7 @@ use core_foundation::data::{CFData, CFDataRef};
 
 use libc::{size_t, off_t};
 use std::mem;
+use std::ptr;
 use std::sync::Arc;
 use std::os::raw::c_void;
 
@@ -61,6 +62,15 @@ impl CGDataProvider {
         unsafe extern "C" fn release(info: *mut c_void, _: *const c_void, _: size_t) {
             drop(mem::transmute::<*mut c_void, Arc<Vec<u8>>>(info))
         }
+    }
+
+    /// Creates a data prvider from a given slice. The data provider does not own the slice in this
+    /// case, so it's up to the user to ensure the memory safety here.
+    pub unsafe fn from_slice(buffer: &[u8]) -> Self {
+        let ptr = buffer.as_ptr() as *const c_void;
+        let len = buffer.len() as size_t;
+        let result = CGDataProviderCreateWithData(ptr::null_mut(), ptr, len, None);
+        CGDataProvider::from_ptr(result)
     }
 }
 

--- a/core-graphics/src/image.rs
+++ b/core-graphics/src/image.rs
@@ -1,7 +1,10 @@
+use std::ptr;
+
+use base::CGFloat;
 use core_foundation::base::{CFRetain, CFTypeID};
 use core_foundation::data::CFData;
 use color_space::CGColorSpace;
-use data_provider::CGDataProviderRef;
+use data_provider::{CGDataProviderRef, CGDataProvider};
 use libc::size_t;
 use foreign_types::{ForeignType, ForeignTypeRef};
 
@@ -36,6 +39,34 @@ foreign_type! {
 }
 
 impl CGImage {
+    pub fn new(width: size_t,
+               height: size_t,
+               bits_per_component: size_t,
+               bits_per_pixel: size_t,
+               bytes_per_row: size_t,
+               colorspace: &CGColorSpace,
+               bitmap_info: u32,
+               provider: &CGDataProvider,
+               should_interpolate: bool,
+               rendering_intent: u32)
+               -> Self {
+        unsafe {
+            let result =  CGImageCreate(width,
+                                        height,
+                                        bits_per_component,
+                                        bits_per_pixel,
+                                        bytes_per_row,
+                                        colorspace.as_ptr(),
+                                        bitmap_info,
+                                        provider.as_ptr(),
+                                        ptr::null_mut(),
+                                        should_interpolate,
+                                        rendering_intent);
+            assert!(!result.is_null());
+            Self::from_ptr(result)
+        }
+    }
+
     pub fn type_id() -> CFTypeID {
         unsafe {
             CGImageGetTypeID()
@@ -103,6 +134,18 @@ extern {
     fn CGImageGetColorSpace(image: ::sys::CGImageRef) -> ::sys::CGColorSpaceRef;
     fn CGImageGetDataProvider(image: ::sys::CGImageRef) -> ::sys::CGDataProviderRef;
     fn CGImageRelease(image: ::sys::CGImageRef);
+    fn CGImageCreate(width: size_t,
+                     height: size_t,
+                     bitsPerComponent: size_t,
+                     bitsPerPixel: size_t,
+                     bytesPerRow: size_t,
+                     space: ::sys::CGColorSpaceRef,
+                     bitmapInfo: u32,
+                     provider: ::sys::CGDataProviderRef,
+                     decode: *const CGFloat,
+                     shouldInterpolate: bool,
+                     intent: u32)
+                     -> ::sys::CGImageRef;
 
     //fn CGImageGetAlphaInfo(image: ::sys::CGImageRef) -> CGImageAlphaInfo;
     //fn CGImageCreateCopyWithColorSpace(image: ::sys::CGImageRef, space: ::sys::CGColorSpaceRef) -> ::sys::CGImageRef


### PR DESCRIPTION
1. Adds a possibility to construct a CGImage from a given provider. I don't know if it's the most optimal way to implement it and if it is safe, but it would be nice to wrap this function somehow, that was the first attempt to do it.
2. Adds some rendring intent constants.
3. Adds a function which allows to create a data provider from a slice. This is highly unsafe, that's why I marked it with unsafe. And I'm not sure if it is the best way to do this. Perhaps the one can store something like `Option<slice>` in the data provider, but in this case the provider will get some lifetime parameter (and we have to update the foreign type definition). I'm not sure that having slice parameter and a lifetime would make it 100% safe though, because when we're passing a data provider ref to some FFI, they could theoretically retain a data provider (or the image which uses the data provider), expecting that the data inside the data provider lives long enough. Probably the only "really safe" way to manage the data provider data is the one which is currently available (via `Arc<Vec<u8>>`), but this limitation of having `Arc<Vec<u8>>` may be very ineffective in some sort of appliations, so for instance in my case I had to add the additional "constructor" to allow creation of unsafe data provider and I guarantee the safety in my code by some other means.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/219)
<!-- Reviewable:end -->
