### PR TITLE
Added missing macOS 10.6+ IOSurface functions

### DIFF
--- a/io-surface/Cargo.toml
+++ b/io-surface/Cargo.toml
@@ -13,5 +13,6 @@ default-target = "x86_64-apple-darwin"
 [dependencies]
 libc = "0.2"
 core-foundation = { path = "../core-foundation", version = "0.9" }
+core-foundation-sys = { path = "../core-foundation-sys", version = "0.8" }
 cgl = "0.3"
 leaky-cow = "0.1.1"


### PR DESCRIPTION
This adds a few `sys` entry points for IOSurface functions.

I also made those public, so that code outside the IOSurface module can call and use them. I didn't add "rusty" wrappers as most of these functions are likely to be used in unsafe contexts anyway.

I limited this to all functions supported in macOS 10.6.