### PR TITLE
core-foundation: Remove 2 transmutes in macros.

### DIFF
--- a/core-foundation/src/lib.rs
+++ b/core-foundation/src/lib.rs
@@ -53,16 +53,13 @@ macro_rules! impl_TCFType {
 
             #[inline]
             unsafe fn wrap_under_get_rule(reference: $ty_ref) -> Self {
-                use std::mem;
-                let reference = mem::transmute($crate::base::CFRetain(mem::transmute(reference)));
+                let reference = $crate::base::CFRetain(reference as *const ::std::os::raw::c_void) as $ty_ref;
                 $crate::base::TCFType::wrap_under_create_rule(reference)
             }
 
             #[inline]
             fn as_CFTypeRef(&self) -> $crate::base::CFTypeRef {
-                unsafe {
-                    ::std::mem::transmute(self.as_concrete_TypeRef())
-                }
+                self.as_concrete_TypeRef() as $crate::base::CFTypeRef
             }
 
             #[inline]


### PR DESCRIPTION
These transmutes were going from one type of pointer to another,
and so can be done as casts instead.

Doing so also means that one unsafe block can be removed.

This was found via clippy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/229)
<!-- Reviewable:end -->
