### PR TITLE
Publish core-text 18.0.1.

### DIFF
--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "18.0.0"
+version = "18.0.1"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This incorporates #399.