### PR TITLE
Add CTFrame::get_lines and related methods

### DIFF
--- a/core-text/src/frame.rs
+++ b/core-text/src/frame.rs
@@ -9,8 +9,10 @@
 
 use std::os::raw::c_void;
 use core_foundation::base::{CFTypeID, TCFType};
+use core_foundation::array::{CFArrayRef, CFArray};
 use core_graphics::context::{CGContext, CGContextRef};
 use foreign_types::{ForeignType, ForeignTypeRef};
+use crate::line::CTLine;
 
 #[repr(C)]
 pub struct __CTFrame(c_void);
@@ -24,6 +26,18 @@ impl_TCFType!(CTFrame, CTFrameRef, CTFrameGetTypeID);
 impl_CFTypeDescription!(CTFrame);
 
 impl CTFrame {
+    /// Returns an owned copy of the underlying lines.
+    ///
+    /// Each line is retained, and will remain valid past the life of this `CTFrame`.
+    pub fn get_lines(&self) -> Vec<CTLine> {
+        unsafe {
+            let array_ref = CTFrameGetLines(self.as_concrete_TypeRef());
+            // not strictly correct but saves an unnecessary retain call
+            let array: CFArray<CTLine> = CFArray::wrap_under_create_rule(array_ref);
+            array.iter().map(|l| CTLine::wrap_under_get_rule(l.as_concrete_TypeRef())).collect()
+        }
+    }
+
     pub fn draw(&self, context: &CGContextRef) {
         unsafe {
             CTFrameDraw(self.as_concrete_TypeRef(), context.as_ptr());
@@ -34,5 +48,6 @@ impl CTFrame {
 #[link(name = "CoreText", kind = "framework")]
 extern {
     fn CTFrameGetTypeID() -> CFTypeID;
+    fn CTFrameGetLines(frame: CTFrameRef) -> CFArrayRef;
     fn CTFrameDraw(frame: CTFrameRef, context: *mut <CGContext as ForeignType>::CType);
 }


### PR DESCRIPTION
This is a bit unsatisfactory; there doesn't seem to be a memory safe
way to get access to the lines without an intermediate allocation.

As a compromise, this adds API for also checking the number of lines
in the frame, and getting a single line safely.