### PR TITLE
Fix `CGDisplayMode` bindings

### DIFF
--- a/core-graphics/src/sys.rs
+++ b/core-graphics/src/sys.rs
@@ -30,9 +30,6 @@ mod macos {
 
 	pub enum CGEventSource {}
 	pub type CGEventSourceRef = *mut CGEventSource;
-
-	pub enum CGDisplayMode {}
-	pub type CGDisplayModeRef = *mut CGDisplayMode;
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
There was some bizarre behaviour going on with `CGDisplayMode::all_display_modes()`, which I believe was resulting in objects being freed that weren't supposed to. In my project, all calls to `CGConfigureDisplayWithDisplayMode()` would crash after this function call, and any subsequent calls to `CGDisplayMode::all_display_modes()` would crash as well.

Familiarising myself with this codebase, I think the right solution here is to wrap the array elements with `TCFType::wrap_under_get_rule()` as indicated by the comment in the `CFArray::iter()` function. In order to do this, instead of the `foreign_type!()` macro we will have to use `impl_TCFType!()` for the `CGDisplayMode` type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/318)
<!-- Reviewable:end -->
