### PR TITLE
Add binding for CTRunGetStringIndices

### DIFF
--- a/core-foundation/src/url.rs
+++ b/core-foundation/src/url.rs
@@ -16,7 +16,6 @@ use string::{CFString};
 
 use core_foundation_sys::base::{kCFAllocatorDefault, Boolean};
 use std::fmt;
-use std::mem::MaybeUninit;
 use std::ptr;
 use std::path::{Path, PathBuf};
 

--- a/core-graphics/src/event.rs
+++ b/core-graphics/src/event.rs
@@ -12,9 +12,9 @@ pub type CGEventField = u32;
 pub type CGKeyCode = u16;
 pub type CGScrollEventUnit = u32;
 
-/// Flags for events
-///
-/// [Ref](http://opensource.apple.com/source/IOHIDFamily/IOHIDFamily-700/IOHIDSystem/IOKit/hidsystem/IOLLEvent.h)
+// Flags for events
+//
+// [Ref](http://opensource.apple.com/source/IOHIDFamily/IOHIDFamily-700/IOHIDSystem/IOKit/hidsystem/IOLLEvent.h)
 bitflags! {
     #[repr(C)]
     pub struct CGEventFlags: u64 {

--- a/core-graphics/src/event.rs
+++ b/core-graphics/src/event.rs
@@ -12,10 +12,10 @@ pub type CGEventField = u32;
 pub type CGKeyCode = u16;
 pub type CGScrollEventUnit = u32;
 
-// Flags for events
-//
-// [Ref](http://opensource.apple.com/source/IOHIDFamily/IOHIDFamily-700/IOHIDSystem/IOKit/hidsystem/IOLLEvent.h)
 bitflags! {
+    /// Flags for events
+    ///
+    /// [Ref](http://opensource.apple.com/source/IOHIDFamily/IOHIDFamily-700/IOHIDSystem/IOKit/hidsystem/IOLLEvent.h)
     #[repr(C)]
     pub struct CGEventFlags: u64 {
         const CGEventFlagNull = 0;

--- a/core-text/src/run.rs
+++ b/core-text/src/run.rs
@@ -83,6 +83,25 @@ impl CTRun {
         }
     }
 
+    pub fn string_indices(&self) -> Cow<[CFIndex]> {
+        unsafe {
+            // CTRunGetStringIndicesPtr can return null under some not understood circumstances.
+            // If it does the Apple documentation tells us to allocate our own buffer and call
+            // CTRunGetStringIndices
+            let count = CTRunGetGlyphCount(self.0);
+            let indices_ptr = CTRunGetStringIndicesPtr(self.0);
+            if !indices_ptr.is_null() {
+                Cow::from(slice::from_raw_parts(indices_ptr, count as usize))
+            } else {
+                let mut vec = Vec::with_capacity(count as usize);
+                // "If the length of the range is set to 0, then the copy operation will continue
+                // from the start index of the range to the end of the run"
+                CTRunGetStringIndices(self.0, CFRange::init(0, 0), vec.as_mut_ptr());
+                vec.set_len(count as usize);
+                Cow::from(vec)
+            }
+        }
+    }
 }
 
 #[test]
@@ -113,6 +132,9 @@ fn create_runs() {
         assert_eq!(glyphs.len(), 4);
         assert_ne!(glyphs[0], glyphs[1]);
         assert_eq!(glyphs[1], glyphs[2]);
+
+        let indices = run.string_indices();
+        assert_eq!(indices.as_ref(), &[0, 1, 2, 3]);
     }
 }
 
@@ -123,6 +145,8 @@ extern {
     fn CTRunGetGlyphCount(run: CTRunRef) -> CFIndex;
     fn CTRunGetPositionsPtr(run: CTRunRef) -> *const CGPoint;
     fn CTRunGetPositions(run: CTRunRef, range: CFRange, buffer: *const CGPoint);
+    fn CTRunGetStringIndicesPtr(run: CTRunRef) -> *const CFIndex;
+    fn CTRunGetStringIndices(run: CTRunRef, range: CFRange, buffer: *const CFIndex);
     fn CTRunGetGlyphsPtr(run: CTRunRef) -> *const CGGlyph;
     fn CTRunGetGlyphs(run: CTRunRef, range: CFRange, buffer: *const CGGlyph);
 }


### PR DESCRIPTION
This PR adds a `CTRun::string_indices` method, which exposes CoreText's `CTRunGetStringIndices`/`CTRunGetStringIndicesPtr` API. The implementation is basically identical to `CTRun::glyphs` and `CTRun::positions`.

I added an assertion about the new method in the existing unit test.