### PR TITLE
Cgdisplaymode extensions

### DIFF
--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -412,9 +412,9 @@ impl CGDisplay {
 }
 
 impl CGDisplayMode {
-    pub fn all_display_modes(display_id: CGDirectDisplayID) -> Option<Vec<CGDisplayMode>> {
+    pub fn all_display_modes(display_id: CGDirectDisplayID, options: CFDictionaryRef) -> Option<Vec<CGDisplayMode>> {
         let array_opt: Option<CFArray> = unsafe {
-            let array_ref = CGDisplayCopyAllDisplayModes(display_id, ptr::null());
+            let array_ref = CGDisplayCopyAllDisplayModes(display_id, options);
             if array_ref != ptr::null() {
                 Some(CFArray::wrap_under_create_rule(array_ref))
             } else {
@@ -496,6 +496,8 @@ impl CGDisplayMode {
 extern "C" {
     pub static CGRectNull: CGRect;
     pub static CGRectInfinite: CGRect;
+
+    pub static kCGDisplayShowDuplicateLowResolutionModes: CFStringRef;
 
     pub fn CGDisplayModeRelease(mode: ::sys::CGDisplayModeRef);
 

--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -552,25 +552,25 @@ impl CGDisplayMode {
     /// Returns the number of bits per pixel of the specified display mode.
     pub fn bit_depth(&self) -> usize {
         let pixel_encoding = self.pixel_encoding().to_string();
-        let mut depth = 0;
         // my numerical representation for kIO16BitFloatPixels and kIO32bitFloatPixels
         // are made up and possibly non-sensical
         if pixel_encoding.eq_ignore_ascii_case(kIO32BitFloatPixels) {
-            depth = 96;
+            96
         } else if pixel_encoding.eq_ignore_ascii_case(kIO64BitDirectPixels) {
-            depth = 64;
+            64
         } else if pixel_encoding.eq_ignore_ascii_case(kIO16BitFloatPixels) {
-            depth = 48;
+            48
         } else if pixel_encoding.eq_ignore_ascii_case(IO32BitDirectPixels) {
-            depth = 32;
+            32
         } else if pixel_encoding.eq_ignore_ascii_case(kIO30BitDirectPixels) {
-            depth = 30;
+            30
         } else if pixel_encoding.eq_ignore_ascii_case(IO16BitDirectPixels) {
-            depth = 16;
+            16
         } else if pixel_encoding.eq_ignore_ascii_case(IO8BitIndexedPixels) {
-            depth = 8;
+            8
+        }else{
+            0
         }
-        return depth as usize;
     }
 }
 
@@ -618,14 +618,14 @@ extern "C" {
     pub fn CGDisplayBounds(display: CGDirectDisplayID) -> CGRect;
     pub fn CGDisplayCreateImage(display: CGDirectDisplayID) -> ::sys::CGImageRef;
 
-    pub fn CGBeginDisplayConfiguration(config: *const *mut libc::c_void) -> CGError;
+    pub fn CGBeginDisplayConfiguration(config: *const CGDisplayConfigRef) -> CGError;
     pub fn CGCancelDisplayConfiguration(config: CGDisplayConfigRef) -> CGError;
     pub fn CGCompleteDisplayConfiguration(
-        config: *const libc::c_void,
+        config: CGDisplayConfigRef,
         option: CGConfigureOption,
     ) -> CGError;
     pub fn CGConfigureDisplayWithDisplayMode(
-        config: *const libc::c_void,
+        config: CGDisplayConfigRef,
         display: CGDirectDisplayID,
         mode: ::sys::CGDisplayModeRef,
         options: CFDictionaryRef,
@@ -644,7 +644,6 @@ extern "C" {
         display: CGDirectDisplayID,
         options: CFDictionaryRef,
     ) -> CFArrayRef;
-
 
     // mouse stuff
     pub fn CGDisplayHideCursor(display: CGDirectDisplayID) -> CGError;

--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -45,7 +45,9 @@ pub const kCGWindowImageOnlyShadows: CGWindowImageOption = 1 << 2;
 pub const kCGWindowImageBestResolution: CGWindowImageOption = 1 << 3;
 pub const kCGWindowImageNominalResolution: CGWindowImageOption = 1 << 4;
 
-pub const kDisplayModeSafetyFlags: u32             = 0x00000007;
+pub const kDisplayModeValidFlag: u32               = 0x00000001;
+pub const kDisplayModeSafeFlag: u32                = 0x00000002;
+pub const kDisplayModeDefaultFlag: u32             = 0x00000004;
 pub const kDisplayModeAlwaysShowFlag: u32          = 0x00000008;
 pub const kDisplayModeNeverShowFlag: u32           = 0x00000080;
 pub const kDisplayModeNotResizeFlag: u32           = 0x00000010;
@@ -63,9 +65,8 @@ pub const kDisplayModeAcceleratorBackedFlag: u32   = 0x00400000;
 pub const kDisplayModeValidForHiResFlag: u32       = 0x00800000;
 pub const kDisplayModeValidForAirPlayFlag: u32     = 0x01000000;
 pub const kDisplayModeNativeFlag: u32              = 0x02000000;
-pub const kDisplayModeValidFlag: u32               = 0x00000001;
-pub const kDisplayModeSafeFlag: u32                = 0x00000002;
-pub const kDisplayModeDefaultFlag: u32             = 0x00000004;
+
+pub const kDisplayModeSafetyFlags: u32             = 0x00000007;
 
 pub const IO1BitIndexedPixels: &str =     "P";
 pub const IO2BitIndexedPixels: &str =     "PP";
@@ -507,21 +508,25 @@ impl CGDisplayMode {
         }
     }
 
+    /// Returns the height of the specified display mode.
     #[inline]
     pub fn height(&self) -> u64 {
         unsafe { CGDisplayModeGetHeight(self.as_ptr()) as u64 }
     }
 
+    /// Returns the width of the specified display mode.
     #[inline]
     pub fn width(&self) -> u64 {
         unsafe { CGDisplayModeGetWidth(self.as_ptr()) as u64 }
     }
 
+    /// Returns the pixel height of the specified display mode.
     #[inline]
     pub fn pixel_height(&self) -> u64 {
         unsafe { CGDisplayModeGetPixelHeight(self.as_ptr()) as u64 }
     }
 
+    /// Returns the pixel width of the specified display mode.
     #[inline]
     pub fn pixel_width(&self) -> u64 {
         unsafe { CGDisplayModeGetPixelWidth(self.as_ptr()) as u64 }
@@ -532,16 +537,19 @@ impl CGDisplayMode {
         unsafe { CGDisplayModeGetRefreshRate(self.as_ptr()) }
     }
 
+    /// Returns the I/O Kit flags of the specified display mode.
     #[inline]
     pub fn io_flags(&self) -> u32 {
         unsafe { CGDisplayModeGetIOFlags(self.as_ptr()) as u32 }
     }
 
+    /// Returns the pixel encoding of the specified display mode.
     #[inline]
     pub fn pixel_encoding(&self) -> CFString {
         unsafe { CFString::wrap_under_create_rule(CGDisplayModeCopyPixelEncoding(self.as_ptr())) }
     }
 
+    /// Returns the number of bits per pixel of the specified display mode.
     pub fn bit_depth(&self) -> usize {
         let pixel_encoding = self.pixel_encoding().to_string();
         let mut depth = 0;


### PR DESCRIPTION
I am writing a tool to change resolution on MacOS. For this I needed, more support for CGDisplayMode methods. I also need support for CGConfigureDisplayWithDisplayMode().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/253)
<!-- Reviewable:end -->
