### PR TITLE
add shared_support_url to CFBundle

### DIFF
--- a/core-foundation-sys/src/bundle.rs
+++ b/core-foundation-sys/src/bundle.rs
@@ -33,4 +33,5 @@ extern {
     pub fn CFBundleGetTypeID() -> CFTypeID;
     pub fn CFBundleCopyExecutableURL(bundle: CFBundleRef) -> CFURLRef;
     pub fn CFBundleCopyPrivateFrameworksURL(bundle: CFBundleRef) -> CFURLRef;
+    pub fn CFBundleCopySharedSupportURL(bundle: CFBundleRef) -> CFURLRef;
 }

--- a/core-foundation/src/bundle.rs
+++ b/core-foundation/src/bundle.rs
@@ -89,6 +89,17 @@ impl CFBundle {
             }
         }
     }
+
+    pub fn shared_support_url(&self) -> Option<CFURL> {
+        unsafe {
+            let fw_url = CFBundleCopySharedSupportURL(self.0);
+            if fw_url.is_null() {
+                None
+            } else {
+                Some(TCFType::wrap_under_create_rule(fw_url))
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
This adds access to CFBundleCopySharedSupportURL from the CFBundle struct

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-foundation-rs/329)
<!-- Reviewable:end -->
