### PR TITLE
remove with-chrono feature

### DIFF
--- a/core-foundation/Cargo.toml
+++ b/core-foundation/Cargo.toml
@@ -15,13 +15,11 @@ version = "0.8.3"
 
 [dependencies]
 libc = "0.2"
-chrono = { version = "0.4", optional = true }
 uuid = { version = "0.5", optional = true }
 
 [features]
 mac_os_10_7_support = ["core-foundation-sys/mac_os_10_7_support"] # backwards compatibility
 mac_os_10_8_features = ["core-foundation-sys/mac_os_10_8_features"] # enables new features
-with-chrono = ["chrono"]
 with-uuid = ["uuid"]
 
 [package.metadata.docs.rs]

--- a/core-foundation/src/date.rs
+++ b/core-foundation/src/date.rs
@@ -14,10 +14,6 @@ use core_foundation_sys::base::kCFAllocatorDefault;
 
 use base::TCFType;
 
-#[cfg(feature = "with-chrono")]
-use chrono::NaiveDateTime;
-
-
 declare_TCFType!{
     /// A date.
     CFDate, CFDateRef
@@ -46,48 +42,12 @@ impl CFDate {
             CFDateGetAbsoluteTime(self.0)
         }
     }
-
-    #[cfg(feature = "with-chrono")]
-    pub fn naive_utc(&self) -> NaiveDateTime {
-        let ts = unsafe {
-            self.abs_time() + kCFAbsoluteTimeIntervalSince1970
-        };
-        let (secs, nanos) = if ts.is_sign_positive() {
-            (ts.trunc() as i64, ts.fract())
-        } else {
-            // nanoseconds can't be negative in NaiveDateTime
-            (ts.trunc() as i64 - 1, 1.0 - ts.fract().abs())
-        };
-        NaiveDateTime::from_timestamp(secs, (nanos * 1e9).floor() as u32)
-    }
-
-    #[cfg(feature = "with-chrono")]
-    pub fn from_naive_utc(time: NaiveDateTime) -> CFDate {
-        let secs = time.timestamp();
-        let nanos = time.timestamp_subsec_nanos();
-        let ts = unsafe {
-            secs as f64 + (nanos as f64 / 1e9) - kCFAbsoluteTimeIntervalSince1970
-        };
-        CFDate::new(ts)
-    }
 }
 
 #[cfg(test)]
 mod test {
     use super::CFDate;
     use std::cmp::Ordering;
-
-    #[cfg(feature = "with-chrono")]
-    use chrono::NaiveDateTime;
-
-    #[cfg(feature = "with-chrono")]
-    fn approx_eq(a: f64, b: f64) -> bool {
-        use std::f64;
-
-        let same_sign = a.is_sign_positive() == b.is_sign_positive();
-        let equal = ((a - b).abs() / f64::min(a.abs() + b.abs(), f64::MAX)) < f64::EPSILON;
-        (same_sign && equal)
-    }
 
     #[test]
     fn date_comparison() {
@@ -103,28 +63,5 @@ mod test {
         let now = CFDate::now();
         let same_time = CFDate::new(now.abs_time());
         assert_eq!(now, same_time);
-    }
-
-    #[test]
-    #[cfg(feature = "with-chrono")]
-    fn date_chrono_conversion_positive() {
-        let date = CFDate::now();
-        let datetime = date.naive_utc();
-        let converted = CFDate::from_naive_utc(datetime);
-        assert!(approx_eq(date.abs_time(), converted.abs_time()));
-    }
-
-    #[test]
-    #[cfg(feature = "with-chrono")]
-    fn date_chrono_conversion_negative() {
-        use super::kCFAbsoluteTimeIntervalSince1970;
-
-        let ts = unsafe {
-            kCFAbsoluteTimeIntervalSince1970 - 420.0
-        };
-        let date = CFDate::new(ts);
-        let datetime: NaiveDateTime = date.naive_utc();
-        let converted = CFDate::from_naive_utc(datetime);
-        assert!(approx_eq(date.abs_time(), converted.abs_time()));
     }
 }


### PR DESCRIPTION
We are currently keen to use `core-foundation` in `chrono` to determine the system time zone name - via [`iana-time-zone`](https://lib.rs/crates/iana-time-zone) (and potentially timezone calculations later), however becuase `core-foundation` depends on `chrono`, `iana-time-zone` has to use `core-foundation-sys` instead. 

I'm proposing here that the `chrono` related code is removed from `core-foundation` and I'll create a separate PR to add it into `chrono`. I recognize this is a breaking change which is not ideal, however I've checked the top reverse dependencies from https://lib.rs/crates/core-foundation/rev and it seems like none of them are using the `with-chrono` feature. If this PR is impractical, I'm keen to explore if there are any other options available.