### PR TITLE
Update cocoa Cargo.toml

### DIFF
--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -15,7 +15,7 @@ default-target = "x86_64-apple-darwin"
 block = "0.1"
 bitflags = "1.0"
 libc = "0.2"
-cocoa-foundation = { path = "../cocoa-foundation", version = "0.1" }
+cocoa-foundation = { path = "../cocoa-foundation", version = "0.1.1" }
 core-foundation = { path = "../core-foundation", version = "0.9" }
 core-graphics = { path = "../core-graphics", version = "0.22" }
 foreign-types = "0.3"


### PR DESCRIPTION
Hello, since [this commit ](https://github.com/servo/core-foundation-rs/pull/498) cocoa-foundation went to 0.1.1, but its version hasn't been updated in cocoa Cargo.toml yet.

@jrmuizel could you please check and release a new version if ok?
Thanks.