### PR TITLE
Fix for link error - undefined CFMutableAttributedStringGetTypeID

### DIFF
--- a/core-foundation-sys/src/attributed_string.rs
+++ b/core-foundation-sys/src/attributed_string.rs
@@ -52,5 +52,4 @@ extern {
         value: CFTypeRef,
     );
 
-    pub fn CFMutableAttributedStringGetTypeID() -> CFTypeID;
 }

--- a/core-foundation/src/attributed_string.rs
+++ b/core-foundation/src/attributed_string.rs
@@ -41,7 +41,7 @@ impl CFAttributedString {
 declare_TCFType!{
     CFMutableAttributedString, CFMutableAttributedStringRef
 }
-impl_TCFType!(CFMutableAttributedString, CFMutableAttributedStringRef, CFMutableAttributedStringGetTypeID);
+impl_TCFType!(CFMutableAttributedString, CFMutableAttributedStringRef, CFAttributedStringGetTypeID);
 
 impl CFMutableAttributedString {
     #[inline]
@@ -81,5 +81,18 @@ impl CFMutableAttributedString {
 impl Default for CFMutableAttributedString {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attributed_string_type_id_comparison() {
+        // CFMutableAttributedString TypeID must be equal to CFAttributedString TypeID.
+        // Compilation must not fail.
+        assert_eq!(<CFAttributedString as TCFType>::type_id(), <CFMutableAttributedString as TCFType>::type_id());
     }
 }


### PR DESCRIPTION
## Intention
Fix for https://github.com/rust-lang/rust/issues/63047 and https://github.com/intellij-rust/intellij-rust/issues/4605


## How to reproduce
The following program fails to compile:

```rust
use core_foundation::attributed_string::{CFAttributedString, CFMutableAttributedString};
use core_foundation::base::TCFType;

fn main() {
    dbg!(<CFAttributedString as TCFType>::type_id());
    dbg!(<CFMutableAttributedString as TCFType>::type_id());
}
```

```
error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-m64" "-L" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps/foo-cef9f22f855ec251.198s3ihm7i58x886.rcgu.o" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps/foo-cef9f22f855ec251.29tmhebao6ewa0ll.rcgu.o" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps/foo-cef9f22f855ec251.2d9bu5z2mybg821y.rcgu.o" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps/foo-cef9f22f855ec251.47seajd45h5x4xvx.rcgu.o" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps/foo-cef9f22f855ec251.4m5r63z1bomeava7.rcgu.o" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps/foo-cef9f22f855ec251.dyb0rm2k46lhkz1.rcgu.o" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps/foo-cef9f22f855ec251.ux6g43y1awzd3xm.rcgu.o" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps/foo-cef9f22f855ec251.ysgemo5b5rzmi6m.rcgu.o" "-o" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps/foo-cef9f22f855ec251" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps/foo-cef9f22f855ec251.25q0sul7ku3gti43.rcgu.o" "-Wl,-dead_strip" "-nodefaultlibs" "-L" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps" "-L" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps/libcore_foundation-3b681be94f15488f.rlib" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps/liblibc-e84db2977ac0591b.rlib" "/Users/vbadanov/projects/tests/codecoverage-issue-testproject/target/debug/deps/libcore_foundation_sys-2e4eeadb22527df2.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libstd-c9ffd87d7c2bccdf.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libpanic_unwind-b6d1e628327abbae.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libhashbrown-760b1a8bb4bcc351.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/librustc_std_workspace_alloc-1660704e36532385.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libbacktrace-c11c21cbed796daf.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libbacktrace_sys-6c38e3c045a3a71f.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/librustc_demangle-5bfb7cde712ed2a9.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libunwind-4540ebf06eb7e37e.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libcfg_if-0a35227c3d306cf2.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/liblibc-c976a950e872076f.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/liballoc-ef822b0e650993e5.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/librustc_std_workspace_core-172ea43efe468d24.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libcore-4d87cbd247e9505f.rlib" "/Users/vbadanov/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libcompiler_builtins-3943751ba8f04dce.rlib" "-framework" "CoreFoundation" "-lSystem" "-lresolv" "-lc" "-lm"
  = note: Undefined symbols for architecture x86_64:
            "_CFMutableAttributedStringGetTypeID", referenced from:
                _$LT$core_foundation..attributed_string..CFMutableAttributedString$u20$as$u20$core_foundation..base..TCFType$GT$::type_id::h9f6f71bdd347aca0 in foo-cef9f22f855ec251.198s3ihm7i58x886.rcgu.o
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: aborting due to previous error
```


## Root cause
Core Foundation framework does not have `CFMutableAttributedStringGetTypeID()` function.
1. Documentation of [CFMutableAttributedString](https://developer.apple.com/documentation/corefoundation/cfmutableattributedstring-rqp) does not have function `CFMutableAttributedStringGetTypeID()` listed.
2. Documentation of [CFAttributedString](https://developer.apple.com/documentation/corefoundation/cfattributedstring-s1s) says that there is function `CFAttributedStringGetTypeID()` available (without word "Mutable").
3. Documentation of [CFAttributedStringGetTypeID()](https://developer.apple.com/documentation/corefoundation/1541715-cfattributedstringgettypeid) says the following:
    > CFMutableAttributedString objects have the same type identifier as CFAttributedString objects.
4. As a double check - there is no `CFMutableAttributedStringGetTypeID()` function in C/C++ headers on MacOS, but `CFAttributedStringGetTypeID()` is available. C/C++ test program (similar to Rust above) does not compile as well.

So, `CFAttributedStringGetTypeID()` must be used instead of `CFMutableAttributedStringGetTypeID()`


## Solution
1. In `core-foundation-sys`: Remove `extern CFMutableAttributedStringGetTypeID()`
2. In `core-foundation`: 
    * Replace `CFMutableAttributedStringGetTypeID` with `CFAttributedStringGetTypeID`
    * Add test (compilation fails before the fix and is OK after the fix)

