### PR TITLE
add barebones NSSpellChecker bindings

### DIFF
--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -12,7 +12,7 @@
 use base::{id, BOOL, SEL};
 use block::Block;
 use foundation::{NSInteger, NSUInteger, NSTimeInterval,
-                 NSPoint, NSSize, NSRect, NSRectEdge};
+                 NSPoint, NSSize, NSRect, NSRange, NSRectEdge};
 use libc;
 
 pub use core_graphics::base::CGFloat;
@@ -4014,6 +4014,66 @@ impl NSToolbar for id {
 
     unsafe fn setShowsBaselineSeparator_(self, value: BOOL) {
         msg_send![self, setShowsBaselineSeparator:value]
+    }
+}
+
+pub trait NSSpellChecker : Sized {
+    unsafe fn sharedSpellChecker(_: Self) -> id;
+    unsafe fn checkSpellingOfString_startingAt(self,
+                                               stringToCheck: id,
+                                               startingOffset: NSInteger) -> NSRange;
+    unsafe fn checkSpellingOfString_startingAt_language_wrap_inSpellDocumentWithTag_wordCount(
+        self,
+        stringToCheck: id,
+        startingOffset: NSInteger,
+        language: id,
+        wrapFlag: BOOL,
+        tag: NSInteger) -> (NSRange, NSInteger);
+    unsafe fn uniqueSpellDocumentTag(_: Self) -> NSInteger;
+    unsafe fn closeSpellDocumentWithTag(self, tag: NSInteger);
+    unsafe fn ignoreWord_inSpellDocumentWithTag(self, wordToIgnore: id, tag: NSInteger);
+}
+
+impl NSSpellChecker for id {
+    unsafe fn sharedSpellChecker(_: Self) -> id {
+        msg_send![class!(NSSpellChecker), sharedSpellChecker]
+    }
+
+    unsafe fn checkSpellingOfString_startingAt(self,
+                                               stringToCheck: id,
+                                               startingOffset: NSInteger) -> NSRange {
+        msg_send![self, checkSpellingOfString:stringToCheck startingAt:startingOffset]
+    }
+
+    unsafe fn checkSpellingOfString_startingAt_language_wrap_inSpellDocumentWithTag_wordCount(
+        self,
+        stringToCheck: id,
+        startingOffset: NSInteger,
+        language: id,
+        wrapFlag: BOOL,
+        tag: NSInteger) -> (NSRange, NSInteger) {
+        let mut wordCount = 0;
+        let range = msg_send![self,
+            checkSpellingOfString:stringToCheck
+            startingAt:startingOffset
+            language:language
+            wrap:wrapFlag
+            inSpellDocumentWithTag:tag
+            wordCount:&mut wordCount
+        ];
+        (range, wordCount)
+    }
+
+    unsafe fn uniqueSpellDocumentTag(_: Self) -> NSInteger {
+        msg_send![class!(NSSpellChecker), uniqueSpellDocumentTag]
+    }
+
+    unsafe fn closeSpellDocumentWithTag(self, tag: NSInteger) {
+        msg_send![self, closeSpellDocumentWithTag:tag]
+    }
+
+    unsafe fn ignoreWord_inSpellDocumentWithTag(self, wordToIgnore: id, tag: NSInteger) {
+        msg_send![self, ignoreWord:wordToIgnore inSpellDocumentWithTag:tag]
     }
 }
 

--- a/cocoa/src/foundation.rs
+++ b/cocoa/src/foundation.rs
@@ -163,6 +163,7 @@ mod macos {
 pub use self::macos::*;
 
 #[repr(C)]
+#[derive(Copy, Clone)]
 pub struct NSRange {
     pub location: NSUInteger,
     pub length: NSUInteger,
@@ -558,6 +559,7 @@ pub trait NSString: Sized {
     unsafe fn UTF8String(self) -> *const libc::c_char;
     unsafe fn len(self) -> usize;
     unsafe fn isEqualToString(self, &str) -> bool;
+    unsafe fn substringWithRange(self, range: NSRange) -> id;
 }
 
 impl NSString for id {
@@ -584,6 +586,10 @@ impl NSString for id {
 
     unsafe fn UTF8String(self) -> *const libc::c_char {
         msg_send![self, UTF8String]
+    }
+
+    unsafe fn substringWithRange(self, range: NSRange) -> id {
+        msg_send![self, substringWithRange:range]
     }
 }
 


### PR DESCRIPTION
Also adds `substringWithRange` to `NSString`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/312)
<!-- Reviewable:end -->
