### PR TITLE
Add ProcessInfo.systemUptime implementation

### DIFF
--- a/cocoa-foundation/src/foundation.rs
+++ b/cocoa-foundation/src/foundation.rs
@@ -242,7 +242,7 @@ impl NSProcessInfo for id {
         msg_send![self, processName]
     }
 
-    unsafe fn uptime(self) -> NSTimeInterval {
+    unsafe fn systemUptime(self) -> NSTimeInterval {
         msg_send![self, systemUptime]
     }
 

--- a/cocoa-foundation/src/foundation.rs
+++ b/cocoa-foundation/src/foundation.rs
@@ -229,9 +229,7 @@ pub trait NSProcessInfo: Sized {
         msg_send![class!(NSProcessInfo), processInfo]
     }
 
-    unsafe fn systemUptime(_: Self) -> NSTimeInterval {
-        msg_send![class!(NSProcessInfo), systemUptime]
-    }
+    unsafe fn systemUptime(_: Self) -> NSTimeInterval;
 
     unsafe fn processName(self) -> id;
     unsafe fn uptime(self) -> NSTimeInterval;

--- a/cocoa-foundation/src/foundation.rs
+++ b/cocoa-foundation/src/foundation.rs
@@ -229,7 +229,12 @@ pub trait NSProcessInfo: Sized {
         msg_send![class!(NSProcessInfo), processInfo]
     }
 
+    unsafe fn systemUptime(_: Self) -> NSTimeInterval {
+        msg_send![class!(NSProcessInfo), systemUptime]
+    }
+
     unsafe fn processName(self) -> id;
+    unsafe fn uptime(self) -> NSTimeInterval;
     unsafe fn operatingSystemVersion(self) -> NSOperatingSystemVersion;
     unsafe fn isOperatingSystemAtLeastVersion(self, version: NSOperatingSystemVersion) -> bool;
 }
@@ -237,6 +242,10 @@ pub trait NSProcessInfo: Sized {
 impl NSProcessInfo for id {
     unsafe fn processName(self) -> id {
         msg_send![self, processName]
+    }
+
+    unsafe fn uptime(self) -> NSTimeInterval {
+        msg_send![self, systemUptime]
     }
 
     unsafe fn operatingSystemVersion(self) -> NSOperatingSystemVersion {

--- a/cocoa-foundation/src/foundation.rs
+++ b/cocoa-foundation/src/foundation.rs
@@ -229,7 +229,7 @@ pub trait NSProcessInfo: Sized {
         msg_send![class!(NSProcessInfo), processInfo]
     }
 
-    unsafe fn systemUptime(_: Self) -> NSTimeInterval;
+    unsafe fn systemUptime(self) -> NSTimeInterval;
     unsafe fn processName(self) -> id;
     unsafe fn operatingSystemVersion(self) -> NSOperatingSystemVersion;
     unsafe fn isOperatingSystemAtLeastVersion(self, version: NSOperatingSystemVersion) -> bool;

--- a/cocoa-foundation/src/foundation.rs
+++ b/cocoa-foundation/src/foundation.rs
@@ -230,9 +230,7 @@ pub trait NSProcessInfo: Sized {
     }
 
     unsafe fn systemUptime(_: Self) -> NSTimeInterval;
-
     unsafe fn processName(self) -> id;
-    unsafe fn uptime(self) -> NSTimeInterval;
     unsafe fn operatingSystemVersion(self) -> NSOperatingSystemVersion;
     unsafe fn isOperatingSystemAtLeastVersion(self, version: NSOperatingSystemVersion) -> bool;
 }


### PR DESCRIPTION
Hello,

Added [NSProcessInfo.systemUptime](https://developer.apple.com/documentation/foundation/processinfo/1414553-systemuptime) implementation, successfully tested on iOS.
Feel free to merge.

Best,