### PR TITLE
Use libc c_char instead of i8 for libc strlen() call

### DIFF
--- a/core-foundation/src/url.rs
+++ b/core-foundation/src/url.rs
@@ -20,7 +20,7 @@ use std::ptr;
 use std::path::{Path, PathBuf};
 use std::mem;
 
-use libc::{strlen, PATH_MAX};
+use libc::{c_char, strlen, PATH_MAX};
 
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
@@ -83,7 +83,7 @@ impl CFURL {
             if result == false as Boolean {
                 return None;
             }
-            let len = strlen(buf.as_ptr() as *const i8);
+            let len = strlen(buf.as_ptr() as *const c_char);
             let path = OsStr::from_bytes(&buf[0..len]);
             Some(PathBuf::from(path))
         }


### PR DESCRIPTION
This patch allows build errors like https://buildd.debian.org/status/fetch.php?pkg=rust-core-foundation&arch=arm64&ver=0.6.1-1&stamp=1533301991&raw=0 to go through on architectures that use u8 as c_char.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/279)
<!-- Reviewable:end -->
