### PR TITLE
Add some bindings for Appkit and Cocoa Foundation

### DIFF
--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -207,6 +207,14 @@ pub enum NSWindowTitleVisibility {
     NSWindowTitleHidden = 1
 }
 
+#[repr(i64)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum NSWindowTabbingMode {
+    NSWindowTabbingModeAutomatic = 0,
+    NSWindowTabbingModeDisallowed = 1,
+    NSWindowTabbingModePreferred = 2
+}
+
 #[repr(u64)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum NSBackingStoreType {
@@ -1001,6 +1009,15 @@ pub trait NSWindow: Sized {
     // Managing Title Bars
     unsafe fn standardWindowButton_(self, windowButtonKind: NSWindowButton) -> id;
 
+    // Managing Window Tabs
+    unsafe fn allowsAutomaticWindowTabbing(_: Self) -> BOOL;
+    unsafe fn setAllowsAutomaticWindowTabbing_(_: Self, allowsAutomaticWindowTabbing: BOOL);
+    unsafe fn tabbingIdentifier(self) -> id;
+    unsafe fn tabbingMode(self) -> NSWindowTabbingMode;
+    unsafe fn setTabbingMode_(self, tabbingMode: NSWindowTabbingMode);
+    unsafe fn addTabbedWindow_ordered_(self, window: id, ordering_mode: NSWindowOrderingMode);
+    unsafe fn toggleTabBar_(self, sender: id);
+
     // TODO: Managing Tooltips
     // TODO: Handling Events
 
@@ -1507,6 +1524,34 @@ impl NSWindow for id {
         msg_send![self, standardWindowButton:windowButtonKind]
     }
 
+    // Managing Window Tabs
+    unsafe fn allowsAutomaticWindowTabbing(_: Self) -> BOOL {
+        msg_send![class!(NSWindow), allowsAutomaticWindowTabbing]
+    }
+
+    unsafe fn setAllowsAutomaticWindowTabbing_(_: Self, allowsAutomaticWindowTabbing: BOOL) {
+        msg_send![class!(NSWindow), setAllowsAutomaticWindowTabbing:allowsAutomaticWindowTabbing]
+    }
+
+    unsafe fn tabbingIdentifier(self) -> id {
+        msg_send![self, tabbingIdentifier]
+    }
+
+    unsafe fn tabbingMode(self) -> NSWindowTabbingMode {
+        msg_send!(self, tabbingMode)
+    }
+
+    unsafe fn setTabbingMode_(self, tabbingMode: NSWindowTabbingMode) {
+        msg_send![self, setTabbingMode: tabbingMode];
+    }
+
+    unsafe fn addTabbedWindow_ordered_(self, window: id, ordering_mode: NSWindowOrderingMode) {
+        msg_send![self, addTabbedWindow:window ordered: ordering_mode];
+    }
+
+    unsafe fn toggleTabBar_(self, sender: id) {
+        msg_send![self, toggleTabBar:sender]
+    }
     // TODO: Managing Tooltips
     // TODO: Handling Events
 
@@ -3530,7 +3575,7 @@ pub trait NSTabView: Sized {
     unsafe fn new(_: Self) -> id  {
         msg_send![class!(NSTabView), new]
     }
-    
+
     unsafe fn initWithFrame_(self, frameRect: NSRect) -> id;
     unsafe fn addTabViewItem_(self, tabViewItem: id);
     unsafe fn insertTabViewItem_atIndex_(self,tabViewItem:id, index:NSInteger);
@@ -4076,6 +4121,21 @@ impl NSSpellChecker for id {
         msg_send![self, ignoreWord:wordToIgnore inSpellDocumentWithTag:tag]
     }
 }
+
+pub trait NSNib: Sized {
+    unsafe fn alloc(_: Self) -> id {
+        msg_send![class!(NSNib), alloc]
+    }
+
+    unsafe fn initWithNibNamed_bundle_(self, name: id, bundle: id) -> id;
+}
+
+impl NSNib for id {
+    unsafe fn initWithNibNamed_bundle_(self, name: id, bundle: id) -> id {
+        msg_send![self, initWithNibNamed:name bundle:bundle]
+    }
+}
+
 
 #[cfg(test)]
 mod test {

--- a/cocoa/src/foundation.rs
+++ b/cocoa/src/foundation.rs
@@ -233,17 +233,34 @@ pub trait NSArray: Sized {
         msg_send![class!(NSArray), arrayWithObject:object]
     }
 
+    unsafe fn init(self) -> id;
+
+    unsafe fn count(self) -> NSUInteger;
+
     unsafe fn arrayByAddingObjectFromArray(self, object: id) -> id;
     unsafe fn arrayByAddingObjectsFromArray(self, objects: id) -> id;
+    unsafe fn objectAtIndex(self, index: NSUInteger) -> id;
 }
 
 impl NSArray for id {
+    unsafe fn init(self) -> id {
+        msg_send![self, init]
+    }
+
+    unsafe fn count(self) -> NSUInteger {
+        msg_send![self, count]
+    }
+
     unsafe fn arrayByAddingObjectFromArray(self, object: id) -> id {
         msg_send![self, arrayByAddingObjectFromArray:object]
     }
 
     unsafe fn arrayByAddingObjectsFromArray(self, objects: id) -> id {
         msg_send![self, arrayByAddingObjectsFromArray:objects]
+    }
+
+    unsafe fn objectAtIndex(self, index: NSUInteger) -> id {
+        msg_send![self, objectAtIndex:index]
     }
 }
 
@@ -1043,6 +1060,30 @@ impl NSURL for id {
 
     // unsafe fn URLFromPasteboard_
     // unsafe fn writeToPasteboard_
+}
+
+pub trait NSBundle: Sized {
+    unsafe fn mainBundle() -> Self;
+
+    unsafe fn loadNibNamed_owner_topLevelObjects_(self,
+                                          name: id /* NSString */,
+                                          owner: id,
+                                          topLevelObjects: *mut id /* NSArray */) -> BOOL;
+}
+
+impl NSBundle for id {
+    unsafe fn mainBundle() -> id {
+        msg_send![class!(NSBundle), mainBundle]
+    }
+
+    unsafe fn loadNibNamed_owner_topLevelObjects_(self,
+                                          name: id /* NSString */,
+                                          owner: id,
+                                          topLevelObjects: *mut id /* NSArray* */) -> BOOL {
+        msg_send![self, loadNibNamed:name
+                               owner:owner
+                     topLevelObjects:topLevelObjects]
+    }
 }
 
 pub trait NSData: Sized {


### PR DESCRIPTION
This commit adds several missing AppKit & Cocoa Foundation bindings. Specifically:

AppKit:

* NSWindowTabbingMode ([Apple Doc](https://developer.apple.com/documentation/appkit/nswindowtabbingmode?language=objc))
* Managing Window Tabs section for NSWindow ([Apple Doc](https://developer.apple.com/documentation/appkit/nswindow?language=objc#3020937))
* NSNib ([Apple Doc](https://developer.apple.com/documentation/appkit/nsnib?language=objc))

Cocoa Foundation

* `init`, `count` and `objectAtIndex` for `NSArray`  ([Apple Doc](https://developer.apple.com/documentation/foundation/nsarray?language=objc))
* `NSBundle` ([Apple Doc](https://developer.apple.com/documentation/foundation/nsbundle?language=objc))

I don't have much experience in Cocoa nor Objective-C. Please let me know if there is anything need to be changed. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/315)
<!-- Reviewable:end -->
