### PR TITLE
foundation: add bundleIdentifier and resourcePath properties

### DIFF
--- a/cocoa-foundation/src/foundation.rs
+++ b/cocoa-foundation/src/foundation.rs
@@ -1100,6 +1100,10 @@ pub trait NSBundle: Sized {
                                           name: id /* NSString */,
                                           owner: id,
                                           topLevelObjects: *mut id /* NSArray */) -> BOOL;
+
+    unsafe fn bundleIdentifier(self) -> id /* NSString */;
+
+    unsafe fn resourcePath(self) -> id /* NSString */;
 }
 
 impl NSBundle for id {
@@ -1114,6 +1118,14 @@ impl NSBundle for id {
         msg_send![self, loadNibNamed:name
                                owner:owner
                      topLevelObjects:topLevelObjects]
+    }
+
+    unsafe fn bundleIdentifier(self) -> id /* NSString */ {
+        msg_send![self, bundleIdentifier]
+    }
+
+    unsafe fn resourcePath(self) -> id /* NSString */ {
+        msg_send![self, resourcePath]
     }
 }
 


### PR DESCRIPTION
Adds the bundleIdentifier and resourcePath properties to the NSBundle
bindings