### PR TITLE
Test 64-bit NSNumbers

### DIFF
--- a/core-foundation/src/propertylist.rs
+++ b/core-foundation/src/propertylist.rs
@@ -262,7 +262,7 @@ pub mod test {
         let boo = CFString::from_static_string("Boo");
         let foo = CFString::from_static_string("Foo");
         let tru = CFBoolean::true_value();
-        let n42 = CFNumber::from(42);
+        let n42 = CFNumber::from(1i64<<33);
 
         let dict1 = CFDictionary::from_CFType_pairs(&[(bar.as_CFType(), boo.as_CFType()),
                                                       (baz.as_CFType(), tru.as_CFType()),


### PR DESCRIPTION
on macOS 10.15.5 Beta the property list tests fails, because dictionary serializes a 32-bit NSNumber, but property list deserializes it to a 64-bit NSNumber. Apparently, they make dictionaries not equal, even though numeric value is the same!

Here's a workaround that forces the NSNumber to be 64-bit.