### PR TITLE
Add CGContextResetClip

### DIFF
--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -389,6 +389,12 @@ impl CGContextRef {
         }
     }
 
+    pub fn reset_clip(&self) {
+        unsafe {
+            CGContextResetClip(self.as_ptr());
+        }
+    }
+
     pub fn draw_path(&self, mode: CGPathDrawingMode) {
         unsafe {
             CGContextDrawPath(self.as_ptr(), mode);
@@ -708,6 +714,7 @@ extern {
     fn CGContextEOFillPath(c: ::sys::CGContextRef);
     fn CGContextClip(c: ::sys::CGContextRef);
     fn CGContextEOClip(c: ::sys::CGContextRef);
+    fn CGContextResetClip(c: ::sys::CGContextRef);
     fn CGContextStrokePath(c: ::sys::CGContextRef);
     fn CGContextSetRGBFillColor(context: ::sys::CGContextRef,
                                 red: CGFloat,


### PR DESCRIPTION
Adds the `CGContextResetClip` function as `context.reset_clip`.

From the `CGContext.h` file:

```
/* Reset the current clip of `c' to the default value. */

CG_EXTERN void CGContextResetClip(CGContextRef c);
```