### PR TITLE
Add CGGradient and CGContext gradient draw functions

### DIFF
--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -12,6 +12,7 @@ use color_space::CGColorSpace;
 use core_foundation::base::{ToVoid, CFRelease, CFRetain, CFTypeID};
 use font::{CGFont, CGGlyph};
 use geometry::CGPoint;
+use gradient::{CGGradient, CGGradientDrawingOptions};
 use color::CGColor;
 use path::CGPathRef;
 use libc::{c_int, size_t};
@@ -535,6 +536,18 @@ impl CGContextRef {
             CGContextConcatCTM(self.as_ptr(), transform)
         }
     }
+
+    pub fn draw_linear_gradient(&self, gradient: &CGGradient, start_point: CGPoint, end_point: CGPoint, options: CGGradientDrawingOptions) {
+        unsafe {
+            CGContextDrawLinearGradient(self.as_ptr(), gradient.as_ptr(), start_point, end_point, options);
+        }
+    }
+
+    pub fn draw_radial_gradient(&self, gradient: &CGGradient, start_center: CGPoint, start_radius: CGFloat, end_center: CGPoint, end_radius: CGFloat, options: CGGradientDrawingOptions) {
+        unsafe {
+            CGContextDrawRadialGradient(self.as_ptr(), gradient.as_ptr(), start_center, start_radius, end_center, end_radius, options);
+        }
+    }
 }
 
 #[test]
@@ -681,5 +694,8 @@ extern {
     fn CGContextRotateCTM(c: ::sys::CGContextRef, angle: CGFloat);
     fn CGContextGetCTM(c: ::sys::CGContextRef) -> CGAffineTransform;
     fn CGContextConcatCTM(c: ::sys::CGContextRef, transform: CGAffineTransform);
+
+    fn CGContextDrawLinearGradient(c: ::sys::CGContextRef, gradient: ::sys::CGGradientRef, startPoint: CGPoint, endPoint: CGPoint, options: CGGradientDrawingOptions);
+    fn CGContextDrawRadialGradient(c: ::sys::CGContextRef, gradient: ::sys::CGGradientRef,  startCenter: CGPoint, startRadius: CGFloat, endCenter:CGPoint, endRadius:CGFloat, options: CGGradientDrawingOptions);
 }
 

--- a/core-graphics/src/gradient.rs
+++ b/core-graphics/src/gradient.rs
@@ -1,0 +1,62 @@
+// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(non_upper_case_globals)]
+
+use base::CGFloat;
+use color::CGColor;
+use color_space::CGColorSpace;
+
+use core_foundation::array::{ CFArray, CFArrayRef };
+use core_foundation::base::{CFRelease, CFRetain, TCFType};
+use foreign_types::ForeignType;
+
+use libc::size_t;
+
+bitflags! {
+    #[repr(C)]
+    pub struct CGGradientDrawingOptions: u32 {
+        const CGGradientDrawsBeforeStartLocation = (1 << 0);
+        const CGGradientDrawsAfterEndLocation = (1 << 1);
+    }
+}
+
+foreign_type! {
+    #[doc(hidden)]
+    type CType = ::sys::CGGradient;
+    fn drop = |p| CFRelease(p as *mut _);
+    fn clone = |p| CFRetain(p as *const _) as *mut _;
+    pub struct CGGradient;
+    pub struct CGGradientRef;
+}
+
+impl CGGradient {
+    pub fn create_with_color_components(color_space: &CGColorSpace, components: &[CGFloat], locations: &[CGFloat], count: usize) -> CGGradient {
+        unsafe {
+            let result = CGGradientCreateWithColorComponents(color_space.as_ptr(), components.as_ptr(), locations.as_ptr(), count);
+            assert!(!result.is_null());
+            Self::from_ptr(result)
+        }
+    }
+
+    pub fn create_with_colors(color_space: &CGColorSpace, colors: &CFArray<CGColor>, locations: &[CGFloat]) -> CGGradient {
+        unsafe {
+            let result = CGGradientCreateWithColors(color_space.as_ptr(), colors.as_concrete_TypeRef(), locations.as_ptr());
+            assert!(!result.is_null());
+            Self::from_ptr(result)
+        }
+    }
+}
+
+#[link(name = "CoreGraphics", kind = "framework")]
+extern {
+    fn CGGradientCreateWithColorComponents(color_space: ::sys::CGColorSpaceRef, components: *const CGFloat, locations: *const CGFloat, count: size_t) -> ::sys::CGGradientRef;
+    fn CGGradientCreateWithColors(color_space: ::sys::CGColorSpaceRef, colors: CFArrayRef, locations: *const CGFloat) -> ::sys::CGGradientRef;
+}
+

--- a/core-graphics/src/lib.rs
+++ b/core-graphics/src/lib.rs
@@ -32,6 +32,7 @@ pub mod event;
 pub mod event_source;
 pub mod font;
 pub mod geometry;
+pub mod gradient;
 #[cfg(target_os = "macos")]
 pub mod window;
 #[cfg(target_os = "macos")]

--- a/core-graphics/src/sys.rs
+++ b/core-graphics/src/sys.rs
@@ -23,6 +23,9 @@ pub type CGFontRef = *mut CGFont;
 pub enum CGContext {}
 pub type CGContextRef = *mut CGContext;
 
+pub enum CGGradient {}
+pub type CGGradientRef = *mut CGGradient;
+
 #[cfg(target_os = "macos")]
 mod macos {
 	pub enum CGEvent {}


### PR DESCRIPTION
This PR adds the following missing APIs:
- Added [CGGradient](https://developer.apple.com/documentation/coregraphics/cggradient) in the `core_graphics::gradient` module.
- Added [CGContextDrawLinearGradient](https://developer.apple.com/documentation/coregraphics/1454782-cgcontextdrawlineargradient) and [CGContextDrawRadialGradient](https://developer.apple.com/documentation/coregraphics/1455923-cgcontextdrawradialgradient) in the `core_graphics::context` module.