### PR TITLE
Use wrap_under_get_rule where expected

### DIFF
--- a/core-text/src/frame.rs
+++ b/core-text/src/frame.rs
@@ -41,8 +41,7 @@ impl CTFrame {
     pub fn get_lines(&self) -> Vec<CTLine> {
         unsafe {
             let array_ref = CTFrameGetLines(self.as_concrete_TypeRef());
-            // not strictly correct but saves an unnecessary retain call
-            let array: CFArray<CTLine> = CFArray::wrap_under_create_rule(array_ref);
+            let array: CFArray<CTLine> = CFArray::wrap_under_get_rule(array_ref);
             array.iter().map(|l| CTLine::wrap_under_get_rule(l.as_concrete_TypeRef())).collect()
         }
     }
@@ -64,7 +63,7 @@ impl CTFrame {
             // range length of 0 means 'all remaining lines'
             0 => unsafe {
                 let array_ref = CTFrameGetLines(self.as_concrete_TypeRef());
-                let array: CFArray<CTLine> = CFArray::wrap_under_create_rule(array_ref);
+                let array: CFArray<CTLine> = CFArray::wrap_under_get_rule(array_ref);
                 array.len() - range.location
             }
             n => n,


### PR DESCRIPTION
I had initially thought I could skip a retain in these cases since
we can trivially track the lifetime of the reference, but I ran into
a segfault in a test that used the empty string, which I tracked
down to here.

I'm not totally sure what's actually going on under the hood, but I
do know that this fixes my crash and also that I was being overly
clever anyway.