### PR TITLE
Bump core graphics version to 0.18.0

### DIFF
--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -17,6 +17,6 @@ block = "0.1"
 bitflags = "1.0"
 libc = "0.2"
 core-foundation = { path = "../core-foundation", version = "0.6" }
-core-graphics = { path = "../core-graphics", version = "0.17" }
+core-graphics = { path = "../core-graphics", version = "0.18" }
 foreign-types = "0.3"
 objc = "0.2.3"

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics"
 description = "Bindings to Core Graphics for macOS"
 homepage = "https://github.com/servo/core-graphics-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.17.3"
+version = "0.18.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -16,4 +16,4 @@ mountainlion = []
 foreign-types = "0.3"
 libc = "0.2"
 core-foundation = { path = "../core-foundation", version = "0.6.2" }
-core-graphics = { path = "../core-graphics", version = "0.17" }
+core-graphics = { path = "../core-graphics", version = "0.18" }


### PR DESCRIPTION
As discussed in #339 bumping version of core graphics to the next minor.