### PR TITLE
Add alpha option to bind_to_gl_texture

### DIFF
--- a/io-surface/src/lib.rs
+++ b/io-surface/src/lib.rs
@@ -22,7 +22,7 @@ use core_foundation::base::{CFRelease, CFRetain, CFTypeID, CFTypeRef, CFType, TC
 use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::string::{CFString, CFStringRef};
 use cgl::{kCGLNoError, CGLGetCurrentContext, CGLTexImageIOSurface2D, CGLErrorString};
-use gleam::gl::{BGRA, GLenum, RGBA, TEXTURE_RECTANGLE_ARB, UNSIGNED_INT_8_8_8_8_REV};
+use gleam::gl::{BGRA, GLenum, RGB, RGBA, TEXTURE_RECTANGLE_ARB, UNSIGNED_INT_8_8_8_8_REV};
 use libc::{c_int, size_t};
 use std::os::raw::c_void;
 use leaky_cow::LeakyCow;
@@ -120,12 +120,12 @@ impl IOSurface {
     }
 
     /// Binds to the current GL texture.
-    pub fn bind_to_gl_texture(&self, width: i32, height: i32) {
+    pub fn bind_to_gl_texture(&self, width: i32, height: i32, has_alpha: bool) {
         unsafe {
             let context = CGLGetCurrentContext();
             let gl_error = CGLTexImageIOSurface2D(context,
                                                   TEXTURE_RECTANGLE_ARB,
-                                                  RGBA as GLenum,
+                                                  if has_alpha { RGBA as GLenum } else { RGB as GLenum },
                                                   width,
                                                   height,
                                                   BGRA as GLenum,


### PR DESCRIPTION
This PR is related to https://github.com/servo/servo/pull/23509.
If the WebGL context we use doesn't have alpha, the underlying IOsurface should use RGB internal format instead of RGBA, else the reported GL_ALPHA_BITS value will be incorrect fot the context in the related wpt-tests.
We only need to change the internal format in this case, according to https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.8.sdk/System/Library/Frameworks/OpenGL.framework/Versions/A/Headers/CGLIOSurface.h#L99
cc @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/324)
<!-- Reviewable:end -->
