### PR TITLE
Converting between dictionary types

### DIFF
--- a/core-foundation/src/dictionary.rs
+++ b/core-foundation/src/dictionary.rs
@@ -177,10 +177,10 @@ impl<K, V> CFMutableDictionary<K, V> {
         unsafe { CFMutableDictionary::wrap_under_create_rule(reference) }
     }
 
-    /// Borrow self as an immutable dictionary.
+    /// Returns a `CFDictionary` pointing to the same underlying dictionary as this mutable one.
     #[inline]
-    pub fn as_immutable(&self) -> ItemRef<CFDictionary<K, V>> {
-        unsafe { CFDictionary::from_void(self.0 as _) }
+    pub fn to_immutable(&self) -> CFDictionary<K, V> {
+        unsafe { CFDictionary::wrap_under_get_rule(self.0) }
     }
 
     // Immutable interface
@@ -385,9 +385,9 @@ pub mod test {
         mut_dict.add(&CFString::from_static_string("Bar"), &CFBoolean::false_value());
         assert_eq!(mut_dict.retain_count(), 1);
 
-        let dict = mut_dict.as_immutable();
-        assert_eq!(mut_dict.retain_count(), 1);
-        assert_eq!(dict.retain_count(), 1);
+        let dict = mut_dict.to_immutable();
+        assert_eq!(mut_dict.retain_count(), 2);
+        assert_eq!(dict.retain_count(), 2);
         assert_eq!(*dict.get(&CFString::from_static_string("Bar")), CFBoolean::false_value());
 
         mem::drop(dict);

--- a/core-foundation/src/dictionary.rs
+++ b/core-foundation/src/dictionary.rs
@@ -19,6 +19,7 @@ use std::marker::PhantomData;
 
 use base::{ItemRef, FromVoid, ToVoid};
 use base::{CFIndexConvertible, TCFType};
+use ConcreteCFType;
 
 // consume the type parameters with PhantomDatas
 pub struct CFDictionary<K = *const c_void, V = *const c_void>(CFDictionaryRef, PhantomData<K>, PhantomData<V>);
@@ -31,6 +32,8 @@ impl<K, V> Drop for CFDictionary<K, V> {
 
 impl_TCFType!(CFDictionary<K, V>, CFDictionaryRef, CFDictionaryGetTypeID);
 impl_CFTypeDescription!(CFDictionary);
+
+unsafe impl ConcreteCFType for CFDictionary<*const c_void, *const c_void> {}
 
 impl<K, V> CFDictionary<K, V> {
     pub fn from_CFType_pairs(pairs: &[(K, V)]) -> CFDictionary<K, V> where K: TCFType, V: TCFType {

--- a/core-foundation/src/dictionary.rs
+++ b/core-foundation/src/dictionary.rs
@@ -177,6 +177,12 @@ impl<K, V> CFMutableDictionary<K, V> {
         unsafe { CFMutableDictionary::wrap_under_create_rule(reference) }
     }
 
+    /// Borrow self as an immutable dictionary.
+    #[inline]
+    pub fn as_immutable(&self) -> ItemRef<CFDictionary<K, V>> {
+        unsafe { CFDictionary::from_void(self.0 as _) }
+    }
+
     // Immutable interface
 
     #[inline]
@@ -371,5 +377,20 @@ pub mod test {
         mut_dict.add(&CFString::from_static_string("Bar"), &CFBoolean::false_value());
         assert_eq!(dict.len(), 1);
         assert_eq!(mut_dict.len(), 2);
+    }
+
+    #[test]
+    fn mutable_dictionary_as_immutable() {
+        let mut mut_dict: CFMutableDictionary<CFString, CFBoolean> = CFMutableDictionary::new();
+        mut_dict.add(&CFString::from_static_string("Bar"), &CFBoolean::false_value());
+        assert_eq!(mut_dict.retain_count(), 1);
+
+        let dict = mut_dict.as_immutable();
+        assert_eq!(mut_dict.retain_count(), 1);
+        assert_eq!(dict.retain_count(), 1);
+        assert_eq!(*dict.get(&CFString::from_static_string("Bar")), CFBoolean::false_value());
+
+        mem::drop(dict);
+        assert_eq!(mut_dict.retain_count(), 1);
     }
 }

--- a/core-foundation/src/dictionary.rs
+++ b/core-foundation/src/dictionary.rs
@@ -54,6 +54,20 @@ impl<K, V> CFDictionary<K, V> {
     }
 
     #[inline]
+    pub fn to_untyped(&self) -> CFDictionary {
+        unsafe { CFDictionary::wrap_under_get_rule(self.0) }
+    }
+
+    /// Returns the same dictionary, but with the types reset to void pointers.
+    /// Equal to `to_untyped`, but is faster since it does not increment the retain count.
+    #[inline]
+    pub fn into_untyped(self) -> CFDictionary {
+        let reference = self.0;
+        mem::forget(self);
+        unsafe { CFDictionary::wrap_under_create_rule(reference) }
+    }
+
+    #[inline]
     pub fn len(&self) -> usize {
         unsafe {
             CFDictionaryGetCount(self.0) as usize
@@ -147,6 +161,20 @@ impl<K, V> CFMutableDictionary<K, V> {
             result.add(key, value);
         }
         result
+    }
+
+    #[inline]
+    pub fn to_untyped(&self) -> CFMutableDictionary {
+        unsafe { CFMutableDictionary::wrap_under_get_rule(self.0) }
+    }
+
+    /// Returns the same dictionary, but with the types reset to void pointers.
+    /// Equal to `to_untyped`, but is faster since it does not increment the retain count.
+    #[inline]
+    pub fn into_untyped(self) -> CFMutableDictionary {
+        let reference = self.0;
+        mem::forget(self);
+        unsafe { CFMutableDictionary::wrap_under_create_rule(reference) }
     }
 
     // Immutable interface

--- a/core-foundation/src/lib.rs
+++ b/core-foundation/src/lib.rs
@@ -97,21 +97,21 @@ macro_rules! impl_TCFType {
 
         unsafe impl<'a> $crate::base::ToVoid<$ty> for &'a $ty {
             fn to_void(&self) -> *const ::std::os::raw::c_void {
-            use $crate::base::TCFTypeRef;
+                use $crate::base::TCFTypeRef;
                 self.as_concrete_TypeRef().as_void_ptr()
             }
         }
 
         unsafe impl $crate::base::ToVoid<$ty> for $ty {
             fn to_void(&self) -> *const ::std::os::raw::c_void {
-            use $crate::base::TCFTypeRef;
+                use $crate::base::TCFTypeRef;
                 self.as_concrete_TypeRef().as_void_ptr()
             }
         }
 
         unsafe impl $crate::base::ToVoid<$ty> for $ty_ref {
             fn to_void(&self) -> *const ::std::os::raw::c_void {
-            use $crate::base::TCFTypeRef;
+                use $crate::base::TCFTypeRef;
                 self.as_void_ptr()
             }
         }


### PR DESCRIPTION
I'm trying to use the `CFDictionary` and `CFMutableDictionary` types more extensively. But run into problems. They are not very compatible with each other. This crate for example does not expose any clean way of using `CFDictionaryCreateMutableCopy` to create a `CFMutableDictionary` from any `CFDictionary`. I added a `From` implementation for this.

It was not possible to, in some safe/simple way, cast a `CFDictionary<K, V>` into the untyped `CFDictionary<*const c_void, *const c_void>` something I added `to_untyped` to be able to do.

When it comes to downcasting, it was not possible to downcast a `CFType` into a dictionary, since they don't implement `ConcreteCFType`. Something they probably should, for the case where the keys and values are just void pointers. `CFArray` does exactly this.

Lastly, what I needed the most was to be able to convert a `CFMutableDictionary` into a `CFDictionary`. This allows me to borrow an immutable `CFDictionary` via the `ItemRef` type basically. It's possible to work around this and actually have owned instances of a `CFDictionary` and a `CFMutableDictionary` pointing to the same actual dictionary by doing this:
```rust
let mut_dict = CFMutableDictionary::new();
let mut_dict2 = mut_dict.clone();
let dict = mut_dict.as_immutable();
// Here one can mutate the dict via `mut_dict2` while `dict` is still in scope/alive.
```
But since we already allow cloning a `CFMutableDictionary` to have two mutable references to the same dictionary I guess someone decided this should be viewed as safe. Both `CFDictionary` and `CFMutableDictionary` does not implement `Send` so we should not end up in any actual thread inconsistencies here.

If the above is indeed considered safe, I could get rid of the `ItemRef` juggling and just make it `fn as_immutable(&self) -> CFDictionary` directly maybe? Would simplify usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/265)
<!-- Reviewable:end -->
