### PR TITLE
Make `CTFontCollection::get_descriptors()` return an Option.

### DIFF
--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "12.0.0"
+version = "13.0.0"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"

--- a/core-text/src/font_collection.rs
+++ b/core-text/src/font_collection.rs
@@ -33,11 +33,17 @@ impl_CFTypeDescription!(CTFontCollection);
 
 
 impl CTFontCollection {
-    pub fn get_descriptors(&self) -> CFArray<CTFontDescriptor> {
+    pub fn get_descriptors(&self) -> Option<CFArray<CTFontDescriptor>> {
         // surprise! this function follows the Get rule, despite being named *Create*.
         // So we have to addRef it to avoid CTFontCollection from double freeing it later.
         unsafe {
-            CFArray::wrap_under_get_rule(CTFontCollectionCreateMatchingFontDescriptors(self.0))
+            let font_descriptors = CTFontCollectionCreateMatchingFontDescriptors(self.0);
+            if font_descriptors.is_null() {
+                // This returns null if there are no matching font descriptors.
+                None
+            } else {
+                Some(CFArray::wrap_under_get_rule(font_descriptors))
+            }
         }
     }
 }


### PR DESCRIPTION
It returns null if there are no matching fonts.

r? @mbrubeck

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/240)
<!-- Reviewable:end -->
