### PR TITLE
chore: add simple NSControl class

### DIFF
--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -2866,6 +2866,28 @@ impl NSScreen for id {
     }
 }
 
+// https://developer.apple.com/documentation/appkit/nscontrol?language=objc
+pub trait NSControl: Sized {
+    unsafe fn alloc(_: Self) -> id {
+        msg_send![class!(NSControl), alloc]
+    }
+    unsafe fn initWithFrame_(self, frameRect: NSRect) -> id;
+    unsafe fn isEnabled_(self) -> BOOL;
+    unsafe fn setEnabled_(self, enabled: BOOL) -> BOOL;
+}
+
+impl NSControl for id {
+    unsafe fn initWithFrame_(self, frameRect: NSRect) -> id {
+        msg_send![self, initWithFrame:frameRect]
+    }
+    unsafe fn isEnabled_(self) -> BOOL {
+        msg_send![self, isEnabled]
+    }
+    unsafe fn setEnabled_(self, enabled: BOOL) -> BOOL {
+        msg_send![self, setEnabled:enabled]
+    }
+}
+
 pub trait NSButton: Sized {
      unsafe fn setImage_(self, img: id /* (NSImage *) */);
      unsafe fn setBezelStyle_(self, style: NSBezelStyle);


### PR DESCRIPTION
I needed to use `[button setEnabled]` for an `NSButton`, so I added some of `NSControl`'s basic functionality.


Example usage:

```rust
use cocoa::foundation::NSRect;
use cocoa::appkit::{NSButton, NSControl, NSView};

// Parent view
let view = NSView::alloc(nil)
    .initWithFrame_(NSRect::new(NSPoint::new(0., 0.), NSSize::new(200., 200.)));

// Add button to view
let button = NSButton::alloc(nil)
    .initWithFrame_(NSRect::new(NSPoint::new(20., 20.), NSSize::new(150., 50.)));
NSView::addSubview_(view, button);

// Prints "1" (button enabled)
println!("{:?}", NSControl::isEnabled_(button));

// Disable the button
NSControl::setEnabled_(button, NO);

// Prints "0" (button disabled)
println!("{:?}", NSControl::isEnabled_(button));
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/272)
<!-- Reviewable:end -->
