### PR TITLE
Add CGContextSetAlpha

### DIFF
--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -612,6 +612,12 @@ impl CGContextRef {
             CGContextSetShadowWithColor(self.as_ptr(), offset, blur, color.as_concrete_TypeRef());
         }
     }
+
+    pub fn set_alpha(&self, alpha: CGFloat) {
+        unsafe {
+            CGContextSetAlpha(self.as_ptr(), alpha);
+        }
+    }
 }
 
 #[test]
@@ -771,5 +777,7 @@ extern {
 
     fn CGContextSetShadow(c: ::sys::CGContextRef, offset: CGSize, blur: CGFloat);
     fn CGContextSetShadowWithColor(c: ::sys::CGContextRef, offset: CGSize, blur: CGFloat, color: ::sys::CGColorRef);
+
+    fn CGContextSetAlpha(c: ::sys::CGContextRef, alpha: CGFloat);
 }
 


### PR DESCRIPTION
Adds the `CGContextSetAlpha` function as `set_alpha`.

From the `CGContextRef.h` file:

```
/* Set the alpha value in the current graphics state of `c' to `alpha'. */

CG_EXTERN void CGContextSetAlpha(CGContextRef cg_nullable c, CGFloat alpha)
    CG_AVAILABLE_STARTING(10.0, 2.0);
```

Tested using the `piet/mondrian` example:
https://github.com/linebender/piet/tree/master/piet-common/examples

The following image was generated with an alpha of 0.5

![image](https://user-images.githubusercontent.com/6184593/194287434-83069151-1ee3-4065-970b-4c5a17d1c6ac.png)
