### PR TITLE
Add the ability to supply custom data to `CGDataProvider`.

### DIFF
--- a/core-graphics/src/data_provider.rs
+++ b/core-graphics/src/data_provider.rs
@@ -72,6 +72,21 @@ impl CGDataProvider {
         let result = CGDataProviderCreateWithData(ptr::null_mut(), ptr, len, None);
         CGDataProvider::from_ptr(result)
     }
+
+    /// Creates a data provider from the given raw pointer, length, and destructor function.
+    ///
+    /// This is double-boxed because the Core Text API requires that the userdata be a single
+    /// pointer.
+    pub unsafe fn from_custom_data(custom_data: Box<Box<CustomData>>) -> Self {
+        let (ptr, len) = (custom_data.ptr() as *const c_void, custom_data.len());
+        let userdata = mem::transmute::<Box<Box<CustomData>>, &mut c_void>(custom_data);
+        let data_provider = CGDataProviderCreateWithData(userdata, ptr, len, Some(release));
+        return CGDataProvider::from_ptr(data_provider);
+
+        unsafe extern "C" fn release(info: *mut c_void, _: *const c_void, _: size_t) {
+            drop(mem::transmute::<*mut c_void, Box<Box<CustomData>>>(info))
+        }
+    }
 }
 
 impl CGDataProviderRef {
@@ -79,6 +94,16 @@ impl CGDataProviderRef {
     pub fn copy_data(&self) -> CFData {
         unsafe { CFData::wrap_under_create_rule(CGDataProviderCopyData(self.as_ptr())) }
     }
+}
+
+/// Encapsulates custom data that can be wrapped.
+pub trait CustomData {
+    /// Returns a pointer to the start of the custom data. This pointer *must not change* during
+    /// the lifespan of this CustomData.
+    unsafe fn ptr(&self) -> *const u8;
+    /// Returns the length of this custom data. This value must not change during the lifespan of
+    /// this CustomData.
+    unsafe fn len(&self) -> usize;
 }
 
 #[link(name = "CoreGraphics", kind = "framework")]


### PR DESCRIPTION
This is useful for opening memory-mapped files.

r? @mbrubeck 