### PR TITLE
Change CFMutableAttributedString::set_attribute argument type

### DIFF
--- a/core-foundation/src/attributed_string.rs
+++ b/core-foundation/src/attributed_string.rs
@@ -70,7 +70,7 @@ impl CFMutableAttributedString {
     }
 
     #[inline]
-    pub fn set_attribute<T: TCFType>(&mut self, range: CFRange, name: CFStringRef, value: T) {
+    pub fn set_attribute<T: TCFType>(&mut self, range: CFRange, name: CFStringRef, value: &T) {
         unsafe {
             CFAttributedStringSetAttribute(
                 self.0, range, name, value.as_CFTypeRef());

--- a/core-text/src/run.rs
+++ b/core-text/src/run.rs
@@ -114,7 +114,7 @@ fn create_runs() {
     string.replace_str(&CFString::new("Food"), CFRange::init(0, 0));
     let len = string.char_len();
     unsafe {
-        string.set_attribute(CFRange::init(0, len), kCTFontAttributeName, font::new_from_name("Helvetica", 16.).unwrap());
+        string.set_attribute(CFRange::init(0, len), kCTFontAttributeName, &font::new_from_name("Helvetica", 16.).unwrap());
     }
     let line = CTLine::new_with_attributed_string(string.as_concrete_TypeRef());
     let runs = line.glyph_runs();


### PR DESCRIPTION
Type of the argument `value` can be a reference as opposed to requiring the value's ownership.