### PR TITLE
Add get_matrix to core text font

### DIFF
--- a/core-text/src/font.rs
+++ b/core-text/src/font.rs
@@ -395,6 +395,12 @@ impl CTFont {
         }
     }
 
+    pub fn get_matrix(&self) -> CGAffineTransform {
+        unsafe {
+            CTFontGetMatrix(self.as_concrete_TypeRef())
+        }
+    }
+
     pub fn url(&self) -> Option<CFURL> {
         unsafe {
             let result = CTFontCopyAttribute(self.0, kCTFontURLAttribute);
@@ -556,7 +562,7 @@ extern {
     fn CTFontCopyFontDescriptor(font: CTFontRef) -> CTFontDescriptorRef;
     fn CTFontCopyAttribute(font: CTFontRef, attribute: CFStringRef) -> CFTypeRef;
     fn CTFontGetSize(font: CTFontRef) -> CGFloat;
-    //fn CTFontGetMatrix
+    fn CTFontGetMatrix(font: CTFontRef) -> CGAffineTransform;
     fn CTFontGetSymbolicTraits(font: CTFontRef) -> CTFontSymbolicTraits;
     fn CTFontCopyTraits(font: CTFontRef) -> CFDictionaryRef;
 


### PR DESCRIPTION
Adds a binding for CTFontGetMatrix, which is needed for emoji support