### PR TITLE
Trim dependencies

### DIFF
--- a/cocoa-foundation/Cargo.toml
+++ b/cocoa-foundation/Cargo.toml
@@ -4,7 +4,7 @@ name = "cocoa-foundation"
 description = "Bindings to Cocoa Foundation for macOS"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 

--- a/cocoa-foundation/Cargo.toml
+++ b/cocoa-foundation/Cargo.toml
@@ -14,7 +14,6 @@ default-target = "x86_64-apple-darwin"
 [dependencies]
 block = "0.1"
 bitflags = "1.0"
-libc = "0.2"
 core-foundation = { path = "../core-foundation", version = "0.9" }
 core-graphics-types = { path = "../core-graphics-types", version = "0.1" }
 foreign-types = "0.3"

--- a/cocoa-foundation/src/foundation.rs
+++ b/cocoa-foundation/src/foundation.rs
@@ -10,21 +10,19 @@
 #![allow(non_upper_case_globals)]
 
 use std::ptr;
-use std::os::raw::c_void;
+use std::os::raw::{c_char, c_double, c_ulong, c_ulonglong, c_void};
 use base::{id, BOOL, NO, SEL, nil};
 use block::Block;
-use libc;
-
 
 #[cfg(target_pointer_width = "32")]
-pub type NSInteger = libc::c_int;
+pub type NSInteger = std::os::raw::c_int;
 #[cfg(target_pointer_width = "32")]
-pub type NSUInteger = libc::c_uint;
+pub type NSUInteger = std::os::raw::c_uint;
 
 #[cfg(target_pointer_width = "64")]
-pub type NSInteger = libc::c_long;
+pub type NSInteger = std::os::raw::c_long;
 #[cfg(target_pointer_width = "64")]
-pub type NSUInteger = libc::c_ulong;
+pub type NSUInteger = std::os::raw::c_ulong;
 
 pub const NSIntegerMax: NSInteger = NSInteger::max_value();
 pub const NSNotFound: NSInteger = NSIntegerMax;
@@ -253,7 +251,7 @@ impl NSProcessInfo for id {
     }
 }
 
