### PR TITLE
Fix docs.rs build

### DIFF
--- a/core-foundation-sys/Cargo.toml
+++ b/core-foundation-sys/Cargo.toml
@@ -13,3 +13,6 @@ build = "build.rs"
 [features]
 mac_os_10_7_support = [] # backwards compatibility
 mac_os_10_8_features = [] # enables new features
+
+[package.metadata.docs.rs]
+default-target = "x86_64-apple-darwin"

--- a/core-foundation/Cargo.toml
+++ b/core-foundation/Cargo.toml
@@ -23,3 +23,6 @@ mac_os_10_7_support = ["core-foundation-sys/mac_os_10_7_support"] # backwards co
 mac_os_10_8_features = ["core-foundation-sys/mac_os_10_8_features"] # enables new features
 with-chrono = ["chrono"]
 with-uuid = ["uuid"]
+
+[package.metadata.docs.rs]
+default-target = "x86_64-apple-darwin"

--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -12,3 +12,6 @@ bitflags = "1.0"
 core-foundation = { path = "../core-foundation", version = "0.9" }
 foreign-types = "0.3.0"
 libc = "0.2"
+
+[package.metadata.docs.rs]
+default-target = "x86_64-apple-darwin"

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -18,3 +18,6 @@ core-foundation = { path = "../core-foundation", version = "0.9" }
 core-graphics-types = { path = "../core-graphics-types", version = "0.1" }
 foreign-types = "0.3.0"
 libc = "0.2"
+
+[package.metadata.docs.rs]
+default-target = "x86_64-apple-darwin"


### PR DESCRIPTION
docs.rs fails to build `core-graphics`. This adds metadata to let it know to build on an Apple platform.