### PR TITLE
Add CGConfigureDisplayMirrorOfDisplay

### DIFF
--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -200,7 +200,7 @@ impl CGDisplay {
         }
     }
 
-    // Configures the origin of a display in the global display coordinate space.
+    /// Configures the origin of a display in the global display coordinate space.
     pub fn configure_display_origin(
         &self,
         config_ref: &CGDisplayConfigRef,

--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -25,7 +25,7 @@ pub type CGDirectDisplayID = u32;
 pub type CGWindowID        = u32;
 
 pub const kCGNullWindowID: CGWindowID = 0 as CGWindowID;
-
+pub const kCGNullDirectDisplayID: CGDirectDisplayID = 0 as CGDirectDisplayID;
 
 pub type CGWindowListOption = u32;
 
@@ -121,6 +121,11 @@ impl CGDisplay {
     #[inline]
     pub fn main() -> CGDisplay {
         CGDisplay::new(unsafe { CGMainDisplayID() })
+    }
+
+    /// A value that will never correspond to actual hardware.
+    pub fn null_display() -> CGDisplay {
+        CGDisplay::new(kCGNullDirectDisplayID)
     }
 
     /// Returns the bounds of a display in the global display coordinate space.

--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -221,6 +221,21 @@ impl CGDisplay {
         }
     }
 
+    /// Changes the configuration of a mirroring set.
+    pub fn configure_display_mirror_of_display(
+        &self,
+        config_ref: &CGDisplayConfigRef,
+        master: &CGDisplay,
+    ) -> Result<(), CGError> {
+        let result = unsafe { CGConfigureDisplayMirrorOfDisplay(*config_ref, self.id, master.id) };
+
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(result)
+        }
+    }
+
     /// Returns an image containing the contents of the specified display.
     #[inline]
     pub fn image(&self) -> Option<CGImage> {
@@ -650,6 +665,11 @@ extern "C" {
         display: CGDirectDisplayID,
         mode: ::sys::CGDisplayModeRef,
         options: CFDictionaryRef,
+    ) -> CGError;
+    pub fn CGConfigureDisplayMirrorOfDisplay(
+        config: CGDisplayConfigRef,
+        display: CGDirectDisplayID,
+        master: CGDirectDisplayID,
     ) -> CGError;
     pub fn CGConfigureDisplayOrigin(
         config: CGDisplayConfigRef,


### PR DESCRIPTION
Hi there,

One more for Core Graphics from me. This time adds [`CGConfigureDisplayMirrorOfDisplay`](https://developer.apple.com/documentation/coregraphics/1454531-cgconfiguredisplaymirrorofdispla) and [`kCGNullDirectDisplay`](https://developer.apple.com/documentation/coregraphics/kcgnulldirectdisplay) APIs.

`CGConfigureDisplayMirrorOfDisplay`:
``` objc
func CGConfigureDisplayMirrorOfDisplay(_ config: CGDisplayConfigRef?, 
                                     _ display: CGDirectDisplayID, 
                                     _ master: CGDirectDisplayID) -> CGError
```

`kCGNullDirectDisplay`:
``` objc
#define kCGNullDirectDisplay
```

Not sure about the `null_display` function, but at least it kind of aligns with `main`. Maybe I should just call it `null`.

Let me know what do you think.