### PR TITLE
add CGRectContainsPoint and corresponding wrapped method

### DIFF
--- a/core-graphics-types/src/geometry.rs
+++ b/core-graphics-types/src/geometry.rs
@@ -138,6 +138,11 @@ impl CGRect {
             ffi::CGRectApplyAffineTransform(*self, *t)
         }
     }
+
+    #[inline]
+    pub fn contains(&self, point: &CGPoint) -> bool {
+        unsafe { ffi::CGRectContainsPoint(*self,*point) == 1 }
+    }
 }
 
 #[repr(C)]
@@ -190,6 +195,8 @@ mod ffi {
         pub fn CGPointApplyAffineTransform(point: CGPoint, t: CGAffineTransform) -> CGPoint;
         pub fn CGRectApplyAffineTransform(rect: CGRect, t: CGAffineTransform) -> CGRect;
         pub fn CGSizeApplyAffineTransform(size: CGSize, t: CGAffineTransform) -> CGSize;
+
+        pub fn CGRectContainsPoint(rect:CGRect, point: CGPoint) -> boolean_t;
     }
 }
 


### PR DESCRIPTION
This method may be used by a downstream project `Tauri`, https://github.com/tauri-apps/tao/issues/187

Related info about this PR: 

1. [CGRectContainsPoint document](https://developer.apple.com/documentation/coregraphics/1456316-cgrectcontainspoint)
2. [CGRectContainsPoint Header](https://github.com/phracker/MacOSX-SDKs/blob/041600eda65c6a668f66cb7d56b7d1da3e8bcc93/MacOSX10.8.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGGeometry.h#L198)