### PR TITLE
Fix use of deprecated libc::(u)int{16,32}_t

### DIFF
--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -28,7 +28,7 @@ use std::os::raw::c_void;
 
 pub type CGLContextObj = *mut c_void;
 
-pub type GLint = libc::int32_t;
+pub type GLint = i32;
 
 #[link(name = "AppKit", kind = "framework")]
 extern {
@@ -371,7 +371,7 @@ pub enum NSRequestUserAttentionType {
     NSInformationalRequest = 10,
 }
 
-pub static NSMainMenuWindowLevel: libc::int32_t = 24;
+pub static NSMainMenuWindowLevel: i32 = 24;
 
 pub trait NSApplication: Sized {
     unsafe fn sharedApplication(_: Self) -> id {

--- a/core-graphics/src/base.rs
+++ b/core-graphics/src/base.rs
@@ -26,7 +26,7 @@ pub type CGFloat = libc::c_double;
 #[cfg(not(target_pointer_width = "64"))]
 pub type CGFloat = libc::c_float;
 
-pub type CGError = libc::int32_t;
+pub type CGError = i32;
 
 pub const kCGImageAlphaNone: u32 = 0;
 pub const kCGImageAlphaPremultipliedLast: u32 = 1;

--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -21,13 +21,13 @@ use core_foundation::base::{CFRetain, TCFType};
 use image::CGImage;
 use foreign_types::ForeignType;
 
-pub type CGDirectDisplayID = libc::uint32_t;
-pub type CGWindowID        = libc::uint32_t;
+pub type CGDirectDisplayID = u32;
+pub type CGWindowID        = u32;
 
 pub const kCGNullWindowID: CGWindowID = 0 as CGWindowID;
 
 
-pub type CGWindowListOption = libc::uint32_t;
+pub type CGWindowListOption = u32;
 
 pub const kCGWindowListOptionAll:              CGWindowListOption    = 0;
 pub const kCGWindowListOptionOnScreenOnly:     CGWindowListOption    = 1 << 0;
@@ -36,7 +36,7 @@ pub const kCGWindowListOptionOnScreenBelowWindow: CGWindowListOption = 1 << 2;
 pub const kCGWindowListOptionIncludingWindow:  CGWindowListOption    = 1 << 3;
 pub const kCGWindowListExcludeDesktopElements: CGWindowListOption    = 1 << 4;
 
-pub type CGWindowImageOption = libc::uint32_t;
+pub type CGWindowImageOption = u32;
 
 pub const kCGWindowImageDefault: CGWindowImageOption = 0;
 pub const kCGWindowImageBoundsIgnoreFraming: CGWindowImageOption = 1 << 0;
@@ -412,7 +412,7 @@ impl CGDisplay {
     /// Provides count of displays that are active (or drawable).
     #[inline]
     pub fn active_display_count() -> Result<u32, CGError> {
-        let mut count: libc::uint32_t = 0;
+        let mut count: u32 = 0;
         let result = unsafe { CGGetActiveDisplayList(0, ptr::null_mut(), &mut count) };
         if result == 0 {
             Ok(count as u32)
@@ -597,22 +597,22 @@ extern "C" {
     pub fn CGDisplayPrimaryDisplay(display: CGDirectDisplayID) -> CGDirectDisplayID;
     pub fn CGDisplayRotation(display: CGDirectDisplayID) -> libc::c_double;
     pub fn CGDisplayScreenSize(display: CGDirectDisplayID) -> CGSize;
-    pub fn CGDisplaySerialNumber(display: CGDirectDisplayID) -> libc::uint32_t;
-    pub fn CGDisplayUnitNumber(display: CGDirectDisplayID) -> libc::uint32_t;
+    pub fn CGDisplaySerialNumber(display: CGDirectDisplayID) -> u32;
+    pub fn CGDisplayUnitNumber(display: CGDirectDisplayID) -> u32;
     pub fn CGDisplayUsesOpenGLAcceleration(display: CGDirectDisplayID) -> boolean_t;
-    pub fn CGDisplayVendorNumber(display: CGDirectDisplayID) -> libc::uint32_t;
+    pub fn CGDisplayVendorNumber(display: CGDirectDisplayID) -> u32;
     pub fn CGGetActiveDisplayList(
-        max_displays: libc::uint32_t,
+        max_displays: u32,
         active_displays: *mut CGDirectDisplayID,
-        display_count: *mut libc::uint32_t,
+        display_count: *mut u32,
     ) -> CGError;
     pub fn CGGetDisplaysWithRect(
         rect: CGRect,
-        max_displays: libc::uint32_t,
+        max_displays: u32,
         displays: *mut CGDirectDisplayID,
-        matching_display_count: *mut libc::uint32_t,
+        matching_display_count: *mut u32,
     ) -> CGError;
-    pub fn CGDisplayModelNumber(display: CGDirectDisplayID) -> libc::uint32_t;
+    pub fn CGDisplayModelNumber(display: CGDirectDisplayID) -> u32;
     pub fn CGDisplayPixelsHigh(display: CGDirectDisplayID) -> libc::size_t;
     pub fn CGDisplayPixelsWide(display: CGDirectDisplayID) -> libc::size_t;
     pub fn CGDisplayBounds(display: CGDirectDisplayID) -> CGRect;
@@ -637,7 +637,7 @@ extern "C" {
     pub fn CGDisplayModeGetPixelHeight(mode: ::sys::CGDisplayModeRef) -> libc::size_t;
     pub fn CGDisplayModeGetPixelWidth(mode: ::sys::CGDisplayModeRef) -> libc::size_t;
     pub fn CGDisplayModeGetRefreshRate(mode: ::sys::CGDisplayModeRef) -> libc::c_double;
-    pub fn CGDisplayModeGetIOFlags(mode: ::sys::CGDisplayModeRef) -> libc::uint32_t;
+    pub fn CGDisplayModeGetIOFlags(mode: ::sys::CGDisplayModeRef) -> u32;
     pub fn CGDisplayModeCopyPixelEncoding(mode: ::sys::CGDisplayModeRef) -> CFStringRef;
 
     pub fn CGDisplayCopyAllDisplayModes(

--- a/core-graphics/src/event.rs
+++ b/core-graphics/src/event.rs
@@ -8,9 +8,9 @@ use libc;
 
 use foreign_types::ForeignType;
 
-pub type CGEventField = libc::uint32_t;
-pub type CGKeyCode = libc::uint16_t;
-pub type CGScrollEventUnit = libc::uint32_t;
+pub type CGEventField = u32;
+pub type CGKeyCode = u16;
+pub type CGScrollEventUnit = u32;
 
 /// Flags for events
 ///
@@ -589,10 +589,10 @@ extern {
     fn CGEventCreateScrollWheelEvent2(
         source: ::sys::CGEventSourceRef,
         units: CGScrollEventUnit,
-        wheelCount: libc::uint32_t,
-        wheel1: libc::int32_t,
-        wheel2: libc::int32_t,
-        wheel3: libc::int32_t,
+        wheelCount: u32,
+        wheel1: i32,
+        wheel2: i32,
+        wheel3: i32,
     ) -> ::sys::CGEventRef;
 
     /// Post an event into the event stream at a specified location.


### PR DESCRIPTION
This fixes warnings like:

>use of deprecated item 'libc::int32_t': Use i32 instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/320)
<!-- Reviewable:end -->
