### PR TITLE
Revert `cocoa` major version bump

### DIFF
--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -4,7 +4,7 @@ name = "cocoa"
 description = "Bindings to Cocoa for macOS"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.25.0"
+version = "0.24.1"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 


### PR DESCRIPTION
39e1e0e is not a breaking change since the NSOpenPanel API has not been published in any stable version.

147a432 is a clear bugfix and didn't work at all before, so while it is breaking public API, no-one could have used it without their program being broken.

See discussion in https://github.com/servo/core-foundation-rs/pull/505