### PR TITLE
gate the build with target_os = "macos"

### DIFF
--- a/core-graphics-types/src/lib.rs
+++ b/core-graphics-types/src/lib.rs
@@ -10,5 +10,7 @@
 extern crate libc;
 extern crate core_foundation;
 
+#[cfg(target_os = "macos")]
 pub mod base;
+#[cfg(target_os = "macos")]
 pub mod geometry;


### PR DESCRIPTION
 so that we don't get build errors on linux.
 
 Ref: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/core-graphics-types/debian/patches/cnf-macos.patch