### PR TITLE
Fixes so the compiler can infer msg_send! return types

### DIFF
--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -549,7 +549,7 @@ pub trait NSPasteboard: Sized {
 
 impl NSPasteboard for id {
     unsafe fn releaseGlobally(self) {
-        msg_send![self, releaseGlobally];
+        msg_send![self, releaseGlobally]
     }
 
     unsafe fn clearContents(self) -> NSInteger {
@@ -1547,11 +1547,11 @@ impl NSWindow for id {
     }
 
     unsafe fn setTabbingMode_(self, tabbingMode: NSWindowTabbingMode) {
-        msg_send![self, setTabbingMode: tabbingMode];
+        msg_send![self, setTabbingMode: tabbingMode]
     }
 
     unsafe fn addTabbedWindow_ordered_(self, window: id, ordering_mode: NSWindowOrderingMode) {
-        msg_send![self, addTabbedWindow:window ordered: ordering_mode];
+        msg_send![self, addTabbedWindow:window ordered: ordering_mode]
     }
 
     unsafe fn toggleTabBar_(self, sender: id) {
@@ -2977,7 +2977,7 @@ impl NSButton for id {
         msg_send![self, initWithFrame:frameRect]
     }
     unsafe fn setBezelStyle_(self, style: NSBezelStyle) {
-        msg_send![self, setBezelStyle:style];
+        msg_send![self, setBezelStyle:style]
     }
     unsafe fn setTitle_(self, title: id /* (NSString*) */) {
         msg_send![self, setTitle:title]
@@ -2990,7 +2990,7 @@ impl NSButton for id {
     }
 
     unsafe fn setAction_(self, selector: objc::runtime::Sel /* (Instance method *) */) {
-        msg_send![self, setAction:selector];
+        msg_send![self, setAction:selector]
     }
 }
 
@@ -3589,10 +3589,10 @@ impl NSTextField for id {
         msg_send![self, initWithFrame:frameRect]
     }
     unsafe fn setEditable_(self, editable: BOOL) {
-        msg_send![self, setEditable:editable];
+        msg_send![self, setEditable:editable]
     }
     unsafe fn setStringValue_(self, label: id) {
-        msg_send![self, setStringValue:label];
+        msg_send![self, setStringValue:label]
     }
 }
 

--- a/cocoa/src/quartzcore.rs
+++ b/cocoa/src/quartzcore.rs
@@ -889,7 +889,7 @@ impl CALayer {
     #[inline]
     pub fn set_should_rasterize(&self, flag: bool) {
         unsafe {
-            msg_send![self.id(), setShouldRasterize:(flag as BOOL)];
+            msg_send![self.id(), setShouldRasterize:(flag as BOOL)]
         }
     }
 
@@ -1459,7 +1459,7 @@ impl CARenderer {
                 Some(ref layer) => layer.id(),
                 None => nil,
             };
-            msg_send![self.id(), setLayer:layer];
+            msg_send![self.id(), setLayer:layer]
         }
     }
 

--- a/cocoa/tests/foundation.rs
+++ b/cocoa/tests/foundation.rs
@@ -100,7 +100,7 @@ mod foundation {
                 let mut_components: id = msg_send![components, mutableCopy];
                 let mut iter = mut_components.iter();
                 iter.next();
-                msg_send![mut_components, removeObjectAtIndex:1];
+                let () = msg_send![mut_components, removeObjectAtIndex:1];
                 iter.next();
             }
         }


### PR DESCRIPTION
Currently, due to a quirk in Rust's type inference interacting with the structure of the `msg_send!` macro, a `()` return type will be inferred when the compiler cannot otherwise determine the return type. This behavior is expected to change, and in the future could resolve to a `!` return type, which results in undefined behavior.

Linting has previously been added for this in rust-lang/rust#39216, but it did not catch these cases due to SSheldon/rust-objc#62. An upcoming version of objc will be fixed to stop hiding these errors, at which point they will become compile errors.

This change fixes these errors and allows cocoa to compile with the fixed version of objc.