### PR TITLE
Properly make core_text::font::Font be Send and Sync

### DIFF
--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "13.3.0"
+version = "13.3.1"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"

--- a/core-text/src/font.rs
+++ b/core-text/src/font.rs
@@ -88,6 +88,9 @@ declare_TCFType! {
 impl_TCFType!(CTFont, CTFontRef, CTFontGetTypeID);
 impl_CFTypeDescription!(CTFont);
 
+unsafe impl Send for CTFont {}
+unsafe impl Sync for CTFont {}
+
 pub fn new_from_CGFont(cgfont: &CGFont, pt_size: f64) -> CTFont {
     unsafe {
         let font_ref = CTFontCreateWithGraphicsFont(cgfont.as_ptr() as *mut _,


### PR DESCRIPTION
The Apple documentation says:

> All individual functions in Core Text are thread-safe. Font objects (CTFont,
> CTFontDescriptor, and associated objects) can be used simultaneously by
> multiple operations, work queues, or threads. However, the layout objects
> (CTTypesetter, CTFramesetter, CTRun, CTLine, CTFrame, and associated objects)
> should be used in a single operation, work queue, or thread.

https://developer.apple.com/documentation/coretext