### PR TITLE
Add `CFTimeZone::name`

### DIFF
--- a/core-foundation-sys/src/timezone.rs
+++ b/core-foundation-sys/src/timezone.rs
@@ -11,6 +11,7 @@ use std::os::raw::c_void;
 
 use base::{CFAllocatorRef, CFTypeID};
 use date::{CFTimeInterval, CFAbsoluteTime};
+use string::CFStringRef;
 
 #[repr(C)]
 pub struct __CFTimeZone(c_void);
@@ -24,4 +25,5 @@ extern {
     pub fn CFTimeZoneGetSecondsFromGMT(tz: CFTimeZoneRef, time: CFAbsoluteTime) -> CFTimeInterval;
 
     pub fn CFTimeZoneGetTypeID() -> CFTypeID;
+    pub fn CFTimeZoneGetName(tz: CFTimeZoneRef) -> CFStringRef;
 }

--- a/core-foundation/src/timezone.rs
+++ b/core-foundation/src/timezone.rs
@@ -14,6 +14,7 @@ use core_foundation_sys::base::kCFAllocatorDefault;
 
 use base::TCFType;
 use date::{CFDate, CFTimeInterval};
+use string::CFString;
 
 #[cfg(feature = "with-chrono")]
 use chrono::{FixedOffset, NaiveDateTime};
@@ -67,6 +68,14 @@ impl CFTimeZone {
     #[cfg(feature = "with-chrono")]
     pub fn from_offset(offset: FixedOffset) -> CFTimeZone {
         CFTimeZone::new(offset.local_minus_utc() as f64)
+    }
+
+    /// The timezone database ID that identifies the time zone. E.g. "America/Los_Angeles" or
+    /// "Europe/Paris".
+    pub fn name(&self) -> CFString {
+        unsafe {
+            CFString::wrap_under_get_rule(CFTimeZoneGetName(self.0))
+        }
     }
 }
 


### PR DESCRIPTION
Add a `name` method to `CFTimeZone` to get the time zone ID (e.g.,
"America/Los_Angeles") of the current time zone.

Core Foundation calls this "name" instead of "id" in its method
signatures, but acknowledges it in the closely-related NSTimeZone
related docs. Since most of the other methods in this library match
closely with CF naming, also use `name` here.

> Time zone database entries such as “America/Los_Angeles” are IDs, not
> names. An example of a time zone name is “Pacific Daylight Time”.
> Although many NSTimeZone symbols include the word “name”, they
> actually refer to IDs.