### PR TITLE
Add ItemMutRef and FromMutVoid

### DIFF
--- a/core-foundation/src/base.rs
+++ b/core-foundation/src/base.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::mem;
 use std::mem::ManuallyDrop;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::os::raw::c_void;
 
 pub use core_foundation_sys::base::*;
@@ -277,6 +277,58 @@ impl<'a, T: fmt::Debug> fmt::Debug for ItemRef<'a, T> {
 impl<'a, T: PartialEq> PartialEq for ItemRef<'a, T> {
     fn eq(&self, other: &Self) -> bool {
         self.0.eq(&other.0)
+    }
+}
+
+/// A reference to a mutable element inside a container
+pub struct ItemMutRef<'a, T: 'a>(ManuallyDrop<T>, PhantomData<&'a T>);
+
+impl<'a, T> Deref for ItemMutRef<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<'a, T> DerefMut for ItemMutRef<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<'a, T: fmt::Debug> fmt::Debug for ItemMutRef<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.0.fmt(f)
+    }
+}
+
+impl<'a, T: PartialEq> PartialEq for ItemMutRef<'a, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+/// A trait describing how to convert from the stored *mut c_void to the desired T
+pub unsafe trait FromMutVoid {
+    unsafe fn from_mut_void<'a>(x: *mut c_void) -> ItemMutRef<'a, Self> where Self: std::marker::Sized;
+}
+
+unsafe impl FromMutVoid for u32 {
+    unsafe fn from_mut_void<'a>(x: *mut c_void) -> ItemMutRef<'a, Self> {
+        ItemMutRef(ManuallyDrop::new(x as u32), PhantomData)
+    }
+}
+
+unsafe impl FromMutVoid for *const c_void {
+    unsafe fn from_mut_void<'a>(x: *mut c_void) -> ItemMutRef<'a, Self> {
+        ItemMutRef(ManuallyDrop::new(x), PhantomData)
+    }
+}
+
+unsafe impl<T: TCFType> FromMutVoid for T {
+    unsafe fn from_mut_void<'a>(x: *mut c_void) -> ItemMutRef<'a, Self> {
+        ItemMutRef(ManuallyDrop::new(TCFType::wrap_under_create_rule(T::Ref::from_void_ptr(x))), PhantomData)
     }
 }
 


### PR DESCRIPTION
Used (in my project) to grab a `&mut CFMutableAttributedString` from an objc-c ivar to use methods introduced in #223.

```rust
CFMutableAttributedString::from_mut_void(ptr)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/244)
<!-- Reviewable:end -->
