### PR TITLE
Bump cocoa to 0.20.1

### DIFF
--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -4,7 +4,7 @@ name = "cocoa"
 description = "Bindings to Cocoa for macOS"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 


### PR DESCRIPTION
The new operating system version and user defaults APIs have been recently added by @casperstorm, so I'd like to propose releasing a new version with those features included.

There hasn't been a version in a bit, so I think it should be fine to create a new non-breaking release, as long as there are no other things currently in the pipeline. It seems like #359 and #363 are both unrelated to cocoa, but maybe #355 can be easily merged before this?