### PR TITLE
feat(CFBoolean): add function `CFBooleanGetValue` to retrieve a value of a `CFBooleanRef`

### DIFF
--- a/core-foundation-sys/src/number.rs
+++ b/core-foundation-sys/src/number.rs
@@ -51,6 +51,8 @@ extern {
     pub static kCFBooleanFalse: CFBooleanRef;
 
     pub fn CFBooleanGetTypeID() -> CFTypeID;
+    pub fn CFBooleanGetValue(boolean: CFBooleanRef) -> bool;
+
     pub fn CFNumberCreate(allocator: CFAllocatorRef, theType: CFNumberType, valuePtr: *const c_void)
                           -> CFNumberRef;
     //fn CFNumberGetByteSize


### PR DESCRIPTION
This PR adds the function `CFBooleanGetValue` that gets the bool value by a `CFBooleanRef`
