### PR TITLE
add `CFNumberGetType` to determine specific number type

### DIFF
--- a/core-foundation-sys/src/number.rs
+++ b/core-foundation-sys/src/number.rs
@@ -57,4 +57,5 @@ extern {
     pub fn CFNumberGetValue(number: CFNumberRef, theType: CFNumberType, valuePtr: *mut c_void) -> bool;
     pub fn CFNumberCompare(date: CFNumberRef, other: CFNumberRef, context: *mut c_void) -> CFComparisonResult;
     pub fn CFNumberGetTypeID() -> CFTypeID;
+    pub fn CFNumberGetType(number: CFNumberRef) -> CFNumberType;
 }


### PR DESCRIPTION
this PR adds support for `CFNumberGetType` that is needed if there is a `CFNumberRef` and it is not clear what sort of number it is.

Now it would be possible to do such a thing:

```rust
let type_id = unsafe { CFNumberGetType(value) };
match type_id {
    si64 if si64 == kCFNumberSInt64Type => {},
    si32 if si32 == kCFNumberSInt32Type => {},
    _ => {},
}
```
