### PR TITLE
Add binding for CGEventTapPostEvent

### DIFF
--- a/core-graphics/src/event.rs
+++ b/core-graphics/src/event.rs
@@ -607,10 +607,14 @@ impl CGEvent {
         }
     }
 
-    pub fn location(&self) -> CGPoint {
+    pub fn post_from_tap(&self, tap_proxy: CGEventTapProxy) {
         unsafe {
-            CGEventGetLocation(self.as_ptr())
+            CGEventTapPostEvent(tap_proxy, self.as_ptr());
         }
+    }
+
+    pub fn location(&self) -> CGPoint {
+        unsafe { CGEventGetLocation(self.as_ptr()) }
     }
 
     #[cfg(feature = "elcapitan")]
@@ -733,6 +737,8 @@ extern {
     /// instantiated for that location, and the event passes through any such
     /// taps.
     fn CGEventPost(tapLocation: CGEventTapLocation, event: ::sys::CGEventRef);
+
+    fn CGEventTapPostEvent(tapProxy: CGEventTapProxy, event: ::sys::CGEventRef);
 
     #[cfg(feature = "elcapitan")]
     /// Post an event to a specified process ID


### PR DESCRIPTION
This change adds the binding for CGEventTapPostEvent and adds a wrapper function CGEvent::post_from_tap to call the core-graphics function.