### PR TITLE
Build cocoa docs for docs.rs on macOS

### DIFF
--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -8,6 +8,9 @@ version = "0.20.1"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 
+[package.metadata.docs.rs]
+default-target = "x86_64-apple-darwin"
+
 [dependencies]
 block = "0.1"
 bitflags = "1.0"


### PR DESCRIPTION
I'm not sure that this will work, but I don't know how to test it locally.  https://docs.rs/about#metadata says that this will cause the package to be built on macOS.