### PR TITLE
Expose more APIs on CGContext

### DIFF
--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -505,6 +505,24 @@ impl CGContextRef {
             CGContextScaleCTM(self.as_ptr(), sx, sy);
         }
     }
+
+    pub fn rotate(&self, angle: CGFloat) {
+        unsafe {
+            CGContextRotateCTM(self.as_ptr(), angle);
+        }
+    }
+
+    pub fn get_ctm(&self) -> CGAffineTransform {
+        unsafe {
+            CGContextGetCTM(self.as_ptr())
+        }
+    }
+
+    pub fn concat_ctm(&self, transform: CGAffineTransform) {
+        unsafe {
+            CGContextConcatCTM(self.as_ptr(), transform)
+        }
+    }
 }
 
 #[test]
@@ -643,5 +661,8 @@ extern {
     fn CGContextRestoreGState(c: ::sys::CGContextRef);
     fn CGContextTranslateCTM(c: ::sys::CGContextRef, tx: CGFloat, ty: CGFloat);
     fn CGContextScaleCTM(c: ::sys::CGContextRef, sx: CGFloat, sy: CGFloat);
+    fn CGContextRotateCTM(c: ::sys::CGContextRef, angle: CGFloat);
+    fn CGContextGetCTM(c: ::sys::CGContextRef) -> CGAffineTransform;
+    fn CGContextConcatCTM(c: ::sys::CGContextRef, transform: CGAffineTransform);
 }
 

