### PR TITLE
Added basic NSToolbar

### DIFF
--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -969,7 +969,11 @@ pub trait NSWindow: Sized {
     // skipped: becomeMainWindow (should not be invoked directly, according to Apple's documentation)
     // skipped: resignMainWindow (should not be invoked directly, according to Apple's documentation)
 
-    // TODO: Managing Toolbars
+    // Managing Toolbars
+    unsafe fn toolbar(self) -> id /* NSToolbar */;
+    unsafe fn setToolbar_(self, toolbar: id /* NSToolbar */);
+    unsafe fn runToolbarCustomizationPalette(self, sender: id);
+
     // TODO: Managing Attached Windows
     // TODO: Managing Window Buffers
     // TODO: Managing Default Buttons
@@ -1459,7 +1463,20 @@ impl NSWindow for id {
         msg_send![self, makeMainWindow]
     }
 
-    // TODO: Managing Toolbars
+    // Managing Toolbars
+
+    unsafe fn toolbar(self) -> id /* NSToolbar */ {
+        msg_send![self, toolbar]
+    }
+
+    unsafe fn setToolbar_(self, toolbar: id /* NSToolbar */) {
+        msg_send![self, setToolbar:toolbar]
+    }
+
+    unsafe fn runToolbarCustomizationPalette(self, sender: id) {
+        msg_send![self, runToolbarCustomizationPalette:sender]
+    }
+
     // TODO: Managing Attached Windows
     // TODO: Managing Window Buffers
     // TODO: Managing Default Buttons
@@ -3778,6 +3795,36 @@ pub trait NSColor: Sized {
 impl NSColor for id {
     unsafe fn clearColor(_: Self) -> id {
         msg_send![class!(NSColor), clearColor]
+    }
+}
+
+pub trait NSToolbar: Sized {
+    unsafe fn alloc(_: Self) -> id {
+        msg_send![class!(NSToolbar), alloc]
+    }
+
+    unsafe fn init_(self) -> id /* NSToolbar */;
+    unsafe fn initWithIdentifier_(self, identifier: id) -> id /* NSToolbar */;
+
+    unsafe fn showsBaselineSeparator(self) -> BOOL;
+    unsafe fn setShowsBaselineSeparator_(self, value: BOOL);
+}
+
+impl NSToolbar for id {
+    unsafe fn init_(self) -> id /* NSToolbar */ {
+        msg_send![self, init]
+    }
+
+    unsafe fn initWithIdentifier_(self, identifier: id) -> id /* NSToolbar */ {
+        msg_send![self, initWithIdentifier:identifier]
+    }
+
+    unsafe fn showsBaselineSeparator(self) -> BOOL {
+        msg_send![self, showsBaselineSeparator]
+    }
+
+    unsafe fn setShowsBaselineSeparator_(self, value: BOOL) {
+        msg_send![self, setShowsBaselineSeparator:value]
     }
 }
 


### PR DESCRIPTION
-> Basic NSToolbar implementation (init, separator, adding to NSWindow)
I needed this for a project, and i wanted to share it.

Empty toolbar example :
![Example](https://user-images.githubusercontent.com/8712146/44870891-954eb980-ac91-11e8-97f5-384ad71baf7a.png)

Even empty, combined with a fullsized content view and a transparent title bar, this can be very useful (used for example by Firefox, and Atom).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/252)
<!-- Reviewable:end -->
