### PR TITLE
Add CGImageDestination

### DIFF
--- a/core-graphics/src/sys.rs
+++ b/core-graphics/src/sys.rs
@@ -3,6 +3,9 @@ use std::os::raw::c_void;
 pub enum CGImage {}
 pub type CGImageRef = *mut CGImage;
 
+pub enum CGImageDestination {}
+pub type CGImageDestinationRef = *mut CGImageDestination;
+
 #[repr(C)]
 pub struct __CGColor(c_void);
 


### PR DESCRIPTION
Hey there, this is an initial work to make CGImages saveable and it was tested with the code below.
I didn't see much tests around, should I add them with my PR?
I also put some TODOs on the code because those were questions that I could not answer.
Let me know if this is useful and I will keep with the work.

```rust
use core_graphics::display::{
    kCGNullWindowID, kCGWindowImageDefault, kCGWindowListOptionAll, CGDisplay, CGPoint, CGRect,
    CGSize,
};

use core_graphics::image::CGImageDestination;

use core_foundation::string::CFString;
use core_foundation::url::CFURL;

fn main() {
    let position = CGPoint::new(0.0, 0.0);
    let size = CGSize::new(1000.0, 1000.0);
    let bounds = CGRect::new(&position, &size);

    let screenshot = CGDisplay::screenshot(
        bounds,
        kCGWindowListOptionAll,
        kCGNullWindowID,
        kCGWindowImageDefault,
    )
    .unwrap();
    let destination = CGImageDestination::with_url(
        CFURL::from_path("screenshot.bmp", false).unwrap(),
        CFString::new("com.microsoft.bmp"),
        1,
        None,
    );
    destination.add_image(screenshot, None);
    assert!(destination.finalize());
}
```