### PR TITLE
Fix build on iOS

### DIFF
--- a/core-graphics/src/lib.rs
+++ b/core-graphics/src/lib.rs
@@ -13,7 +13,6 @@ extern crate libc;
 extern crate core_foundation;
 
 #[macro_use]
-#[cfg(target_os = "macos")]
 extern crate bitflags;
 
 #[macro_use]


### PR DESCRIPTION
#365 broke iOS, since `bitflags` was used despite `bitflags` only being included on macOS. Since it looks like the `CGGradient` API is supported on iOS as well, I fixed this by just removing the `#[cfg(target_os = "macos")]` line on `extern crate bitflags`.

If I made a follow-up PR that adds iOS to CI, would that be welcome?