### PR TITLE
Bump version for cocoa-rs (New Publish Required)

### DIFF
--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -4,7 +4,7 @@ name = "cocoa"
 description = "Bindings to Cocoa for macOS"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 


### PR DESCRIPTION
Sets cocoa-rs to version `0.25.0` to solve https://github.com/servo/core-foundation-rs/issues/504.