### PR TITLE
Add constants for new AppKit versions through El Capitan.

### DIFF
--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -4,7 +4,7 @@ name = "cocoa"
 description = "Bindings to Cocoa for OS X"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.18.2"
+version = "0.18.3"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 

--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -118,6 +118,23 @@ pub const NSAppKitVersionNumber10_7_3: f64 = 1138.32;
 pub const NSAppKitVersionNumber10_7_4: f64 = 1138.47;
 pub const NSAppKitVersionNumber10_8: f64 = 1187.0;
 pub const NSAppKitVersionNumber10_9: f64 = 1265.0;
+pub const NSAppKitVersionNumber10_10: f64 = 1343.0;
+pub const NSAppKitVersionNumber10_10_2: f64 = 1344.0;
+pub const NSAppKitVersionNumber10_10_3: f64 = 1347.0;
+pub const NSAppKitVersionNumber10_10_4: f64 = 1348.0;
+pub const NSAppKitVersionNumber10_10_5: f64 = 1348.0;
+pub const NSAppKitVersionNumber10_10_Max: f64 = 1349.0;
+pub const NSAppKitVersionNumber10_11: f64 = 1404.0;
+pub const NSAppKitVersionNumber10_11_1: f64 = 1404.13;
+pub const NSAppKitVersionNumber10_11_2: f64 = 1404.34;
+pub const NSAppKitVersionNumber10_11_3: f64 = 1404.34;
+pub const NSAppKitVersionNumber10_12: f64 = 1504.0;
+pub const NSAppKitVersionNumber10_12_1: f64 = 1504.60;
+pub const NSAppKitVersionNumber10_12_2: f64 = 1504.76;
+pub const NSAppKitVersionNumber10_13: f64 = 1561.0;
+pub const NSAppKitVersionNumber10_13_1: f64 = 1561.1;
+pub const NSAppKitVersionNumber10_13_2: f64 = 1561.2;
+pub const NSAppKitVersionNumber10_13_4: f64 = 1561.4;
 
 pub unsafe fn NSApp() -> id {
     msg_send![class!(NSApplication), sharedApplication]


### PR DESCRIPTION
I need this to fix `winit`, because Mojave has some new behavior around
layer-backed views and version sniffing is the easiest way to detect when I need to handle it.

This also bumps the version to 0.18.3.

r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/266)
<!-- Reviewable:end -->