--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -85,6 +85,16 @@ pub enum CGLineJoin {
     CGLineJoinBevel,
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub enum CGPathDrawingMode {
+    CGPathFill,
+    CGPathEOFill,
+    CGPathStroke,
+    CGPathFillStroke,
+    CGPathEOFillStroke,
+}
+
 foreign_type! {
     #[doc(hidden)]
     type CType = ::sys::CGContext;
@@ -351,6 +361,12 @@ impl CGContextRef {
         }
     }
 
+    pub fn draw_path(&self, mode: CGPathDrawingMode) {
+        unsafe {
+            CGContextDrawPath(self.as_ptr(), mode);
+        }
+    }
+
     pub fn fill_path(&self) {
         unsafe {
             CGContextFillPath(self.as_ptr());
@@ -375,9 +391,51 @@ impl CGContextRef {
         }
     }
 
+    pub fn fill_rects(&self, rects: &[CGRect]) {
+        unsafe {
+            CGContextFillRects(self.as_ptr(), rects.as_ptr(), rects.len())
+        }
+    }
+
     pub fn clear_rect(&self, rect: CGRect) {
         unsafe {
             CGContextClearRect(self.as_ptr(), rect)
+        }
+    }
+
+    pub fn stroke_rect(&self, rect: CGRect) {
+        unsafe {
+            CGContextStrokeRect(self.as_ptr(), rect)
+        }
+    }
+
+    pub fn stroke_rect_with_width(&self, rect: CGRect, width: CGFloat) {
+        unsafe {
+            CGContextStrokeRectWithWidth(self.as_ptr(), rect, width)
+        }
+    }
+
+    pub fn replace_path_with_stroked_path(&self) {
+        unsafe {
+            CGContextReplacePathWithStrokedPath(self.as_ptr())
+        }
+    }
+
+    pub fn fill_ellipse_in_rect(&self, rect: CGRect) {
+        unsafe {
+            CGContextFillEllipseInRect(self.as_ptr(), rect)
+        }
+    }
+
+    pub fn stroke_ellipse_in_rect(&self, rect: CGRect) {
+        unsafe {
+            CGContextStrokeEllipseInRect(self.as_ptr(), rect)
+        }
+    }
+
+    pub fn stroke_line_segments(&self, points: &[CGPoint]) {
+        unsafe {
+            CGContextStrokeLineSegments(self.as_ptr(), points.as_ptr(), points.len())
         }
     }
 
@@ -535,6 +593,7 @@ extern {
     fn CGContextMoveToPoint(c: ::sys::CGContextRef,
                             x: CGFloat,
                             y: CGFloat);
+    fn CGContextDrawPath(c: ::sys::CGContextRef, mode: CGPathDrawingMode);
     fn CGContextFillPath(c: ::sys::CGContextRef);
     fn CGContextEOFillPath(c: ::sys::CGContextRef);
     fn CGContextClip(c: ::sys::CGContextRef);
@@ -555,6 +614,22 @@ extern {
                           rect: CGRect);
     fn CGContextFillRect(context: ::sys::CGContextRef,
                          rect: CGRect);
+    fn CGContextFillRects(context: ::sys::CGContextRef,
+                          rects: *const CGRect,
+                          count: size_t);
+    fn CGContextStrokeRect(context: ::sys::CGContextRef,
+                           rect: CGRect);
+    fn CGContextStrokeRectWithWidth(context: ::sys::CGContextRef,
+                                    rect: CGRect,
+                                    width: CGFloat);
+    fn CGContextReplacePathWithStrokedPath(context: ::sys::CGContextRef);
+    fn CGContextFillEllipseInRect(context: ::sys::CGContextRef,
+                                  rect: CGRect);
+    fn CGContextStrokeEllipseInRect(context: ::sys::CGContextRef,
+                                    rect: CGRect);
+    fn CGContextStrokeLineSegments(context: ::sys::CGContextRef,
+                                    points: *const CGPoint,
+                                    count: size_t);
     fn CGContextDrawImage(c: ::sys::CGContextRef, rect: CGRect, image: ::sys::CGImageRef);
     fn CGContextSetFont(c: ::sys::CGContextRef, font: ::sys::CGFontRef);
     fn CGContextSetFontSize(c: ::sys::CGContextRef, size: CGFloat);

--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -415,6 +415,18 @@ impl CGContextRef {
         }
     }
 
+    pub fn clip_to_rect(&self, rect: CGRect) {
+        unsafe {
+            CGContextClipToRect(self.as_ptr(), rect)
+        }
+    }
+
+    pub fn clip_to_rects(&self, rects: &[CGRect]) {
+        unsafe {
+            CGContextClipToRects(self.as_ptr(), rects.as_ptr(), rects.len())
+        }
+    }
+
     pub fn replace_path_with_stroked_path(&self) {
         unsafe {
             CGContextReplacePathWithStrokedPath(self.as_ptr())
@@ -640,6 +652,11 @@ extern {
     fn CGContextStrokeRectWithWidth(context: ::sys::CGContextRef,
                                     rect: CGRect,
                                     width: CGFloat);
+    fn CGContextClipToRect(context: ::sys::CGContextRef,
+                           rect: CGRect);
+    fn CGContextClipToRects(context: ::sys::CGContextRef,
+                            rects: *const CGRect,
+                            count: size_t);
     fn CGContextReplacePathWithStrokedPath(context: ::sys::CGContextRef);
     fn CGContextFillEllipseInRect(context: ::sys::CGContextRef,
                                   rect: CGRect);

--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -303,6 +303,18 @@ impl CGContextRef {
         }
     }
 
+    pub fn add_quad_curve_to_point(&self,
+                                   cpx: CGFloat,
+                                   cpy: CGFloat,
+                                   x: CGFloat,
+                                   y: CGFloat) {
+        unsafe {
+            CGContextAddQuadCurveToPoint(self.as_ptr(),
+                                         cpx, cpy,
+                                         x, y);
+        }
+    }
+
     pub fn add_line_to_point(&self, x: CGFloat, y: CGFloat) {
         unsafe {
             CGContextAddLineToPoint(self.as_ptr(), x, y);
@@ -510,6 +522,11 @@ extern {
                                 cp2y: CGFloat,
                                 x: CGFloat,
                                 y: CGFloat);
+    fn CGContextAddQuadCurveToPoint(c: ::sys::CGContextRef,
+                                    cpx: CGFloat,
+                                    cpy: CGFloat,
+                                    x: CGFloat,
+                                    y: CGFloat);
     fn CGContextAddLineToPoint(c: ::sys::CGContextRef,
                                x: CGFloat,
                                y: CGFloat);


### PR DESCRIPTION
This PR exposes the following APIs:

- `CGContextRotateCTM`
- `CGContextGetCTM`
- `CGContextConcatCTM`
- `CGContextFillRects`
- `CGContextStrokeRect`
- `CGContextStrokeRectWithWidth`
- `CGContextReplacePathWithStrokedPath`
- `CGContextFillEllipseInRect`
- `CGContextStrokeEllipseInRect`
- `CGContextStrokeLineSegments`
- `CGContextAddQuadCurveToPoint`
- `CGContextClipToRect`
- `CGContextClipToRects`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/313)
<!-- Reviewable:end -->