### PR TITLE
Adds function for fetching ID of a core_graphics::display::CGDisplayMode

### DIFF
--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -608,6 +608,10 @@ impl CGDisplayMode {
             0
         }
     }
+
+    pub fn mode_id(&self) -> i32 {
+        unsafe { CGDisplayModeGetIODisplayModeID(self.as_ptr()) }
+    }
 }
 
 #[link(name = "CoreGraphics", kind = "framework")]
@@ -686,6 +690,7 @@ extern "C" {
     pub fn CGDisplayModeGetRefreshRate(mode: ::sys::CGDisplayModeRef) -> libc::c_double;
     pub fn CGDisplayModeGetIOFlags(mode: ::sys::CGDisplayModeRef) -> u32;
     pub fn CGDisplayModeCopyPixelEncoding(mode: ::sys::CGDisplayModeRef) -> CFStringRef;
+    pub fn CGDisplayModeGetIODisplayModeID(mode: ::sys::CGDisplayModeRef) -> i32;
 
     pub fn CGDisplayCopyAllDisplayModes(
         display: CGDirectDisplayID,


### PR DESCRIPTION
This adds a `mode_id()` function on `CGDisplayMode` which returns the unique (to that display) integer ID the system uses to identify the display mode. It internally calls down to `CGDisplayModeGetIODisplayModeID()` in the CoreGraphics framework. The FFI for this function was previously missing and has also been added.