-pub type NSTimeInterval = libc::c_double;
+pub type NSTimeInterval = c_double;
 
 pub trait NSArray: Sized {
     unsafe fn array(_: Self) -> id {
@@ -385,7 +383,7 @@ pub trait NSDictionary: Sized {
     unsafe fn fileOwnerAccountID(self) -> id;
     unsafe fn fileOwnerAccountName(self) -> id;
     unsafe fn filePosixPermissions(self) -> NSUInteger;
-    unsafe fn fileSize(self) -> libc::c_ulonglong;
+    unsafe fn fileSize(self) -> c_ulonglong;
     unsafe fn fileSystemFileNumber(self) -> NSUInteger;
     unsafe fn fileSystemNumber(self) -> NSInteger;
     unsafe fn fileType(self) -> id;
@@ -552,7 +550,7 @@ impl NSDictionary for id {
         msg_send![self, filePosixPermissions]
     }
 
-    unsafe fn fileSize(self) -> libc::c_ulonglong {
+    unsafe fn fileSize(self) -> c_ulonglong {
         msg_send![self, fileSize]
     }
 
@@ -586,7 +584,7 @@ impl NSDictionary for id {
 }
 
 bitflags! {
-    pub struct NSEnumerationOptions: libc::c_ulonglong {
+    pub struct NSEnumerationOptions: c_ulonglong {
         const NSEnumerationConcurrent = 1 << 0;
         const NSEnumerationReverse = 1 << 1;
     }
@@ -609,7 +607,7 @@ pub trait NSString: Sized {
 
     unsafe fn stringByAppendingString_(self, other: id) -> id;
     unsafe fn init_str(self, string: &str) -> Self;
-    unsafe fn UTF8String(self) -> *const libc::c_char;
+    unsafe fn UTF8String(self) -> *const c_char;
     unsafe fn len(self) -> usize;
     unsafe fn isEqualToString(self, &str) -> bool;
     unsafe fn substringWithRange(self, range: NSRange) -> id;
@@ -637,7 +635,7 @@ impl NSString for id {
         msg_send![self, lengthOfBytesUsingEncoding:UTF8_ENCODING]
     }
 
-    unsafe fn UTF8String(self) -> *const libc::c_char {
+    unsafe fn UTF8String(self) -> *const c_char {
         msg_send![self, UTF8String]
     }
 
@@ -662,10 +660,10 @@ impl NSDate for id {
 
 #[repr(C)]
 struct NSFastEnumerationState {
-    pub state: libc::c_ulong,
+    pub state: c_ulong,
     pub items_ptr: *mut id,
-    pub mutations_ptr: *mut libc::c_ulong,
-    pub extra: [libc::c_ulong; 5]
+    pub mutations_ptr: *mut c_ulong,
+    pub extra: [c_ulong; 5]
 }
 
 const NS_FAST_ENUM_BUF_SIZE: usize = 16;
@@ -673,7 +671,7 @@ const NS_FAST_ENUM_BUF_SIZE: usize = 16;
 pub struct NSFastIterator {
     state: NSFastEnumerationState,
     buffer: [id; NS_FAST_ENUM_BUF_SIZE],
-    mut_val: Option<libc::c_ulong>,
+    mut_val: Option<c_ulong>,
     len: usize,
     idx: usize,
     object: id
@@ -1329,7 +1327,7 @@ impl NSData for id {
 }
 
 bitflags! {
-    pub struct NSDataReadingOptions: libc::c_ulonglong {
+    pub struct NSDataReadingOptions: c_ulonglong {
        const NSDataReadingMappedIfSafe = 1 << 0;
        const NSDataReadingUncached = 1 << 1;
        const NSDataReadingMappedAlways = 1 << 3;
@@ -1337,7 +1335,7 @@ bitflags! {
 }
 
 bitflags! {
-    pub struct NSDataBase64EncodingOptions: libc::c_ulonglong {
+    pub struct NSDataBase64EncodingOptions: c_ulonglong {
         const NSDataBase64Encoding64CharacterLineLength = 1 << 0;
         const NSDataBase64Encoding76CharacterLineLength = 1 << 1;
         const NSDataBase64EncodingEndLineWithCarriageReturn = 1 << 4;
@@ -1346,20 +1344,20 @@ bitflags! {
 }
 
 bitflags! {
-    pub struct NSDataBase64DecodingOptions: libc::c_ulonglong {
+    pub struct NSDataBase64DecodingOptions: c_ulonglong {
        const NSDataBase64DecodingIgnoreUnknownCharacters = 1 << 0;
     }
 }
 
 bitflags! {
-    pub struct NSDataWritingOptions: libc::c_ulonglong {
+    pub struct NSDataWritingOptions: c_ulonglong {
         const NSDataWritingAtomic = 1 << 0;
         const NSDataWritingWithoutOverwriting = 1 << 1;
     }
 }
 
 bitflags! {
-    pub struct NSDataSearchOptions: libc::c_ulonglong {
+    pub struct NSDataSearchOptions: c_ulonglong {
         const NSDataSearchBackwards = 1 << 0;
         const NSDataSearchAnchored = 1 << 1;
     }

--- a/cocoa-foundation/src/lib.rs
+++ b/cocoa-foundation/src/lib.rs
@@ -15,7 +15,6 @@ extern crate bitflags;
 extern crate core_foundation;
 extern crate core_graphics_types;
 extern crate foreign_types;
-extern crate libc;
 #[macro_use]
 extern crate objc;
 

--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -13,7 +13,7 @@ use base::{id, BOOL, SEL};
 use block::Block;
 use foundation::{NSInteger, NSUInteger, NSTimeInterval,
                  NSPoint, NSSize, NSRect, NSRange, NSRectEdge};
-use libc;
+use std::os::raw::{c_int, c_float, c_ushort, c_ulonglong, c_void};
 
 pub use core_graphics::base::CGFloat;
 pub use core_graphics::geometry::CGPoint;
@@ -24,7 +24,6 @@ pub use self::NSBackingStoreType::*;
 pub use self::NSOpenGLPixelFormatAttribute::*;
 pub use self::NSOpenGLPFAOpenGLProfiles::*;
 pub use self::NSEventType::*;
-use std::os::raw::c_void;
 
 pub type CGLContextObj = *mut c_void;
 
@@ -258,7 +257,7 @@ bitflags! {
 }
 
 bitflags! {
-    pub struct NSAlignmentOptions: libc::c_ulonglong {
+    pub struct NSAlignmentOptions: c_ulonglong {
         const NSAlignMinXInward         = 1 << 0;
         const NSAlignMinYInward         = 1 << 1;
         const NSAlignMaxXInward         = 1 << 2;
@@ -873,7 +872,7 @@ impl NSMenuItem for id {
     }
 }
 
-pub type NSWindowDepth = libc::c_int;
+pub type NSWindowDepth = c_int;
 
 bitflags! {
     pub struct NSWindowCollectionBehavior: NSUInteger {
@@ -2332,43 +2331,43 @@ pub enum NSEventType {
 }
 
 bitflags! {
-    pub struct NSEventMask: libc::c_ulonglong {
-        const NSLeftMouseDownMask         = 1 << NSLeftMouseDown as libc::c_ulonglong;
-        const NSLeftMouseUpMask           = 1 << NSLeftMouseUp as libc::c_ulonglong;
-        const NSRightMouseDownMask        = 1 << NSRightMouseDown as libc::c_ulonglong;
-        const NSRightMouseUpMask          = 1 << NSRightMouseUp as libc::c_ulonglong;
-        const NSMouseMovedMask            = 1 << NSMouseMoved as libc::c_ulonglong;
-        const NSLeftMouseDraggedMask      = 1 << NSLeftMouseDragged as libc::c_ulonglong;
-        const NSRightMouseDraggedMask     = 1 << NSRightMouseDragged as libc::c_ulonglong;
-        const NSMouseEnteredMask          = 1 << NSMouseEntered as libc::c_ulonglong;
-        const NSMouseExitedMask           = 1 << NSMouseExited as libc::c_ulonglong;
-        const NSKeyDownMask               = 1 << NSKeyDown as libc::c_ulonglong;
-        const NSKeyUpMask                 = 1 << NSKeyUp as libc::c_ulonglong;
-        const NSFlagsChangedMask          = 1 << NSFlagsChanged as libc::c_ulonglong;
-        const NSAppKitDefinedMask         = 1 << NSAppKitDefined as libc::c_ulonglong;
-        const NSSystemDefinedMask         = 1 << NSSystemDefined as libc::c_ulonglong;
-        const NSApplicationDefinedMask    = 1 << NSApplicationDefined as libc::c_ulonglong;
-        const NSPeriodicMask              = 1 << NSPeriodic as libc::c_ulonglong;
-        const NSCursorUpdateMask          = 1 << NSCursorUpdate as libc::c_ulonglong;
-        const NSScrollWheelMask           = 1 << NSScrollWheel as libc::c_ulonglong;
-        const NSTabletPointMask           = 1 << NSTabletPoint as libc::c_ulonglong;
-        const NSTabletProximityMask       = 1 << NSTabletProximity as libc::c_ulonglong;
-        const NSOtherMouseDownMask        = 1 << NSOtherMouseDown as libc::c_ulonglong;
-        const NSOtherMouseUpMask          = 1 << NSOtherMouseUp as libc::c_ulonglong;
-        const NSOtherMouseDraggedMask     = 1 << NSOtherMouseDragged as libc::c_ulonglong;
-        const NSEventMaskGesture          = 1 << NSEventTypeGesture as libc::c_ulonglong;
-        const NSEventMaskSwipe            = 1 << NSEventTypeSwipe as libc::c_ulonglong;
-        const NSEventMaskRotate           = 1 << NSEventTypeRotate as libc::c_ulonglong;
-        const NSEventMaskBeginGesture     = 1 << NSEventTypeBeginGesture as libc::c_ulonglong;
-        const NSEventMaskEndGesture       = 1 << NSEventTypeEndGesture as libc::c_ulonglong;
-        const NSEventMaskPressure         = 1 << NSEventTypePressure as libc::c_ulonglong;
+    pub struct NSEventMask: c_ulonglong {
+        const NSLeftMouseDownMask         = 1 << NSLeftMouseDown as c_ulonglong;
+        const NSLeftMouseUpMask           = 1 << NSLeftMouseUp as c_ulonglong;
+        const NSRightMouseDownMask        = 1 << NSRightMouseDown as c_ulonglong;
+        const NSRightMouseUpMask          = 1 << NSRightMouseUp as c_ulonglong;
+        const NSMouseMovedMask            = 1 << NSMouseMoved as c_ulonglong;
+        const NSLeftMouseDraggedMask      = 1 << NSLeftMouseDragged as c_ulonglong;
+        const NSRightMouseDraggedMask     = 1 << NSRightMouseDragged as c_ulonglong;
+        const NSMouseEnteredMask          = 1 << NSMouseEntered as c_ulonglong;
+        const NSMouseExitedMask           = 1 << NSMouseExited as c_ulonglong;
+        const NSKeyDownMask               = 1 << NSKeyDown as c_ulonglong;
+        const NSKeyUpMask                 = 1 << NSKeyUp as c_ulonglong;
+        const NSFlagsChangedMask          = 1 << NSFlagsChanged as c_ulonglong;
+        const NSAppKitDefinedMask         = 1 << NSAppKitDefined as c_ulonglong;
+        const NSSystemDefinedMask         = 1 << NSSystemDefined as c_ulonglong;
+        const NSApplicationDefinedMask    = 1 << NSApplicationDefined as c_ulonglong;
+        const NSPeriodicMask              = 1 << NSPeriodic as c_ulonglong;
+        const NSCursorUpdateMask          = 1 << NSCursorUpdate as c_ulonglong;
+        const NSScrollWheelMask           = 1 << NSScrollWheel as c_ulonglong;
+        const NSTabletPointMask           = 1 << NSTabletPoint as c_ulonglong;
+        const NSTabletProximityMask       = 1 << NSTabletProximity as c_ulonglong;
+        const NSOtherMouseDownMask        = 1 << NSOtherMouseDown as c_ulonglong;
+        const NSOtherMouseUpMask          = 1 << NSOtherMouseUp as c_ulonglong;
+        const NSOtherMouseDraggedMask     = 1 << NSOtherMouseDragged as c_ulonglong;
+        const NSEventMaskGesture          = 1 << NSEventTypeGesture as c_ulonglong;
+        const NSEventMaskSwipe            = 1 << NSEventTypeSwipe as c_ulonglong;
+        const NSEventMaskRotate           = 1 << NSEventTypeRotate as c_ulonglong;
+        const NSEventMaskBeginGesture     = 1 << NSEventTypeBeginGesture as c_ulonglong;
+        const NSEventMaskEndGesture       = 1 << NSEventTypeEndGesture as c_ulonglong;
+        const NSEventMaskPressure         = 1 << NSEventTypePressure as c_ulonglong;
         const NSAnyEventMask              = 0xffffffffffffffff;
     }
 }
 
 impl NSEventMask {
     pub fn from_type(ty: NSEventType) -> NSEventMask {
-        NSEventMask { bits: 1 << ty as libc::c_ulonglong }
+        NSEventMask { bits: 1 << ty as c_ulonglong }
     }
 }
 
@@ -2418,78 +2417,78 @@ pub enum NSEventSubtype {
     NSAWTEventType = 16,
 }
 
-pub const NSUpArrowFunctionKey: libc::c_ushort = 0xF700;
-pub const NSDownArrowFunctionKey: libc::c_ushort = 0xF701;
-pub const NSLeftArrowFunctionKey: libc::c_ushort = 0xF702;
-pub const NSRightArrowFunctionKey: libc::c_ushort = 0xF703;
-pub const NSF1FunctionKey: libc::c_ushort = 0xF704;
-pub const NSF2FunctionKey: libc::c_ushort = 0xF705;
-pub const NSF3FunctionKey: libc::c_ushort = 0xF706;
-pub const NSF4FunctionKey: libc::c_ushort = 0xF707;
-pub const NSF5FunctionKey: libc::c_ushort = 0xF708;
-pub const NSF6FunctionKey: libc::c_ushort = 0xF709;
-pub const NSF7FunctionKey: libc::c_ushort = 0xF70A;
-pub const NSF8FunctionKey: libc::c_ushort = 0xF70B;
-pub const NSF9FunctionKey: libc::c_ushort = 0xF70C;
-pub const NSF10FunctionKey: libc::c_ushort = 0xF70D;
-pub const NSF11FunctionKey: libc::c_ushort = 0xF70E;
-pub const NSF12FunctionKey: libc::c_ushort = 0xF70F;
-pub const NSF13FunctionKey: libc::c_ushort = 0xF710;
-pub const NSF14FunctionKey: libc::c_ushort = 0xF711;
-pub const NSF15FunctionKey: libc::c_ushort = 0xF712;
-pub const NSF16FunctionKey: libc::c_ushort = 0xF713;
-pub const NSF17FunctionKey: libc::c_ushort = 0xF714;
-pub const NSF18FunctionKey: libc::c_ushort = 0xF715;
-pub const NSF19FunctionKey: libc::c_ushort = 0xF716;
-pub const NSF20FunctionKey: libc::c_ushort = 0xF717;
-pub const NSF21FunctionKey: libc::c_ushort = 0xF718;
-pub const NSF22FunctionKey: libc::c_ushort = 0xF719;
-pub const NSF23FunctionKey: libc::c_ushort = 0xF71A;
-pub const NSF24FunctionKey: libc::c_ushort = 0xF71B;
-pub const NSF25FunctionKey: libc::c_ushort = 0xF71C;
-pub const NSF26FunctionKey: libc::c_ushort = 0xF71D;
-pub const NSF27FunctionKey: libc::c_ushort = 0xF71E;
-pub const NSF28FunctionKey: libc::c_ushort = 0xF71F;
-pub const NSF29FunctionKey: libc::c_ushort = 0xF720;
-pub const NSF30FunctionKey: libc::c_ushort = 0xF721;
-pub const NSF31FunctionKey: libc::c_ushort = 0xF722;
-pub const NSF32FunctionKey: libc::c_ushort = 0xF723;
-pub const NSF33FunctionKey: libc::c_ushort = 0xF724;
-pub const NSF34FunctionKey: libc::c_ushort = 0xF725;
-pub const NSF35FunctionKey: libc::c_ushort = 0xF726;
-pub const NSInsertFunctionKey: libc::c_ushort = 0xF727;
-pub const NSDeleteFunctionKey: libc::c_ushort = 0xF728;
-pub const NSHomeFunctionKey: libc::c_ushort = 0xF729;
-pub const NSBeginFunctionKey: libc::c_ushort = 0xF72A;
-pub const NSEndFunctionKey: libc::c_ushort = 0xF72B;
-pub const NSPageUpFunctionKey: libc::c_ushort = 0xF72C;
-pub const NSPageDownFunctionKey: libc::c_ushort = 0xF72D;
-pub const NSPrintScreenFunctionKey: libc::c_ushort = 0xF72E;
-pub const NSScrollLockFunctionKey: libc::c_ushort = 0xF72F;
-pub const NSPauseFunctionKey: libc::c_ushort = 0xF730;
-pub const NSSysReqFunctionKey: libc::c_ushort = 0xF731;
-pub const NSBreakFunctionKey: libc::c_ushort = 0xF732;
-pub const NSResetFunctionKey: libc::c_ushort = 0xF733;
-pub const NSStopFunctionKey: libc::c_ushort = 0xF734;
-pub const NSMenuFunctionKey: libc::c_ushort = 0xF735;
-pub const NSUserFunctionKey: libc::c_ushort = 0xF736;
-pub const NSSystemFunctionKey: libc::c_ushort = 0xF737;
-pub const NSPrintFunctionKey: libc::c_ushort = 0xF738;
-pub const NSClearLineFunctionKey: libc::c_ushort = 0xF739;
-pub const NSClearDisplayFunctionKey: libc::c_ushort = 0xF73A;
-pub const NSInsertLineFunctionKey: libc::c_ushort = 0xF73B;
-pub const NSDeleteLineFunctionKey: libc::c_ushort = 0xF73C;
-pub const NSInsertCharFunctionKey: libc::c_ushort = 0xF73D;
-pub const NSDeleteCharFunctionKey: libc::c_ushort = 0xF73E;
-pub const NSPrevFunctionKey: libc::c_ushort = 0xF73F;
-pub const NSNextFunctionKey: libc::c_ushort = 0xF740;
-pub const NSSelectFunctionKey: libc::c_ushort = 0xF741;
-pub const NSExecuteFunctionKey: libc::c_ushort = 0xF742;
-pub const NSUndoFunctionKey: libc::c_ushort = 0xF743;
-pub const NSRedoFunctionKey: libc::c_ushort = 0xF744;
-pub const NSFindFunctionKey: libc::c_ushort = 0xF745;
-pub const NSHelpFunctionKey: libc::c_ushort = 0xF746;
-pub const NSModeSwitchFunctionKey: libc::c_ushort = 0xF747;
+pub const NSUpArrowFunctionKey: c_ushort = 0xF700;
+pub const NSDownArrowFunctionKey: c_ushort = 0xF701;
+pub const NSLeftArrowFunctionKey: c_ushort = 0xF702;
+pub const NSRightArrowFunctionKey: c_ushort = 0xF703;
+pub const NSF1FunctionKey: c_ushort = 0xF704;
+pub const NSF2FunctionKey: c_ushort = 0xF705;
+pub const NSF3FunctionKey: c_ushort = 0xF706;
+pub const NSF4FunctionKey: c_ushort = 0xF707;
+pub const NSF5FunctionKey: c_ushort = 0xF708;
+pub const NSF6FunctionKey: c_ushort = 0xF709;
+pub const NSF7FunctionKey: c_ushort = 0xF70A;
+pub const NSF8FunctionKey: c_ushort = 0xF70B;
+pub const NSF9FunctionKey: c_ushort = 0xF70C;
+pub const NSF10FunctionKey: c_ushort = 0xF70D;
+pub const NSF11FunctionKey: c_ushort = 0xF70E;
+pub const NSF12FunctionKey: c_ushort = 0xF70F;
+pub const NSF13FunctionKey: c_ushort = 0xF710;
+pub const NSF14FunctionKey: c_ushort = 0xF711;
+pub const NSF15FunctionKey: c_ushort = 0xF712;
+pub const NSF16FunctionKey: c_ushort = 0xF713;
+pub const NSF17FunctionKey: c_ushort = 0xF714;
+pub const NSF18FunctionKey: c_ushort = 0xF715;
+pub const NSF19FunctionKey: c_ushort = 0xF716;
+pub const NSF20FunctionKey: c_ushort = 0xF717;
+pub const NSF21FunctionKey: c_ushort = 0xF718;
+pub const NSF22FunctionKey: c_ushort = 0xF719;
+pub const NSF23FunctionKey: c_ushort = 0xF71A;
+pub const NSF24FunctionKey: c_ushort = 0xF71B;
+pub const NSF25FunctionKey: c_ushort = 0xF71C;
+pub const NSF26FunctionKey: c_ushort = 0xF71D;
+pub const NSF27FunctionKey: c_ushort = 0xF71E;
+pub const NSF28FunctionKey: c_ushort = 0xF71F;
+pub const NSF29FunctionKey: c_ushort = 0xF720;
+pub const NSF30FunctionKey: c_ushort = 0xF721;
+pub const NSF31FunctionKey: c_ushort = 0xF722;
+pub const NSF32FunctionKey: c_ushort = 0xF723;
+pub const NSF33FunctionKey: c_ushort = 0xF724;
+pub const NSF34FunctionKey: c_ushort = 0xF725;
+pub const NSF35FunctionKey: c_ushort = 0xF726;
+pub const NSInsertFunctionKey: c_ushort = 0xF727;
+pub const NSDeleteFunctionKey: c_ushort = 0xF728;
+pub const NSHomeFunctionKey: c_ushort = 0xF729;
+pub const NSBeginFunctionKey: c_ushort = 0xF72A;
+pub const NSEndFunctionKey: c_ushort = 0xF72B;
+pub const NSPageUpFunctionKey: c_ushort = 0xF72C;
+pub const NSPageDownFunctionKey: c_ushort = 0xF72D;
+pub const NSPrintScreenFunctionKey: c_ushort = 0xF72E;
+pub const NSScrollLockFunctionKey: c_ushort = 0xF72F;
+pub const NSPauseFunctionKey: c_ushort = 0xF730;
+pub const NSSysReqFunctionKey: c_ushort = 0xF731;
+pub const NSBreakFunctionKey: c_ushort = 0xF732;
+pub const NSResetFunctionKey: c_ushort = 0xF733;
+pub const NSStopFunctionKey: c_ushort = 0xF734;
+pub const NSMenuFunctionKey: c_ushort = 0xF735;
+pub const NSUserFunctionKey: c_ushort = 0xF736;
+pub const NSSystemFunctionKey: c_ushort = 0xF737;
+pub const NSPrintFunctionKey: c_ushort = 0xF738;
+pub const NSClearLineFunctionKey: c_ushort = 0xF739;
+pub const NSClearDisplayFunctionKey: c_ushort = 0xF73A;
+pub const NSInsertLineFunctionKey: c_ushort = 0xF73B;
+pub const NSDeleteLineFunctionKey: c_ushort = 0xF73C;
+pub const NSInsertCharFunctionKey: c_ushort = 0xF73D;
+pub const NSDeleteCharFunctionKey: c_ushort = 0xF73E;
+pub const NSPrevFunctionKey: c_ushort = 0xF73F;
+pub const NSNextFunctionKey: c_ushort = 0xF740;
+pub const NSSelectFunctionKey: c_ushort = 0xF741;
+pub const NSExecuteFunctionKey: c_ushort = 0xF742;
+pub const NSUndoFunctionKey: c_ushort = 0xF743;
+pub const NSRedoFunctionKey: c_ushort = 0xF744;
+pub const NSFindFunctionKey: c_ushort = 0xF745;
+pub const NSHelpFunctionKey: c_ushort = 0xF746;
+pub const NSModeSwitchFunctionKey: c_ushort = 0xF747;
 
 pub trait NSEvent: Sized {
     // Creating Events
@@ -2504,7 +2503,7 @@ pub trait NSEvent: Sized {
         characters: id /* (NSString *) */,
         unmodCharacters: id /* (NSString *) */,
         repeatKey: BOOL,
-        code: libc::c_ushort) -> id /* (NSEvent *) */;
+        code: c_ushort) -> id /* (NSEvent *) */;
     unsafe fn mouseEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_clickCount_pressure_(
         _: Self,
         eventType: NSEventType,
@@ -2515,7 +2514,7 @@ pub trait NSEvent: Sized {
         context: id /* (NSGraphicsContext *) */,
         eventNumber: NSInteger,
         clickCount: NSInteger,
-        pressure: libc::c_float) -> id /* (NSEvent *) */;
+        pressure: c_float) -> id /* (NSEvent *) */;
     unsafe fn enterExitEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_trackingNumber_userData_(
         _: Self,
         eventType: NSEventType,
@@ -2560,7 +2559,7 @@ pub trait NSEvent: Sized {
     unsafe fn keyRepeatInterval(_: Self) -> NSTimeInterval;
     unsafe fn characters(self) -> id /* (NSString *) */;
     unsafe fn charactersIgnoringModifiers(self) -> id /* (NSString *) */;
-    unsafe fn keyCode(self) -> libc::c_ushort;
+    unsafe fn keyCode(self) -> c_ushort;
     unsafe fn isARepeat(self) -> BOOL;
 
     // Getting Mouse Event Information
@@ -2569,7 +2568,7 @@ pub trait NSEvent: Sized {
     unsafe fn mouseLocation(_: Self) -> NSPoint;
     unsafe fn buttonNumber(self) -> NSInteger;
     unsafe fn clickCount(self) -> NSInteger;
-    unsafe fn pressure(self) -> libc::c_float;
+    unsafe fn pressure(self) -> c_float;
     unsafe fn stage(self) -> NSInteger;
     unsafe fn setMouseCoalescingEnabled_(_: Self, flag: BOOL);
     unsafe fn isMouseCoalescingEnabled(_: Self) -> BOOL;
@@ -2598,7 +2597,7 @@ pub trait NSEvent: Sized {
     unsafe fn pointingDeviceType(self) -> NSPointingDeviceType;
     unsafe fn systemTabletID(self) -> NSUInteger;
     unsafe fn tabletID(self) -> NSUInteger;
-    unsafe fn uniqueID(self) -> libc::c_ulonglong;
+    unsafe fn uniqueID(self) -> c_ulonglong;
     unsafe fn vendorID(self) -> NSUInteger;
     unsafe fn vendorPointingDeviceType(self) -> NSUInteger;
 
@@ -2607,8 +2606,8 @@ pub trait NSEvent: Sized {
     unsafe fn absoluteY(self) -> NSInteger;
     unsafe fn absoluteZ(self) -> NSInteger;
     unsafe fn buttonMask(self) -> NSEventButtonMask;
-    unsafe fn rotation(self) -> libc::c_float;
-    unsafe fn tangentialPressure(self) -> libc::c_float;
+    unsafe fn rotation(self) -> c_float;
+    unsafe fn tangentialPressure(self) -> c_float;
     unsafe fn tilt(self) -> NSPoint;
     unsafe fn vendorDefined(self) -> id;
 
@@ -2652,7 +2651,7 @@ impl NSEvent for id {
         characters: id /* (NSString *) */,
         unmodCharacters: id /* (NSString *) */,
         repeatKey: BOOL,
-        code: libc::c_ushort) -> id /* (NSEvent *) */
+        code: c_ushort) -> id /* (NSEvent *) */
     {
         msg_send![class!(NSEvent), keyEventWithType:eventType
                                             location:location
@@ -2676,7 +2675,7 @@ impl NSEvent for id {
         context: id /* (NSGraphicsContext *) */,
         eventNumber: NSInteger,
         clickCount: NSInteger,
-        pressure: libc::c_float) -> id /* (NSEvent *) */
+        pressure: c_float) -> id /* (NSEvent *) */
     {
         msg_send![class!(NSEvent), mouseEventWithType:eventType
                                               location:location
@@ -2806,7 +2805,7 @@ impl NSEvent for id {
         msg_send![self, charactersIgnoringModifiers]
     }
 
-    unsafe fn keyCode(self) -> libc::c_ushort {
+    unsafe fn keyCode(self) -> c_ushort {
         msg_send![self, keyCode]
     }
 
@@ -2836,7 +2835,7 @@ impl NSEvent for id {
         msg_send![self, clickCount]
     }
 
-    unsafe fn pressure(self) -> libc::c_float {
+    unsafe fn pressure(self) -> c_float {
         msg_send![self, pressure]
     }
 
@@ -2928,7 +2927,7 @@ impl NSEvent for id {
         msg_send![self, tabletID]
     }
 
-    unsafe fn uniqueID(self) -> libc::c_ulonglong {
+    unsafe fn uniqueID(self) -> c_ulonglong {
         msg_send![self, uniqueID]
     }
 
@@ -2958,11 +2957,11 @@ impl NSEvent for id {
         msg_send![self, buttonMask]
     }
 
-    unsafe fn rotation(self) -> libc::c_float {
+    unsafe fn rotation(self) -> c_float {
         msg_send![self, rotation]
     }
 
-    unsafe fn tangentialPressure(self) -> libc::c_float {
+    unsafe fn tangentialPressure(self) -> c_float {
         msg_send![self, tangentialPressure]
     }
 
@@ -3942,7 +3941,7 @@ impl NSTabView for id {
         msg_send![self, drawsBackground]
     }
     unsafe fn setDrawsBackground_(self,drawsBackground:BOOL){
-        msg_send![self, setDrawsBackground:drawsBackground as libc::c_int]
+        msg_send![self, setDrawsBackground:drawsBackground as c_int]
     }
 
     unsafe fn minimumSize(self) -> id{
@@ -3962,7 +3961,7 @@ impl NSTabView for id {
         msg_send![self, allowsTruncatedLabels]
     }
     unsafe fn setAllowsTruncatedLabels_(self, allowTruncatedLabels:BOOL){
-        msg_send![self, setAllowsTruncatedLabels:allowTruncatedLabels as libc::c_int]
+        msg_send![self, setAllowsTruncatedLabels:allowTruncatedLabels as c_int]
     }
 
     unsafe fn setDelegate_(self, delegate:id){
@@ -4017,7 +4016,7 @@ impl NSTabViewItem for id {
     }
 
     unsafe fn drawLabel_inRect_(self, shouldTruncateLabel:BOOL,labelRect:NSRect){
-        msg_send![self, drawLabel:shouldTruncateLabel as libc::c_int inRect:labelRect]
+        msg_send![self, drawLabel:shouldTruncateLabel as c_int inRect:labelRect]
     }
 
     unsafe fn label(self)->id{
@@ -4028,7 +4027,7 @@ impl NSTabViewItem for id {
     }
 
     unsafe fn sizeOfLabel_(self,computeMin:BOOL){
-        msg_send![self, sizeOfLabel:computeMin as libc::c_int]
+        msg_send![self, sizeOfLabel:computeMin as c_int]
     }
 
     unsafe fn tabState(self) -> NSTabState{

--- a/core-foundation-sys/Cargo.toml
+++ b/core-foundation-sys/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-foundation-sys"
 description = "Bindings to Core Foundation for macOS"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 

--- a/core-foundation/Cargo.toml
+++ b/core-foundation/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-foundation"
 description = "Bindings to Core Foundation for macOS"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 categories = ["os::macos-apis"]
@@ -11,7 +11,7 @@ keywords = ["macos", "framework", "objc"]
 
 [dependencies.core-foundation-sys]
 path = "../core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 
 [dependencies]
 chrono = { version = "0.4", optional = true }

--- a/core-foundation/Cargo.toml
+++ b/core-foundation/Cargo.toml
@@ -14,11 +14,12 @@ path = "../core-foundation-sys"
 version = "0.8.3"
 
 [dependencies]
-libc = "0.2"
 chrono = { version = "0.4", optional = true }
 uuid = { version = "0.5", optional = true }
+libc = { version = "0.2", optional = true }
 
 [features]
+default = ["libc"]
 mac_os_10_7_support = ["core-foundation-sys/mac_os_10_7_support"] # backwards compatibility
 mac_os_10_8_features = ["core-foundation-sys/mac_os_10_8_features"] # enables new features
 with-chrono = ["chrono"]

--- a/core-foundation/src/filedescriptor.rs
+++ b/core-foundation/src/filedescriptor.rs
@@ -102,9 +102,8 @@ impl AsRawFd for CFFileDescriptor {
 
 
 #[cfg(test)]
+#[cfg(feature = "libc")]
 mod test {
-    extern crate libc;
-
     use super::*;
     use std::ffi::CString;
     use std::os::raw::c_void;

--- a/core-foundation/src/lib.rs
+++ b/core-foundation/src/lib.rs
@@ -16,6 +16,7 @@
 //! other frameworks that use the CoreFoundation framework.
 
 extern crate core_foundation_sys;
+#[cfg(feature = "libc")]
 extern crate libc;
 
 #[cfg(feature = "with-chrono")]

--- a/core-foundation/src/url.rs
+++ b/core-foundation/src/url.rs
@@ -18,8 +18,9 @@ use core_foundation_sys::base::{kCFAllocatorDefault, Boolean};
 use std::fmt;
 use std::ptr;
 use std::path::{Path, PathBuf};
+use std::os::raw::c_char;
 
-use libc::{c_char, strlen, PATH_MAX};
+use libc::{strlen, PATH_MAX};
 
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;

--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -8,9 +8,7 @@ authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 
 [dependencies]
-bitflags = "1.0"
 core-foundation = { path = "../core-foundation", version = "0.9", default-features = false }
-foreign-types = "0.3.0"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT / Apache-2.0"
 
 [dependencies]
 bitflags = "1.0"
-core-foundation = { path = "../core-foundation", version = "0.9" }
+core-foundation = { path = "../core-foundation", version = "0.9", default-features = false }
 foreign-types = "0.3.0"
 
 [package.metadata.docs.rs]

--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics-types"
 description = "Bindings for some fundamental Core Graphics types"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 

--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT / Apache-2.0"
 bitflags = "1.0"
 core-foundation = { path = "../core-foundation", version = "0.9" }
 foreign-types = "0.3.0"
-libc = "0.2"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/core-graphics-types/src/base.rs
+++ b/core-graphics-types/src/base.rs
@@ -12,23 +12,23 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 
-use libc;
+use std::os::raw::c_ushort;
 
 #[cfg(any(target_arch = "x86",
           target_arch = "arm",
           target_arch = "aarch64"))]
-pub type boolean_t = libc::c_int;
+pub type boolean_t = std::os::raw::c_int;
 #[cfg(target_arch = "x86_64")]
-pub type boolean_t = libc::c_uint;
+pub type boolean_t = std::os::raw::c_uint;
 
 #[cfg(target_pointer_width = "64")]
-pub type CGFloat = libc::c_double;
+pub type CGFloat = std::os::raw::c_double;
 #[cfg(not(target_pointer_width = "64"))]
-pub type CGFloat = libc::c_float;
+pub type CGFloat = std::os::raw::c_float;
 
-pub type CGError = libc::int32_t;
+pub type CGError = i32;
 
-pub type CGGlyph = libc::c_ushort;
+pub type CGGlyph = c_ushort;
 
 pub const kCGErrorSuccess: CGError = 0;
 pub const kCGErrorFailure: CGError = 1000;

--- a/core-graphics-types/src/lib.rs
+++ b/core-graphics-types/src/lib.rs
@@ -7,7 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate libc;
 extern crate core_foundation;
 
 pub mod base;

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -14,7 +14,7 @@ highsierra = []
 
 [dependencies]
 bitflags = "1.0"
-core-foundation = { path = "../core-foundation", version = "0.9" }
+core-foundation = { path = "../core-foundation", version = "0.9", default-features = false }
 core-graphics-types = { path = "../core-graphics-types", version = "0.1" }
 foreign-types = "0.3.0"
 libc = "0.2"

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -8,16 +8,18 @@ authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 
 [features]
-default = []
-elcapitan = []
+default = ["libc"]
+elcapitan = ["libc"]
 highsierra = []
+libc = ["libc_", "core-foundation/libc"]
 
 [dependencies]
 bitflags = "1.0"
 core-foundation = { path = "../core-foundation", version = "0.9", default-features = false }
 core-graphics-types = { path = "../core-graphics-types", version = "0.1" }
 foreign-types = "0.3.0"
-libc = "0.2"
+# TODO: Use dep:libc functionality once in MSRV
+libc_ = { version = "0.2", optional = true, package = "libc" }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics"
 description = "Bindings to Core Graphics for macOS"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.22.3"
+version = "0.22.4"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 

--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -15,8 +15,7 @@ use geometry::{CGPoint, CGSize};
 use gradient::{CGGradient, CGGradientDrawingOptions};
 use color::CGColor;
 use path::CGPathRef;
-use libc::{c_int, size_t};
-use std::os::raw::c_void;
+use std::os::raw::{c_void, c_int};
 
 use std::cmp;
 use std::ptr;
@@ -140,10 +139,10 @@ impl CGContext {
     }
 
     pub fn create_bitmap_context(data: Option<*mut c_void>,
-                                 width: size_t,
-                                 height: size_t,
-                                 bits_per_component: size_t,
-                                 bytes_per_row: size_t,
+                                 width: usize,
+                                 height: usize,
+                                 bits_per_component: usize,
+                                 bytes_per_row: usize,
                                  space: &CGColorSpace,
                                  bitmap_info: u32)
                                  -> CGContext {
@@ -176,19 +175,19 @@ impl CGContextRef {
         }
     }
 
-    pub fn width(&self) -> size_t {
+    pub fn width(&self) -> usize {
         unsafe {
             CGBitmapContextGetWidth(self.as_ptr())
         }
     }
 
-    pub fn height(&self) -> size_t {
+    pub fn height(&self) -> usize {
         unsafe {
             CGBitmapContextGetHeight(self.as_ptr())
         }
     }
 
-    pub fn bytes_per_row(&self) -> size_t {
+    pub fn bytes_per_row(&self) -> usize {
         unsafe {
             CGBitmapContextGetBytesPerRow(self.as_ptr())
         }
@@ -657,17 +656,17 @@ extern {
     fn CGContextRelease(c: ::sys::CGContextRef);
 
     fn CGBitmapContextCreate(data: *mut c_void,
-                             width: size_t,
-                             height: size_t,
-                             bitsPerComponent: size_t,
-                             bytesPerRow: size_t,
+                             width: usize,
+                             height: usize,
+                             bitsPerComponent: usize,
+                             bytesPerRow: usize,
                              space: ::sys::CGColorSpaceRef,
                              bitmapInfo: u32)
                              -> ::sys::CGContextRef;
     fn CGBitmapContextGetData(context: ::sys::CGContextRef) -> *mut c_void;
-    fn CGBitmapContextGetWidth(context: ::sys::CGContextRef) -> size_t;
-    fn CGBitmapContextGetHeight(context: ::sys::CGContextRef) -> size_t;
-    fn CGBitmapContextGetBytesPerRow(context: ::sys::CGContextRef) -> size_t;
+    fn CGBitmapContextGetWidth(context: ::sys::CGContextRef) -> usize;
+    fn CGBitmapContextGetHeight(context: ::sys::CGContextRef) -> usize;
+    fn CGBitmapContextGetBytesPerRow(context: ::sys::CGContextRef) -> usize;
     fn CGBitmapContextCreateImage(context: ::sys::CGContextRef) -> ::sys::CGImageRef;
     fn CGContextGetTypeID() -> CFTypeID;
     fn CGContextGetClipBoundingBox(c: ::sys::CGContextRef) -> CGRect;
@@ -689,7 +688,7 @@ extern {
     fn CGContextSetTextDrawingMode(c: ::sys::CGContextRef, mode: CGTextDrawingMode);
     fn CGContextSetFillColorWithColor(c: ::sys::CGContextRef, color: ::sys::CGColorRef);
     fn CGContextSetLineCap(c: ::sys::CGContextRef, cap: CGLineCap);
-    fn CGContextSetLineDash(c: ::sys::CGContextRef, phase: CGFloat, lengths: *const CGFloat, count: size_t);
+    fn CGContextSetLineDash(c: ::sys::CGContextRef, phase: CGFloat, lengths: *const CGFloat, count: usize);
     fn CGContextSetLineJoin(c: ::sys::CGContextRef, join: CGLineJoin);
     fn CGContextSetLineWidth(c: ::sys::CGContextRef, width: CGFloat);
     fn CGContextSetMiterLimit(c: ::sys::CGContextRef, limit: CGFloat);
@@ -739,7 +738,7 @@ extern {
                          rect: CGRect);
     fn CGContextFillRects(context: ::sys::CGContextRef,
                           rects: *const CGRect,
-                          count: size_t);
+                          count: usize);
     fn CGContextStrokeRect(context: ::sys::CGContextRef,
                            rect: CGRect);
     fn CGContextStrokeRectWithWidth(context: ::sys::CGContextRef,
@@ -749,7 +748,7 @@ extern {
                            rect: CGRect);
     fn CGContextClipToRects(context: ::sys::CGContextRef,
                             rects: *const CGRect,
-                            count: size_t);
+                            count: usize);
     fn CGContextClipToMask(ctx: ::sys::CGContextRef, rect: CGRect, mask: ::sys::CGImageRef);
     fn CGContextReplacePathWithStrokedPath(context: ::sys::CGContextRef);
     fn CGContextFillEllipseInRect(context: ::sys::CGContextRef,
@@ -758,7 +757,7 @@ extern {
                                     rect: CGRect);
     fn CGContextStrokeLineSegments(context: ::sys::CGContextRef,
                                     points: *const CGPoint,
-                                    count: size_t);
+                                    count: usize);
     fn CGContextDrawImage(c: ::sys::CGContextRef, rect: CGRect, image: ::sys::CGImageRef);
     fn CGContextSetInterpolationQuality(c: ::sys::CGContextRef, quality: CGInterpolationQuality);
     fn CGContextGetInterpolationQuality(c: ::sys::CGContextRef) -> CGInterpolationQuality;
@@ -769,7 +768,7 @@ extern {
     fn CGContextShowGlyphsAtPositions(c: ::sys::CGContextRef,
                                       glyphs: *const CGGlyph,
                                       positions: *const CGPoint,
-                                      count: size_t);
+                                      count: usize);
 
     fn CGContextSaveGState(c: ::sys::CGContextRef);
     fn CGContextRestoreGState(c: ::sys::CGContextRef);

--- a/core-graphics/src/data_provider.rs
+++ b/core-graphics/src/data_provider.rs
@@ -10,7 +10,6 @@
 use core_foundation::base::{CFRelease, CFRetain, CFTypeID, TCFType};
 use core_foundation::data::{CFData, CFDataRef};
 
-use libc::off_t;
 use std::mem;
 use std::ptr;
 use std::sync::Arc;
@@ -22,13 +21,15 @@ pub type CGDataProviderGetBytesCallback = Option<unsafe extern fn (*mut c_void, 
 pub type CGDataProviderReleaseInfoCallback = Option<unsafe extern fn (*mut c_void)>;
 pub type CGDataProviderRewindCallback = Option<unsafe extern fn (*mut c_void)>;
 pub type CGDataProviderSkipBytesCallback = Option<unsafe extern fn (*mut c_void, usize)>;
-pub type CGDataProviderSkipForwardCallback = Option<unsafe extern fn (*mut c_void, off_t) -> off_t>;
+#[cfg(feature = "libc")]
+pub type CGDataProviderSkipForwardCallback = Option<unsafe extern fn (*mut c_void, libc_::off_t) -> libc_::off_t>;
 
 pub type CGDataProviderGetBytePointerCallback = Option<unsafe extern fn (*mut c_void) -> *mut c_void>;
 pub type CGDataProviderGetBytesAtOffsetCallback = Option<unsafe extern fn (*mut c_void, *mut c_void, usize, usize)>;
 pub type CGDataProviderReleaseBytePointerCallback = Option<unsafe extern fn (*mut c_void, *const c_void)>;
 pub type CGDataProviderReleaseDataCallback = Option<unsafe extern fn (*mut c_void, *const c_void, usize)>;
-pub type CGDataProviderGetBytesAtPositionCallback = Option<unsafe extern fn (*mut c_void, *mut c_void, off_t, usize)>;
+#[cfg(feature = "libc")]
+pub type CGDataProviderGetBytesAtPositionCallback = Option<unsafe extern fn (*mut c_void, *mut c_void, libc_::off_t, usize)>;
 
 foreign_type! {
     #[doc(hidden)]

--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -9,9 +9,9 @@
 
 #![allow(non_upper_case_globals)]
 
-use libc;
 use std::ptr;
 use std::ops::Deref;
+use std::os::raw::{c_double, c_void};
 
 pub use base::{CGError, boolean_t};
 pub use geometry::{CGRect, CGPoint, CGSize};
@@ -99,7 +99,7 @@ pub use core_foundation::array::{ CFArray, CFArrayRef };
 pub use core_foundation::array::{ CFArrayGetCount, CFArrayGetValueAtIndex };
 pub use core_foundation::base::{  CFIndex, CFRelease, CFTypeRef };
 
-pub type CGDisplayConfigRef = *mut libc::c_void;
+pub type CGDisplayConfigRef = *mut c_void;
 
 #[repr(u32)]
 #[derive(Clone, Copy)]
@@ -648,7 +648,7 @@ extern "C" {
     pub fn CGDisplayIsStereo(display: CGDirectDisplayID) -> boolean_t;
     pub fn CGDisplayMirrorsDisplay(display: CGDirectDisplayID) -> CGDirectDisplayID;
     pub fn CGDisplayPrimaryDisplay(display: CGDirectDisplayID) -> CGDirectDisplayID;
-    pub fn CGDisplayRotation(display: CGDirectDisplayID) -> libc::c_double;
+    pub fn CGDisplayRotation(display: CGDirectDisplayID) -> c_double;
     pub fn CGDisplayScreenSize(display: CGDirectDisplayID) -> CGSize;
     pub fn CGDisplaySerialNumber(display: CGDirectDisplayID) -> u32;
     pub fn CGDisplayUnitNumber(display: CGDirectDisplayID) -> u32;
@@ -666,8 +666,8 @@ extern "C" {
         matching_display_count: *mut u32,
     ) -> CGError;
     pub fn CGDisplayModelNumber(display: CGDirectDisplayID) -> u32;
-    pub fn CGDisplayPixelsHigh(display: CGDirectDisplayID) -> libc::size_t;
-    pub fn CGDisplayPixelsWide(display: CGDirectDisplayID) -> libc::size_t;
+    pub fn CGDisplayPixelsHigh(display: CGDirectDisplayID) -> usize;
+    pub fn CGDisplayPixelsWide(display: CGDirectDisplayID) -> usize;
     pub fn CGDisplayBounds(display: CGDirectDisplayID) -> CGRect;
     pub fn CGDisplayCreateImage(display: CGDirectDisplayID) -> ::sys::CGImageRef;
 
@@ -703,11 +703,11 @@ extern "C" {
     pub fn CGRestorePermanentDisplayConfiguration();
 
     pub fn CGDisplayCopyDisplayMode(display: CGDirectDisplayID) -> ::sys::CGDisplayModeRef;
-    pub fn CGDisplayModeGetHeight(mode: ::sys::CGDisplayModeRef) -> libc::size_t;
-    pub fn CGDisplayModeGetWidth(mode: ::sys::CGDisplayModeRef) -> libc::size_t;
-    pub fn CGDisplayModeGetPixelHeight(mode: ::sys::CGDisplayModeRef) -> libc::size_t;
-    pub fn CGDisplayModeGetPixelWidth(mode: ::sys::CGDisplayModeRef) -> libc::size_t;
-    pub fn CGDisplayModeGetRefreshRate(mode: ::sys::CGDisplayModeRef) -> libc::c_double;
+    pub fn CGDisplayModeGetHeight(mode: ::sys::CGDisplayModeRef) -> usize;
+    pub fn CGDisplayModeGetWidth(mode: ::sys::CGDisplayModeRef) -> usize;
+    pub fn CGDisplayModeGetPixelHeight(mode: ::sys::CGDisplayModeRef) -> usize;
+    pub fn CGDisplayModeGetPixelWidth(mode: ::sys::CGDisplayModeRef) -> usize;
+    pub fn CGDisplayModeGetRefreshRate(mode: ::sys::CGDisplayModeRef) -> c_double;
     pub fn CGDisplayModeGetIOFlags(mode: ::sys::CGDisplayModeRef) -> u32;
     pub fn CGDisplayModeCopyPixelEncoding(mode: ::sys::CGDisplayModeRef) -> CFStringRef;
     pub fn CGDisplayModeGetIODisplayModeID(mode: ::sys::CGDisplayModeRef) -> i32;

--- a/core-graphics/src/event.rs
+++ b/core-graphics/src/event.rs
@@ -6,7 +6,7 @@ use core_foundation::{
 use event_source::CGEventSource;
 use foreign_types::ForeignType;
 use geometry::CGPoint;
-use libc::c_void;
+use std::os::raw::{c_ulong, c_void};
 use std::mem::ManuallyDrop;
 
 pub type CGEventField = u32;
@@ -645,7 +645,7 @@ impl CGEvent {
     }
 
     pub fn set_string_from_utf16_unchecked(&self, buf: &[u16]) {
-        let buflen = buf.len() as libc::c_ulong;
+        let buflen = buf.len() as c_ulong;
         unsafe {
             CGEventKeyboardSetUnicodeString(self.as_ptr(), buflen, buf.as_ptr());
         }
@@ -763,7 +763,7 @@ extern {
     /// keyboard event and do their own translation based on the virtual
     /// keycode and perceived event state.
     fn CGEventKeyboardSetUnicodeString(event: ::sys::CGEventRef,
-                                       length: libc::c_ulong,
+                                       length: c_ulong,
                                        string: *const u16);
 
     /// Return the integer value of a field in an event.

--- a/core-graphics/src/event.rs
+++ b/core-graphics/src/event.rs
@@ -614,7 +614,7 @@ impl CGEvent {
     }
 
     #[cfg(feature = "elcapitan")]
-    pub fn post_to_pid(&self, pid: libc::pid_t) {
+    pub fn post_to_pid(&self, pid: libc_::pid_t) {
         unsafe {
             CGEventPostToPid(pid, self.as_ptr());
         }
@@ -736,7 +736,7 @@ extern {
 
     #[cfg(feature = "elcapitan")]
     /// Post an event to a specified process ID
-    fn CGEventPostToPid(pid: libc::pid_t, event: ::sys::CGEventRef);
+    fn CGEventPostToPid(pid: libc_::pid_t, event: ::sys::CGEventRef);
 
     /// Set the event flags of an event.
     fn CGEventSetFlags(event: ::sys::CGEventRef, flags: CGEventFlags);

--- a/core-graphics/src/font.rs
+++ b/core-graphics/src/font.rs
@@ -18,7 +18,7 @@ use geometry::CGRect;
 
 use foreign_types::ForeignType;
 
-use libc::{c_int, size_t};
+use std::os::raw::c_int;
 
 pub use core_graphics_types::base::CGGlyph;
 
@@ -159,12 +159,12 @@ extern {
 
     fn CGFontGetGlyphBBoxes(font: ::sys::CGFontRef,
                             glyphs: *const CGGlyph,
-                            count: size_t,
+                            count: usize,
                             bboxes: *mut CGRect)
                             -> bool;
     fn CGFontGetGlyphAdvances(font: ::sys::CGFontRef,
                               glyphs: *const CGGlyph,
-                              count: size_t,
+                              count: usize,
                               advances: *mut c_int)
                               -> bool;
     fn CGFontGetUnitsPerEm(font: ::sys::CGFontRef) -> c_int;

--- a/core-graphics/src/gradient.rs
+++ b/core-graphics/src/gradient.rs
@@ -17,8 +17,6 @@ use core_foundation::array::{ CFArray, CFArrayRef };
 use core_foundation::base::{CFRelease, CFRetain, TCFType};
 use foreign_types::ForeignType;
 
-use libc::size_t;
-
 bitflags! {
     #[repr(C)]
     pub struct CGGradientDrawingOptions: u32 {
@@ -56,7 +54,7 @@ impl CGGradient {
 
 #[link(name = "CoreGraphics", kind = "framework")]
 extern {
-    fn CGGradientCreateWithColorComponents(color_space: ::sys::CGColorSpaceRef, components: *const CGFloat, locations: *const CGFloat, count: size_t) -> ::sys::CGGradientRef;
+    fn CGGradientCreateWithColorComponents(color_space: ::sys::CGColorSpaceRef, components: *const CGFloat, locations: *const CGFloat, count: usize) -> ::sys::CGGradientRef;
     fn CGGradientCreateWithColors(color_space: ::sys::CGColorSpaceRef, colors: CFArrayRef, locations: *const CGFloat) -> ::sys::CGGradientRef;
 }
 

--- a/core-graphics/src/image.rs
+++ b/core-graphics/src/image.rs
@@ -6,7 +6,6 @@ use core_foundation::data::CFData;
 use color_space::CGColorSpace;
 use data_provider::{CGDataProviderRef, CGDataProvider};
 use geometry::CGRect;
-use libc::size_t;
 use foreign_types::{ForeignType, ForeignTypeRef};
 
 #[repr(C)]
@@ -40,11 +39,11 @@ foreign_type! {
 }
 
 impl CGImage {
-    pub fn new(width: size_t,
-               height: size_t,
-               bits_per_component: size_t,
-               bits_per_pixel: size_t,
-               bytes_per_row: size_t,
+    pub fn new(width: usize,
+               height: usize,
+               bits_per_component: usize,
+               bits_per_pixel: usize,
+               bytes_per_row: usize,
                colorspace: &CGColorSpace,
                bitmap_info: u32,
                provider: &CGDataProvider,
@@ -76,31 +75,31 @@ impl CGImage {
 }
 
 impl CGImageRef {
-    pub fn width(&self) -> size_t {
+    pub fn width(&self) -> usize {
         unsafe {
             CGImageGetWidth(self.as_ptr())
         }
     }
 
-    pub fn height(&self) -> size_t {
+    pub fn height(&self) -> usize {
         unsafe {
             CGImageGetHeight(self.as_ptr())
         }
     }
 
-    pub fn bits_per_component(&self) -> size_t {
+    pub fn bits_per_component(&self) -> usize {
         unsafe {
             CGImageGetBitsPerComponent(self.as_ptr())
         }
     }
 
-    pub fn bits_per_pixel(&self) -> size_t {
+    pub fn bits_per_pixel(&self) -> usize {
         unsafe {
             CGImageGetBitsPerPixel(self.as_ptr())
         }
     }
 
-    pub fn bytes_per_row(&self) -> size_t {
+    pub fn bytes_per_row(&self) -> usize {
         unsafe {
             CGImageGetBytesPerRow(self.as_ptr())
         }
@@ -138,19 +137,19 @@ impl CGImageRef {
 #[link(name = "CoreGraphics", kind = "framework")]
 extern {
     fn CGImageGetTypeID() -> CFTypeID;
-    fn CGImageGetWidth(image: ::sys::CGImageRef) -> size_t;
-    fn CGImageGetHeight(image: ::sys::CGImageRef) -> size_t;
-    fn CGImageGetBitsPerComponent(image: ::sys::CGImageRef) -> size_t;
-    fn CGImageGetBitsPerPixel(image: ::sys::CGImageRef) -> size_t;
-    fn CGImageGetBytesPerRow(image: ::sys::CGImageRef) -> size_t;
+    fn CGImageGetWidth(image: ::sys::CGImageRef) -> usize;
+    fn CGImageGetHeight(image: ::sys::CGImageRef) -> usize;
+    fn CGImageGetBitsPerComponent(image: ::sys::CGImageRef) -> usize;
+    fn CGImageGetBitsPerPixel(image: ::sys::CGImageRef) -> usize;
+    fn CGImageGetBytesPerRow(image: ::sys::CGImageRef) -> usize;
     fn CGImageGetColorSpace(image: ::sys::CGImageRef) -> ::sys::CGColorSpaceRef;
     fn CGImageGetDataProvider(image: ::sys::CGImageRef) -> ::sys::CGDataProviderRef;
     fn CGImageRelease(image: ::sys::CGImageRef);
-    fn CGImageCreate(width: size_t,
-                     height: size_t,
-                     bitsPerComponent: size_t,
-                     bitsPerPixel: size_t,
-                     bytesPerRow: size_t,
+    fn CGImageCreate(width: usize,
+                     height: usize,
+                     bitsPerComponent: usize,
+                     bitsPerPixel: usize,
+                     bytesPerRow: usize,
                      space: ::sys::CGColorSpaceRef,
                      bitmapInfo: u32,
                      provider: ::sys::CGDataProviderRef,

--- a/core-graphics/src/lib.rs
+++ b/core-graphics/src/lib.rs
@@ -7,7 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate libc;
+#[cfg(feature = "libc")]
+extern crate libc_;
 
 #[macro_use]
 extern crate core_foundation;

--- a/core-graphics/src/path.rs
+++ b/core-graphics/src/path.rs
@@ -12,7 +12,7 @@ pub use sys::CGPathRef as SysCGPathRef;
 use core_foundation::base::{CFRelease, CFRetain, CFTypeID};
 use foreign_types::ForeignType;
 use geometry::{CGAffineTransform, CGPoint, CGRect};
-use libc::c_void;
+use std::os::raw::c_void;
 use std::fmt::{self, Debug, Formatter};
 use std::marker::PhantomData;
 use std::ops::Deref;

--- a/core-graphics/src/private.rs
+++ b/core-graphics/src/private.rs
@@ -12,7 +12,7 @@
 //! These are liable to change at any time. Use with caution!
 
 use geometry::CGRect;
-use libc::{c_int, c_uint};
+use std::os::raw::{c_int, c_uint};
 use std::ptr;
 
 pub struct CGSRegion {
@@ -88,7 +88,7 @@ impl CGSSurface {
 
 mod ffi {
     use geometry::CGRect;
-    use libc::{c_int, c_uint};
+    use std::os::raw::{c_int, c_uint};
 
     // This is an enum so that we can't easily make instances of this opaque type.
     pub enum CGSRegionObject {}

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -10,12 +10,13 @@ repository = "https://github.com/servo/core-foundation-rs"
 default-target = "x86_64-apple-darwin"
 
 [features]
-default = ["mountainlion"]
+default = ["mountainlion", "libc"]
 # For OS X 10.7 compat, exclude this feature. It will exclude some things from
 # the exposed APIs in the crate.
 mountainlion = []
+libc = ["core-foundation/libc"]
 
 [dependencies]
 foreign-types = "0.3"
-core-foundation = { path = "../core-foundation", version = "0.9" }
+core-foundation = { path = "../core-foundation", version = "0.9", default-features = false }
 core-graphics = { path = "../core-graphics", version = "0.22.0" }

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -14,9 +14,9 @@ default = ["mountainlion", "libc"]
 # For OS X 10.7 compat, exclude this feature. It will exclude some things from
 # the exposed APIs in the crate.
 mountainlion = []
-libc = ["core-foundation/libc"]
+libc = ["core-foundation/libc", "core-graphics/libc"]
 
 [dependencies]
 foreign-types = "0.3"
 core-foundation = { path = "../core-foundation", version = "0.9", default-features = false }
-core-graphics = { path = "../core-graphics", version = "0.22.0" }
+core-graphics = { path = "../core-graphics", version = "0.22.0", default-features = false }

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -17,6 +17,5 @@ mountainlion = []
 
 [dependencies]
 foreign-types = "0.3"
-libc = "0.2"
 core-foundation = { path = "../core-foundation", version = "0.9" }
 core-graphics = { path = "../core-graphics", version = "0.22.0" }

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "19.2.0"
+version = "19.3.0"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT/Apache-2.0"
@@ -18,5 +18,5 @@ libc = ["core-foundation/libc", "core-graphics/libc"]
 
 [dependencies]
 foreign-types = "0.3"
-core-foundation = { path = "../core-foundation", version = "0.9", default-features = false }
-core-graphics = { path = "../core-graphics", version = "0.22.0", default-features = false }
+core-foundation = { path = "../core-foundation", version = "0.9.4", default-features = false }
+core-graphics = { path = "../core-graphics", version = "0.22.4", default-features = false }

--- a/core-text/src/font.rs
+++ b/core-text/src/font.rs
@@ -28,8 +28,7 @@ use core_graphics::geometry::{CGAffineTransform, CGPoint, CGRect, CGSize};
 use core_graphics::path::CGPath;
 
 use foreign_types::ForeignType;
-use libc::{self, size_t};
-use std::os::raw::c_void;
+use std::os::raw::{c_void, c_uint, c_double};
 use std::ptr;
 
 type CGContextRef = *mut <CGContext as ForeignType>::CType;
@@ -365,7 +364,7 @@ impl CTFont {
         }
     }
 
-    pub fn units_per_em(&self) -> libc::c_uint {
+    pub fn units_per_em(&self) -> c_uint {
         unsafe {
             CTFontGetUnitsPerEm(self.0)
         }
@@ -460,7 +459,7 @@ impl CTFont {
             CTFontDrawGlyphs(self.as_concrete_TypeRef(),
                              glyphs.as_ptr(),
                              positions.as_ptr(),
-                             glyphs.len() as size_t,
+                             glyphs.len() as usize,
                              context.as_ptr())
         }
     }
@@ -639,7 +638,7 @@ extern {
     fn CTFontGetAscent(font: CTFontRef) -> CGFloat;
     fn CTFontGetDescent(font: CTFontRef) -> CGFloat;
     fn CTFontGetLeading(font: CTFontRef) -> CGFloat;
-    fn CTFontGetUnitsPerEm(font: CTFontRef) -> libc::c_uint;
+    fn CTFontGetUnitsPerEm(font: CTFontRef) -> c_uint;
     fn CTFontGetGlyphCount(font: CTFontRef) -> CFIndex;
     fn CTFontGetBoundingBox(font: CTFontRef) -> CGRect;
     fn CTFontGetUnderlinePosition(font: CTFontRef) -> CGFloat;
@@ -663,7 +662,7 @@ extern {
                                   glyphs: *const CGGlyph,
                                   advances: *mut CGSize,
                                   count: CFIndex)
-                                  -> libc::c_double;
+                                  -> c_double;
     fn CTFontGetVerticalTranslationsForGlyphs(font: CTFontRef,
                                               orientation: CTFontOrientation,
                                               glyphs: *const CGGlyph,
@@ -683,7 +682,7 @@ extern {
     fn CTFontDrawGlyphs(font: CTFontRef,
                         glyphs: *const CGGlyph,
                         positions: *const CGPoint,
-                        count: size_t,
+                        count: usize,
                         context: CGContextRef);
     //fn CTFontGetLigatureCaretPositions
 

--- a/core-text/src/font_descriptor.rs
+++ b/core-text/src/font_descriptor.rs
@@ -15,11 +15,9 @@ use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::number::{CFNumber, CFNumberRef};
 use core_foundation::set::CFSetRef;
 use core_foundation::string::{CFString, CFStringRef};
-use core_foundation::url::{CFURL, CFURLRef};
 use core_graphics::base::CGFloat;
 
 use std::os::raw::c_void;
-use std::path::PathBuf;
 
 /*
 * CTFontTraits.h
@@ -259,7 +257,11 @@ impl CTFontDescriptor {
         }
     }
 
-    pub fn font_path(&self) -> Option<PathBuf> {
+    #[cfg(unix)]
+    #[cfg(feature = "libc")]
+    pub fn font_path(&self) -> Option<std::path::PathBuf> {
+        use core_foundation::url::{CFURL, CFURLRef};
+
         unsafe {
             let value = CTFontDescriptorCopyAttribute(self.0, kCTFontURLAttribute);
             if value.is_null() {
@@ -332,6 +334,7 @@ pub fn debug_descriptor(desc: &CTFontDescriptor) {
     println!("name: {}", desc.font_name());
     println!("style: {}", desc.style_name());
     println!("display: {}", desc.display_name());
+    #[cfg(feature = "libc")]
     println!("path: {:?}", desc.font_path());
     desc.show();
 }

--- a/core-text/src/lib.rs
+++ b/core-text/src/lib.rs
@@ -18,7 +18,6 @@ If you don't have one this will cause leaks.
 */
 
 extern crate foreign_types;
-extern crate libc;
 
 #[macro_use]
 extern crate core_foundation;

--- a/io-surface/Cargo.toml
+++ b/io-surface/Cargo.toml
@@ -14,4 +14,3 @@ default-target = "x86_64-apple-darwin"
 core-foundation = { path = "../core-foundation", version = "0.9", default-features = false }
 core-foundation-sys = { path = "../core-foundation-sys", version = "0.8" }
 cgl = "0.3"
-leaky-cow = "0.1.1"

--- a/io-surface/Cargo.toml
+++ b/io-surface/Cargo.toml
@@ -3,7 +3,7 @@ name = "io-surface"
 description = "Bindings to IO Surface for macOS"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 

--- a/io-surface/Cargo.toml
+++ b/io-surface/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT / Apache-2.0"
 default-target = "x86_64-apple-darwin"
 
 [dependencies]
-libc = "0.2"
 core-foundation = { path = "../core-foundation", version = "0.9" }
 core-foundation-sys = { path = "../core-foundation-sys", version = "0.8" }
 cgl = "0.3"

--- a/io-surface/Cargo.toml
+++ b/io-surface/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT / Apache-2.0"
 default-target = "x86_64-apple-darwin"
 
 [dependencies]
-core-foundation = { path = "../core-foundation", version = "0.9" }
+core-foundation = { path = "../core-foundation", version = "0.9", default-features = false }
 core-foundation-sys = { path = "../core-foundation-sys", version = "0.8" }
 cgl = "0.3"
 leaky-cow = "0.1.1"

--- a/io-surface/src/lib.rs
+++ b/io-surface/src/lib.rs
@@ -13,7 +13,6 @@
 extern crate core_foundation;
 extern crate core_foundation_sys;
 extern crate cgl;
-extern crate leaky_cow;
 
 // Rust bindings to the IOSurface framework on macOS.
 
@@ -23,7 +22,6 @@ use core_foundation::string::{CFString, CFStringRef};
 use core_foundation_sys::base::mach_port_t;
 use cgl::{kCGLNoError, CGLGetCurrentContext, CGLTexImageIOSurface2D, CGLErrorString, GLenum};
 use std::os::raw::{c_int, c_void};
-use leaky_cow::LeakyCow;
 use std::slice;
 use std::ffi::CStr;
 
@@ -145,9 +143,7 @@ impl IOSurface {
             if gl_error != kCGLNoError {
                 let error_msg = CStr::from_ptr(CGLErrorString(gl_error));
                 let error_msg = error_msg.to_string_lossy();
-                // This will only actually leak memory if error_msg is a `Cow::Owned`, which
-                // will only happen if the platform gives us invalid unicode.
-                panic!("{}", error_msg.leak());
+                panic!("{}", error_msg);
             }
         }
     }

--- a/io-surface/src/lib.rs
+++ b/io-surface/src/lib.rs
@@ -10,7 +10,6 @@
 #![crate_name = "io_surface"]
 #![crate_type = "rlib"]
 
-extern crate libc;
 extern crate core_foundation;
 extern crate core_foundation_sys;
 extern crate cgl;
@@ -23,8 +22,7 @@ use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::string::{CFString, CFStringRef};
 use core_foundation_sys::base::mach_port_t;
 use cgl::{kCGLNoError, CGLGetCurrentContext, CGLTexImageIOSurface2D, CGLErrorString, GLenum};
-use libc::{c_int, size_t};
-use std::os::raw::c_void;
+use std::os::raw::{c_int, c_void};
 use leaky_cow::LeakyCow;
 use std::slice;
 use std::ffi::CStr;
@@ -141,7 +139,7 @@ impl IOSurface {
                                                   height,
                                                   BGRA as GLenum,
                                                   UNSIGNED_INT_8_8_8_8_REV,
-                                                  self.as_concrete_TypeRef() as *mut libc::c_void,
+                                                  self.as_concrete_TypeRef() as *mut c_void,
                                                   0);
 
             if gl_error != kCGLNoError {
@@ -211,9 +209,9 @@ extern {
     pub fn IOSurfaceUnlock(buffer: IOSurfaceRef, options: u32, seed: *mut u32) -> IOReturn;
     pub fn IOSurfaceGetSeed(buffer: IOSurfaceRef) -> u32;
 
-    pub fn IOSurfaceGetHeight(buffer: IOSurfaceRef) -> size_t;
+    pub fn IOSurfaceGetHeight(buffer: IOSurfaceRef) -> usize;
     pub fn IOSurfaceGetWidth(buffer: IOSurfaceRef) -> usize;
-    pub fn IOSurfaceGetBytesPerRow(buffer: IOSurfaceRef) -> size_t;
+    pub fn IOSurfaceGetBytesPerRow(buffer: IOSurfaceRef) -> usize;
     pub fn IOSurfaceGetBaseAddress(buffer: IOSurfaceRef) -> *mut c_void;
     pub fn IOSurfaceGetElementHeight(buffer: IOSurfaceRef) -> usize;
     pub fn IOSurfaceGetElementWidth(buffer: IOSurfaceRef) -> usize;


### PR DESCRIPTION
Of particular note:
- `libc` is not needed in most cases, one can simply use `std::os::raw`
- `leaky-cow` seems like it existed to work around compiler limitations, these are no more

@jrmuizel I've included version bumps in here as well, would be nice if you could also do a new release after this