### PR TITLE
feat(CFNumber): change `CFNumberType` from static to const, to improve match expression ergonomics

### DIFF
--- a/core-foundation-sys/src/number.rs
+++ b/core-foundation-sys/src/number.rs
@@ -19,23 +19,23 @@ pub type CFBooleanRef = *const __CFBoolean;
 pub type CFNumberType = u32;
 
 // members of enum CFNumberType
-// static kCFNumberSInt8Type:     CFNumberType = 1;
-// static kCFNumberSInt16Type:    CFNumberType = 2;
-pub static kCFNumberSInt32Type:    CFNumberType = 3;
-pub static kCFNumberSInt64Type:    CFNumberType = 4;
-pub static kCFNumberFloat32Type:   CFNumberType = 5;
-pub static kCFNumberFloat64Type:   CFNumberType = 6;
-// static kCFNumberCharType:      CFNumberType = 7;
-// static kCFNumberShortType:     CFNumberType = 8;
-// static kCFNumberIntType:       CFNumberType = 9;
-// static kCFNumberLongType:      CFNumberType = 10;
-// static kCFNumberLongLongType:  CFNumberType = 11;
-// static kCFNumberFloatType:     CFNumberType = 12;
-// static kCFNumberDoubleType:    CFNumberType = 13;
-// static kCFNumberCFIndexType:   CFNumberType = 14;
-// static kCFNumberNSIntegerType: CFNumberType = 15;
-// static kCFNumberCGFloatType:   CFNumberType = 16;
-// static kCFNumberMaxType:       CFNumberType = 16;
+pub const kCFNumberSInt8Type:     CFNumberType = 1;
+pub const kCFNumberSInt16Type:    CFNumberType = 2;
+pub const kCFNumberSInt32Type:    CFNumberType = 3;
+pub const kCFNumberSInt64Type:    CFNumberType = 4;
+pub const kCFNumberFloat32Type:   CFNumberType = 5;
+pub const kCFNumberFloat64Type:   CFNumberType = 6;
+pub const kCFNumberCharType:      CFNumberType = 7;
+pub const kCFNumberShortType:     CFNumberType = 8;
+pub const kCFNumberIntType:       CFNumberType = 9;
+pub const kCFNumberLongType:      CFNumberType = 10;
+pub const kCFNumberLongLongType:  CFNumberType = 11;
+pub const kCFNumberFloatType:     CFNumberType = 12;
+pub const kCFNumberDoubleType:    CFNumberType = 13;
+pub const kCFNumberCFIndexType:   CFNumberType = 14;
+pub const kCFNumberNSIntegerType: CFNumberType = 15;
+pub const kCFNumberCGFloatType:   CFNumberType = 16;
+pub const kCFNumberMaxType:       CFNumberType = 16;
 
 // This is an enum due to zero-sized types warnings.
 // For more details see https://github.com/rust-lang/rust/issues/27303
@@ -57,4 +57,25 @@ extern {
     pub fn CFNumberGetValue(number: CFNumberRef, theType: CFNumberType, valuePtr: *mut c_void) -> bool;
     pub fn CFNumberCompare(date: CFNumberRef, other: CFNumberRef, context: *mut c_void) -> CFComparisonResult;
     pub fn CFNumberGetTypeID() -> CFTypeID;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn match_for_type_id_should_be_backwards_compatible() {
+        let type_id = kCFNumberFloat32Type;
+        // this is the old style of matching for static variables
+        match type_id {
+            vf64 if vf64 == kCFNumberFloat32Type => assert!(true),
+            _ => panic!("should not happen"),
+        };
+
+        // this is new new style of matching for consts
+        match type_id {
+            kCFNumberFloat32Type => assert!(true),
+            _ => panic!("should not happen"),
+        };
+    }
 }


### PR DESCRIPTION
this PR changes the `CFNumberType` values like `kCFNumberSInt64Type` from `static` to `const`.

That way it is possible to simplify match expressions like this:

before:
```rust
let type_id = unsafe { CFNumberGetType(value) };
match type_id {
    si64 if si64 == kCFNumberSInt64Type => {},
    si32 if si32 == kCFNumberSInt32Type => {},
    _ => {},
}
```

after:
```rust
let type_id = unsafe { CFNumberGetType(value) };
match type_id {
    kCFNumberSInt64Type => {},
    kCFNumberSInt32Type => {},
    _ => {},
}
```

Note: function call `CFNumberGetType(value)` is implemented in PR #411

