### PR TITLE
Add NSSavePanel binding

### DIFF
--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -1786,7 +1786,36 @@ pub enum NSModalResponse {
     NSModalResponseCancel = 0,
 }
 
-pub trait NSOpenPanel: Sized {
+pub trait NSSavePanel: Sized {
+    unsafe fn savePanel(_: Self) -> id {
+        msg_send![class!(NSSavePanel), savePanel]
+    }
+
+    unsafe fn setDirectoryURL(self, url: id);
+    unsafe fn setCanCreateDirectories(self, canCreateDirectories: BOOL);
+    unsafe fn URL(self) -> id;
+    unsafe fn runModal(self) -> NSModalResponse;
+}
+
+impl NSSavePanel for id {
+    unsafe fn setDirectoryURL(self, url: id) {
+        msg_send![self, setDirectoryURL: url]
+    }
+
+    unsafe fn setCanCreateDirectories(self, canCreateDirectories: BOOL) {
+        msg_send![self, setCanCreateDirectories: canCreateDirectories]
+    }
+
+    unsafe fn URL(self) -> id {
+        msg_send![self, URL]
+    }
+
+    unsafe fn runModal(self) -> NSModalResponse {
+        msg_send![self, runModal]
+    }
+}
+
+pub trait NSOpenPanel: NSSavePanel {
     unsafe fn openPanel(_: Self) -> id {
         msg_send![class!(NSOpenPanel), openPanel]
     }
@@ -1796,7 +1825,6 @@ pub trait NSOpenPanel: Sized {
     unsafe fn setResolvesAliases_(self, resolvesAliases: BOOL);
     unsafe fn setAllowsMultipleSelection_(self, allowsMultipleSelection: BOOL);
     unsafe fn URLs(self) -> id;
-    unsafe fn runModal(self) -> NSModalResponse;
 }
 
 impl NSOpenPanel for id {
@@ -1818,10 +1846,6 @@ impl NSOpenPanel for id {
 
     unsafe fn URLs(self) -> id {
         msg_send![self, URLs]
-    }
-
-    unsafe fn runModal(self) -> NSModalResponse {
-        msg_send![self, runModal]
     }
 }
 


### PR DESCRIPTION
This PR adds bindings to some basic `NSSavePanel` APIs. In Cocoa, `NSSavePanel` is a superclass of `NSOpenPanel`, which I added bindings for in #454.

Example:

```rust
let panel = NSSavePanel::savePanel(nil);
panel.setDirectoryURL(the_url);
let response = panel.runModal();
if response == NSModalResponse::NSModalResponseOk {
    let url_ptr = panel.URL().absoluteString().UTF8String();
    let url = CStr::from_ptr(url_ptr).to_string_lossy();
    eprintln!("You picked URL {}", url);
}

```