### PR TITLE
CFSet: Add missing methods in -sys

### DIFF
--- a/core-foundation-sys/src/set.rs
+++ b/core-foundation-sys/src/set.rs
@@ -9,7 +9,7 @@
 
 use std::os::raw::c_void;
 
-use base::{CFAllocatorRef, CFIndex, CFTypeID};
+use base::{CFAllocatorRef, CFIndex, CFTypeID, Boolean};
 
 pub type CFSetApplierFunction = extern "C" fn (value: *const c_void,
                                                context: *const c_void);
@@ -45,14 +45,22 @@ extern {
     /* Creating Sets */
     pub fn CFSetCreate(allocator: CFAllocatorRef, values: *const *const c_void, numValues: CFIndex,
                        callBacks: *const CFSetCallBacks) -> CFSetRef;
+    pub fn CFSetCreateCopy(allocator: CFAllocatorRef, theSet: CFSetRef) -> CFSetRef;
+
+    /* Examining a Set */
+    pub fn CFSetContainsValue(theSet: CFSetRef, value: *const c_void) -> Boolean;
+    pub fn CFSetGetCount(theSet: CFSetRef) -> CFIndex;
+    pub fn CFSetGetCountOfValue(theSet: CFSetRef, value: *const c_void) -> CFIndex;
+    pub fn CFSetGetValue(theSet: CFSetRef, value: *const c_void) -> *const c_void;
+    pub fn CFSetGetValueIfPresent(theSet: CFSetRef, candidate: *const c_void, value: *mut *const c_void) -> Boolean;
+    pub fn CFSetGetValues(theSet: CFSetRef, values: *mut *const c_void);
 
     /* Applying a Function to Set Members */
     pub fn CFSetApplyFunction(theSet: CFSetRef,
                               applier: CFSetApplierFunction,
                               context: *const c_void);
 
-    pub fn CFSetGetCount(theSet: CFSetRef) -> CFIndex;
-
+    /* Getting the CFSet Type ID */
     pub fn CFSetGetTypeID() -> CFTypeID;
 }
 

--- a/core-foundation/src/set.rs
+++ b/core-foundation/src/set.rs
@@ -42,3 +42,12 @@ impl CFSet {
         }
     }
 }
+
+impl<T> CFSet<T> {
+    /// Get the number of elements in the CFSet
+    pub fn len(&self) -> usize {
+        unsafe {
+            CFSetGetCount(self.0) as usize
+        }
+    }
+}


### PR DESCRIPTION
Adds a handful of missing methods from the CFSet family. 