### PR TITLE
Increase minor version for core-text to 13.2.0.

### DIFF
--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "13.1.1"
+version = "13.2.0"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This includes changes from #293 and #269 which only add new public APIs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/294)
<!-- Reviewable:end -->
