### PR TITLE
Fix deprecated usage of Rust features

### DIFF
--- a/core-foundation/src/filedescriptor.rs
+++ b/core-foundation/src/filedescriptor.rs
@@ -15,7 +15,7 @@ use core_foundation_sys::base::{kCFAllocatorDefault, CFOptionFlags};
 use base::TCFType;
 use runloop::CFRunLoopSource;
 
-use std::mem;
+use std::mem::MaybeUninit;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::ptr;
 
@@ -46,9 +46,9 @@ impl CFFileDescriptor {
 
     pub fn context(&self) -> CFFileDescriptorContext {
         unsafe {
-            let mut context: CFFileDescriptorContext = mem::uninitialized();
-            CFFileDescriptorGetContext(self.0, &mut context);
-            context
+            let mut context = MaybeUninit::<CFFileDescriptorContext>::uninit();
+            CFFileDescriptorGetContext(self.0, context.as_mut_ptr());
+            context.assume_init()
         }
     }
 

--- a/core-foundation/src/url.rs
+++ b/core-foundation/src/url.rs
@@ -16,9 +16,9 @@ use string::{CFString};
 
 use core_foundation_sys::base::{kCFAllocatorDefault, Boolean};
 use std::fmt;
+use std::mem::MaybeUninit;
 use std::ptr;
 use std::path::{Path, PathBuf};
-use std::mem;
 
 use libc::{c_char, strlen, PATH_MAX};
 
@@ -78,13 +78,15 @@ impl CFURL {
     pub fn to_path(&self) -> Option<PathBuf> {
         // implementing this on Windows is more complicated because of the different OsStr representation
         unsafe {
-            let mut buf: [u8; PATH_MAX as usize] = mem::uninitialized();
-            let result = CFURLGetFileSystemRepresentation(self.0, true as Boolean, buf.as_mut_ptr(), buf.len() as CFIndex);
+            let mut buf = MaybeUninit::<[u8; PATH_MAX as usize]>::uninit();
+            let result = CFURLGetFileSystemRepresentation(self.0, true as Boolean, buf.as_mut_ptr() as *mut u8, PATH_MAX as CFIndex);
             if result == false as Boolean {
                 return None;
             }
-            let len = strlen(buf.as_ptr() as *const c_char);
-            let path = OsStr::from_bytes(&buf[0..len]);
+
+            let buf_init = buf.assume_init();
+            let len = strlen(buf_init.as_ptr() as *const c_char);
+            let path = OsStr::from_bytes(&buf_init[0..len]);
             Some(PathBuf::from(path))
         }
     }

--- a/core-foundation/src/url.rs
+++ b/core-foundation/src/url.rs
@@ -78,15 +78,13 @@ impl CFURL {
     pub fn to_path(&self) -> Option<PathBuf> {
         // implementing this on Windows is more complicated because of the different OsStr representation
         unsafe {
-            let mut buf = MaybeUninit::<[u8; PATH_MAX as usize]>::uninit();
-            let result = CFURLGetFileSystemRepresentation(self.0, true as Boolean, buf.as_mut_ptr() as *mut u8, PATH_MAX as CFIndex);
+            let mut buf = [0u8; PATH_MAX as usize];
+            let result = CFURLGetFileSystemRepresentation(self.0, true as Boolean, buf.as_mut_ptr(), buf.len() as CFIndex);
             if result == false as Boolean {
                 return None;
             }
-
-            let buf_init = buf.assume_init();
-            let len = strlen(buf_init.as_ptr() as *const c_char);
-            let path = OsStr::from_bytes(&buf_init[0..len]);
+            let len = strlen(buf.as_ptr() as *const c_char);
+            let path = OsStr::from_bytes(&buf[0..len]);
             Some(PathBuf::from(path))
         }
     }

--- a/core-graphics/src/data_provider.rs
+++ b/core-graphics/src/data_provider.rs
@@ -77,14 +77,14 @@ impl CGDataProvider {
     ///
     /// This is double-boxed because the Core Text API requires that the userdata be a single
     /// pointer.
-    pub unsafe fn from_custom_data(custom_data: Box<Box<CustomData>>) -> Self {
+    pub unsafe fn from_custom_data(custom_data: Box<Box<dyn CustomData>>) -> Self {
         let (ptr, len) = (custom_data.ptr() as *const c_void, custom_data.len());
-        let userdata = mem::transmute::<Box<Box<CustomData>>, &mut c_void>(custom_data);
+        let userdata = mem::transmute::<Box<Box<dyn CustomData>>, &mut c_void>(custom_data);
         let data_provider = CGDataProviderCreateWithData(userdata, ptr, len, Some(release));
         return CGDataProvider::from_ptr(data_provider);
 
         unsafe extern "C" fn release(info: *mut c_void, _: *const c_void, _: size_t) {
-            drop(mem::transmute::<*mut c_void, Box<Box<CustomData>>>(info))
+            drop(mem::transmute::<*mut c_void, Box<Box<dyn CustomData>>>(info))
         }
     }
 }

--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -434,7 +434,7 @@ impl CGDisplay {
     /// Provides a list of displays that are active (or drawable).
     #[inline]
     pub fn active_displays() -> Result<Vec<CGDirectDisplayID>, CGError> {
-        let count = try!(CGDisplay::active_display_count());
+        let count = CGDisplay::active_display_count()?;
         let mut buf: Vec<CGDirectDisplayID> = vec![0; count as usize];
         let result =
             unsafe { CGGetActiveDisplayList(count as u32, buf.as_mut_ptr(), ptr::null_mut()) };


### PR DESCRIPTION
This PR fixes some deprecated usage of Rust features. However, because of the use of `MaybeUninit` this PR will bump the minimum required Rust version to 1.36, which will need some discussion.