### PR TITLE
delegate! macro, a higher-level way to create Cocoa delegates (e.g. NSWindowDelegate)

### DIFF
--- a/cocoa/src/lib.rs
+++ b/cocoa/src/lib.rs
@@ -28,3 +28,5 @@ pub mod base;
 pub mod foundation;
 #[cfg(target_os = "macos")]
 pub mod quartzcore;
+#[macro_use]
+mod macros;

--- a/cocoa/src/macros.rs
+++ b/cocoa/src/macros.rs
@@ -16,22 +16,26 @@
 /// #[macro_use] extern crate objc;
 ///
 /// use cocoa::appkit::NSWindow;
-/// use cocoa::base::nil;
+/// use cocoa::base::{id, nil};
 ///
-/// # unsafe fn main() {
-/// let my_window: id = NSWindow::alloc(nil);
+/// use objc::runtime::{Object, Sel};
 ///
-/// extern fn on_enter_fullscreen(this: &Object, _cmd: Sel, _notification: id) {
-///     unsafe {
-///         let window: id = *this.get_ivar("window");
-///         window.setToolbar_(nil);
+/// # fn main() {
+/// unsafe {
+///     let my_window: id = NSWindow::alloc(nil);
+///
+///     extern fn on_enter_fullscreen(this: &Object, _cmd: Sel, _notification: id) {
+///         unsafe {
+///             let window: id = *this.get_ivar("window");
+///             window.setToolbar_(nil);
+///         }
 ///     }
-/// }
 ///
-/// my_window.setDelegate_(delegate!("MyWindowDelegate", {
-///     window: id = my_window, // Declare instance variable(s)
-///     (onWindowWillEnterFullscreen:) => on_enter_fullscreen as extern fn(&Object, Sel, id) // Declare function(s)
-/// }));
+///     my_window.setDelegate_(delegate!("MyWindowDelegate", {
+///         window: id = my_window, // Declare instance variable(s)
+///         (onWindowWillEnterFullscreen:) => on_enter_fullscreen as extern fn(&Object, Sel, id) // Declare function(s)
+///     }));
+/// }
 /// # }
 /// ```
 #[macro_export]

--- a/cocoa/src/macros.rs
+++ b/cocoa/src/macros.rs
@@ -1,0 +1,75 @@
+// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Creates a Cocoa delegate to use e.g. with `NSWindow.setDelegate_`.
+/// Adds instance variables and methods to the definition.
+///
+/// # Example with NSWindowDelegate
+/// ``` no_run
+/// #[macro_use] extern crate cocoa;
+/// #[macro_use] extern crate objc;
+///
+/// use cocoa::appkit::NSWindow;
+/// use cocoa::base::nil;
+///
+/// # unsafe fn main() {
+/// let my_window: id = NSWindow::alloc(nil);
+///
+/// extern fn on_enter_fullscreen(this: &Object, _cmd: Sel, _notification: id) {
+///     unsafe {
+///         let window: id = *this.get_ivar("window");
+///         window.setToolbar_(nil);
+///     }
+/// }
+///
+/// my_window.setDelegate_(delegate!("MyWindowDelegate", {
+///     window: id = my_window, // Declare instance variable(s)
+///     (onWindowWillEnterFullscreen:) => on_enter_fullscreen as extern fn(&Object, Sel, id) // Declare function(s)
+/// }));
+/// # }
+/// ```
+#[macro_export]
+macro_rules! delegate {
+    (
+        $name:expr, {
+            $( ($($sel:ident :)+) => $func:expr),*
+        }
+    ) => (
+        delegate!($name, {
+            ,
+            $( ($($sel :)+) => $func),*
+        })
+    );
+
+    (
+        $name:expr, {
+            $($var:ident : $var_type:ty = $value:expr),* ,
+            $( ($($sel:ident :)+) => $func:expr),*
+        }
+    ) => ({
+        let mut decl = objc::declare::ClassDecl::new($name, class!(NSObject)).unwrap();
+
+        $(
+            decl.add_ivar::<$var_type>(stringify!($var));
+        )*
+
+        $(
+            decl.add_method(sel!($($sel :)+), $func);
+        )*
+
+        let cl = decl.register();
+        let delegate: id = msg_send![cl, alloc];
+
+        $(
+            (*delegate).set_ivar(stringify!($var), $value);
+        )*
+
+        delegate
+    });
+}


### PR DESCRIPTION
As @vbo mentioned in #205 the only way to create cocoa delegates such as NSWindowDelegate is to use the objc crate and it's a bit hard.

I thought a macro for this would be useful.

## Example with NSWindowDelegate

Without macro :
```rust
let mut decl = ClassDecl::new("MyWindowDelegate", class!(NSObject)).unwrap();

decl.add_ivar::<id>("window");
decl.add_method(sel!(windowWillEnterFullScreen:), on_enter_fullscreen as extern fn(&Object, Sel, id));

let cl = decl.register();

let delegate: id = msg_send![cl, alloc];
(*delegate).set_ivar("window", window);

window.setDelegate_(delegate);
```

With macro :
```rust
window.setDelegate_(delegate!("MyWindowDelegate", {
    window: id = window,
    (windowWillEnterFullScreen:) => on_enter_fullscreen as extern fn(&Object, Sel, id)
}));
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/314)
<!-- Reviewable:end -->
