### PR TITLE
Assert when creating a CFType from null

### DIFF
--- a/core-foundation/src/base.rs
+++ b/core-foundation/src/base.rs
@@ -243,6 +243,7 @@ impl TCFType for CFType {
 
     #[inline]
     unsafe fn wrap_under_get_rule(reference: CFTypeRef) -> CFType {
+        assert!(!reference.is_null(), "Attempted to create a NULL object.");
         let reference: CFTypeRef = CFRetain(reference);
         TCFType::wrap_under_create_rule(reference)
     }
@@ -254,6 +255,7 @@ impl TCFType for CFType {
 
     #[inline]
     unsafe fn wrap_under_create_rule(obj: CFTypeRef) -> CFType {
+        assert!(!obj.is_null(), "Attempted to create a NULL object.");
         CFType(obj)
     }
 

--- a/core-foundation/src/lib.rs
+++ b/core-foundation/src/lib.rs
@@ -95,6 +95,7 @@ macro_rules! impl_TCFType {
 
             #[inline]
             unsafe fn wrap_under_get_rule(reference: $ty_ref) -> Self {
+                assert!(!reference.is_null(), "Attempted to create a NULL object.");
                 let reference = $crate::base::CFRetain(reference as *const ::std::os::raw::c_void) as $ty_ref;
                 $crate::base::TCFType::wrap_under_create_rule(reference)
             }
@@ -106,6 +107,7 @@ macro_rules! impl_TCFType {
 
             #[inline]
             unsafe fn wrap_under_create_rule(reference: $ty_ref) -> Self {
+                assert!(!reference.is_null(), "Attempted to create a NULL object.");
                 // we need one PhantomData for each type parameter so call ourselves
                 // again with @Phantom $p to produce that
                 $ty(reference $(, impl_TCFType!(@Phantom $p))*)

--- a/core-foundation/src/propertylist.rs
+++ b/core-foundation/src/propertylist.rs
@@ -121,6 +121,7 @@ impl CFPropertyList {
 
     #[inline]
     pub unsafe fn wrap_under_get_rule(reference: CFPropertyListRef) -> CFPropertyList {
+        assert!(!reference.is_null(), "Attempted to create a NULL object.");
         let reference = CFRetain(reference);
         CFPropertyList(reference)
     }
@@ -147,6 +148,7 @@ impl CFPropertyList {
 
     #[inline]
     pub unsafe fn wrap_under_create_rule(obj: CFPropertyListRef) -> CFPropertyList {
+        assert!(!obj.is_null(), "Attempted to create a NULL object.");
         CFPropertyList(obj)
     }
 

--- a/io-surface/src/lib.rs
+++ b/io-surface/src/lib.rs
@@ -73,6 +73,7 @@ impl TCFType for IOSurface {
 
     #[inline]
     unsafe fn wrap_under_create_rule(obj: IOSurfaceRef) -> IOSurface {
+        assert!(!obj.is_null(), "Attempted to create a NULL object.");
         IOSurface {
             obj: obj,
         }
@@ -92,6 +93,7 @@ impl TCFType for IOSurface {
 
     #[inline]
     unsafe fn wrap_under_get_rule(reference: IOSurfaceRef) -> IOSurface {
+        assert!(!reference.is_null(), "Attempted to create a NULL object.");
         let reference = CFRetain(reference as *const c_void) as IOSurfaceRef;
         TCFType::wrap_under_create_rule(reference)
     }


### PR DESCRIPTION
What's the reason behind IOSurface not using `impl_TCFType`? It feels dangerous not to use it.

Fixes #361 