### PR TITLE
core-graphics: CGBeginDisplayConfiguration takes *mut.

### DIFF
--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -618,7 +618,7 @@ extern "C" {
     pub fn CGDisplayBounds(display: CGDirectDisplayID) -> CGRect;
     pub fn CGDisplayCreateImage(display: CGDirectDisplayID) -> ::sys::CGImageRef;
 
-    pub fn CGBeginDisplayConfiguration(config: *const CGDisplayConfigRef) -> CGError;
+    pub fn CGBeginDisplayConfiguration(config: *mut CGDisplayConfigRef) -> CGError;
     pub fn CGCancelDisplayConfiguration(config: CGDisplayConfigRef) -> CGError;
     pub fn CGCompleteDisplayConfiguration(
         config: CGDisplayConfigRef,


### PR DESCRIPTION
This was incorrectly saying it wanted a *const pointer, but the
value is modified and in the C headers, it is not const.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/305)
<!-- Reviewable:end -->
