### PR TITLE
Add missing APIs to CTLine

### DIFF
--- a/core-foundation-sys/src/base.rs
+++ b/core-foundation-sys/src/base.rs
@@ -107,6 +107,9 @@ impl<T> TCFTypeRef for *mut T {
     }
 }
 
+/// Constant used by some functions to indicate failed searches.
+pub static kCFNotFound: CFIndex = -1;
+
 extern {
     /*
      * CFBase.h

--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -66,6 +66,7 @@ pub enum CGTextDrawingMode {
     CGTextInvisible,
     CGTextFillClip,
     CGTextStrokeClip,
+    CGTextFillStrokeClip,
     CGTextClip
 }
 
@@ -484,6 +485,12 @@ impl CGContextRef {
         }
     }
 
+    pub fn set_text_position(&self, x: CGFloat, y: CGFloat) {
+        unsafe {
+            CGContextSetTextPosition(self.as_ptr(), x, y)
+        }
+    }
+
     pub fn show_glyphs_at_positions(&self, glyphs: &[CGGlyph], positions: &[CGPoint]) {
         unsafe {
             let count = cmp::min(glyphs.len(), positions.len());
@@ -669,6 +676,7 @@ extern {
     fn CGContextSetFont(c: ::sys::CGContextRef, font: ::sys::CGFontRef);
     fn CGContextSetFontSize(c: ::sys::CGContextRef, size: CGFloat);
     fn CGContextSetTextMatrix(c: ::sys::CGContextRef, t: CGAffineTransform);
+    fn CGContextSetTextPosition(c: ::sys::CGContextRef, x: CGFloat, y: CGFloat);
     fn CGContextShowGlyphsAtPositions(c: ::sys::CGContextRef,
                                       glyphs: *const CGGlyph,
                                       positions: *const CGPoint,

--- a/core-graphics/src/lib.rs
+++ b/core-graphics/src/lib.rs
@@ -38,4 +38,4 @@ pub mod window;
 pub mod private;
 pub mod image;
 pub mod path;
-mod sys;
+pub mod sys;

--- a/core-text/src/line.rs
+++ b/core-text/src/line.rs
@@ -10,7 +10,11 @@
 use std::os::raw::c_void;
 use core_foundation::attributed_string::CFAttributedStringRef;
 use core_foundation::array::{CFArray, CFArrayRef};
-use core_foundation::base::{CFTypeID, TCFType};
+use core_foundation::base::{CFIndex, CFTypeID, TCFType};
+use core_graphics::base::{CGFloat};
+use core_graphics::context::{CGContext};
+use core_graphics::geometry::{CGPoint,CGRect};
+use foreign_types::{ForeignType};
 use run::CTRun;
 
 #[repr(C)]
@@ -37,11 +41,47 @@ impl CTLine {
             TCFType::wrap_under_get_rule(CTLineGetGlyphRuns(self.0))
         }
     }
+
+    pub fn draw(&self, context: &CGContext) {
+        unsafe {
+            CTLineDraw(self.as_concrete_TypeRef(), context.as_ptr())
+        }
+    }
+
+    pub fn get_image_bounds(&self, context: &CGContext) -> CGRect {
+        unsafe {
+            CTLineGetImageBounds(self.as_concrete_TypeRef(), context.as_ptr())
+        }
+    }
+
+    pub fn get_string_index_for_position(&self, position: CGPoint) -> CFIndex {
+        unsafe {
+            CTLineGetStringIndexForPosition(self.as_concrete_TypeRef(), position)
+        }
+    }
+
+    pub fn get_string_offset_for_string_index(&self, charIndex: CFIndex) -> CGFloat {
+        unsafe {
+            CTLineGetOffsetForStringIndex(self.as_concrete_TypeRef(), charIndex, std::ptr::null())
+        }
+    }
 }
 
 #[link(name = "CoreText", kind = "framework")]
 extern {
     fn CTLineGetTypeID() -> CFTypeID;
     fn CTLineGetGlyphRuns(line: CTLineRef) -> CFArrayRef;
+
+    // Creating Lines
     fn CTLineCreateWithAttributedString(string: CFAttributedStringRef) -> CTLineRef;
+
+    // Drawing the Line
+    fn CTLineDraw(line: CTLineRef, context: * const core_graphics::sys::CGContext);
+
+    // Measuring Lines
+    fn CTLineGetImageBounds(line: CTLineRef, context: * const core_graphics::sys::CGContext) -> CGRect;
+
+    // Getting Line Positioning
+    fn CTLineGetStringIndexForPosition(line: CTLineRef, position: CGPoint) -> CFIndex;
+    fn CTLineGetOffsetForStringIndex(line: CTLineRef, charIndex: CFIndex, secondaryOffset: *const CGFloat) -> CGFloat;
 }


### PR DESCRIPTION
Added the following missing APIs to [CTLine](https://developer.apple.com/documentation/coretext/ctline):
- CTLineDraw
- CTLineGetImageBounds
- CTLineGetStringIndexForPosition
- CTLineGetOffsetForStringIndex

Added `CGContextSetTextPosition` to `CGContext`.

Added `CGTextFillStrokeClip` to `CGTextDrawingMode`.