### PR TITLE
Add several new functions to Core Graphics and Core Text for `font-kit`'s use.

### DIFF
--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -4,7 +4,7 @@ name = "cocoa"
 description = "Bindings to Cocoa for OS X"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 
@@ -16,5 +16,5 @@ crate-type = ["rlib"]
 block = "0.1"
 bitflags = "1.0"
 libc = "0.2"
-core-graphics = { path = "../core-graphics", version = "0.16" }
+core-graphics = { path = "../core-graphics", version = "0.17" }
 objc = "0.2.3"

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics"
 description = "Bindings to Core Graphics for OS X"
 homepage = "https://github.com/servo/core-graphics-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 

--- a/core-graphics/src/color_space.rs
+++ b/core-graphics/src/color_space.rs
@@ -34,9 +34,18 @@ impl CGColorSpace {
         }
     }
 
+    #[inline]
     pub fn create_device_rgb() -> CGColorSpace {
         unsafe {
             let result = CGColorSpaceCreateDeviceRGB();
+            CGColorSpace::from_ptr(result)
+        }
+    }
+
+    #[inline]
+    pub fn create_device_gray() -> CGColorSpace {
+        unsafe {
+            let result = CGColorSpaceCreateDeviceGray();
             CGColorSpace::from_ptr(result)
         }
     }
@@ -53,6 +62,7 @@ extern {
     pub static kCGColorSpaceGenericGrayGamma2_2: CFStringRef;
 
     fn CGColorSpaceCreateDeviceRGB() -> ::sys::CGColorSpaceRef;
+    fn CGColorSpaceCreateDeviceGray() -> ::sys::CGColorSpaceRef;
     fn CGColorSpaceCreateWithName(name: CFStringRef) -> ::sys::CGColorSpaceRef;
     fn CGColorSpaceGetTypeID() -> CFTypeID;
 }

--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -78,6 +78,12 @@ impl CGContext {
         }
     }
 
+    pub fn flush(&self) {
+        unsafe {
+            CGContextFlush(self.as_ptr())
+        }
+    }
+
     pub fn width(&self) -> size_t {
         unsafe {
             CGBitmapContextGetWidth(self.as_ptr())
@@ -99,6 +105,12 @@ impl CGContext {
     pub fn set_rgb_fill_color(&self, red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
         unsafe {
             CGContextSetRGBFillColor(self.as_ptr(), red, green, blue, alpha)
+        }
+    }
+
+    pub fn set_gray_fill_color(&self, gray: CGFloat, alpha: CGFloat) {
+        unsafe {
+            CGContextSetGrayFillColor(self.as_ptr(), gray, alpha)
         }
     }
 
@@ -252,6 +264,7 @@ extern {
     fn CGBitmapContextGetBytesPerRow(context: ::sys::CGContextRef) -> size_t;
     fn CGBitmapContextCreateImage(context: ::sys::CGContextRef) -> ::sys::CGImageRef;
     fn CGContextGetTypeID() -> CFTypeID;
+    fn CGContextFlush(c: ::sys::CGContextRef);
     fn CGContextSetAllowsFontSmoothing(c: ::sys::CGContextRef, allowsFontSmoothing: bool);
     fn CGContextSetShouldSmoothFonts(c: ::sys::CGContextRef, shouldSmoothFonts: bool);
     fn CGContextSetFontSmoothingStyle(c: ::sys::CGContextRef, style: c_int);
@@ -271,6 +284,7 @@ extern {
                                 green: CGFloat,
                                 blue: CGFloat,
                                 alpha: CGFloat);
+    fn CGContextSetGrayFillColor(context: ::sys::CGContextRef, gray: CGFloat, alpha: CGFloat);
     fn CGContextFillRect(context: ::sys::CGContextRef,
                          rect: CGRect);
     fn CGContextDrawImage(c: ::sys::CGContextRef, rect: CGRect, image: ::sys::CGImageRef);

--- a/core-graphics/src/geometry.rs
+++ b/core-graphics/src/geometry.rs
@@ -140,6 +140,15 @@ impl CGRect {
     }
 }
 
+impl PartialEq for CGRect {
+    #[inline]
+    fn eq(&self, other: &CGRect) -> bool {
+        unsafe {
+            ffi::CGRectEqualToRect(*self, *other) != 0
+        }
+    }
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct CGAffineTransform {
@@ -184,6 +193,7 @@ mod ffi {
                                                       rect: *mut CGRect) -> boolean_t;
         pub fn CGRectIsEmpty(rect: CGRect) -> boolean_t;
         pub fn CGRectIntersectsRect(rect1: CGRect, rect2: CGRect) -> boolean_t;
+        pub fn CGRectEqualToRect(rect1: CGRect, rect2: CGRect) -> boolean_t;
 
         pub fn CGAffineTransformInvert(t: CGAffineTransform) -> CGAffineTransform;
 

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "11.0.0"
+version = "12.0.0"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"
@@ -16,4 +16,4 @@ mountainlion = []
 foreign-types = "0.3"
 libc = "0.2"
 core-foundation = { path = "../core-foundation", version = "0.6" }
-core-graphics = { path = "../core-graphics", version = "0.16" }
+core-graphics = { path = "../core-graphics", version = "0.17" }

--- a/core-text/src/font_descriptor.rs
+++ b/core-text/src/font_descriptor.rs
@@ -53,6 +53,7 @@ pub trait SymbolicTraitAccessors {
     fn is_expanded(&self) -> bool;
     fn is_condensed(&self) -> bool;
     fn is_monospace(&self) -> bool;
+    fn is_vertical(&self) -> bool;
 }
 
 impl SymbolicTraitAccessors for CTFontSymbolicTraits {
@@ -61,6 +62,7 @@ impl SymbolicTraitAccessors for CTFontSymbolicTraits {
     fn is_expanded(&self) -> bool { (*self & kCTFontExpandedTrait) != 0 }
     fn is_condensed(&self) -> bool { (*self & kCTFontCondensedTrait) != 0 }
     fn is_monospace(&self) -> bool { (*self & kCTFontMonoSpaceTrait) != 0 }
+    fn is_vertical(&self) -> bool { (*self & kCTFontVerticalTrait) != 0 }
 }
 
 pub type CTFontStylisticClass = u32;

--- a/core-text/src/font_manager.rs
+++ b/core-text/src/font_manager.rs
@@ -7,8 +7,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core_foundation::array::CFArrayRef;
+use core_foundation::array::{CFArray, CFArrayRef};
+use core_foundation::base::TCFType;
+use core_foundation::string::CFString;
 use core_foundation::url::CFURLRef;
+
+pub fn copy_available_font_family_names() -> CFArray<CFString> {
+    unsafe {
+        TCFType::wrap_under_create_rule(CTFontManagerCopyAvailableFontFamilyNames())
+    }
+}
 
 extern {
     /*


### PR DESCRIPTION
This bumps the major version of `core-text` since the previous version of
`get_glyphs_for_characters` was unsoundly marked safe before and is now marked unsafe.

r? @jrmuizel (or whoever)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/237)
<!-- Reviewable:end -->
