### PR TITLE
Add CGDisplayCreateImageForRect function  

### DIFF
--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -261,6 +261,19 @@ impl CGDisplay {
         }
     }
 
+    /// Returns an image containing the contents of a portion of the specified display.
+    #[inline]
+    pub fn image_for_rect(&self, bounds: CGRect) -> Option<CGImage> {
+        unsafe {
+            let image_ref = CGDisplayCreateImageForRect(self.id, bounds);
+            if !image_ref.is_null() {
+                Some(CGImage::from_ptr(image_ref))
+            } else {
+                None
+            }
+        }
+    }
+
     /// Returns a composite image based on a dynamically generated list of
     /// windows.
     #[inline]
@@ -616,7 +629,7 @@ impl CGDisplayMode {
             16
         } else if pixel_encoding.eq_ignore_ascii_case(IO8BitIndexedPixels) {
             8
-        }else{
+        } else {
             0
         }
     }
@@ -670,6 +683,10 @@ extern "C" {
     pub fn CGDisplayPixelsWide(display: CGDirectDisplayID) -> libc::size_t;
     pub fn CGDisplayBounds(display: CGDirectDisplayID) -> CGRect;
     pub fn CGDisplayCreateImage(display: CGDirectDisplayID) -> ::sys::CGImageRef;
+    pub fn CGDisplayCreateImageForRect(
+        display: CGDirectDisplayID,
+        rect: CGRect,
+    ) -> ::sys::CGImageRef;
 
     // Capturing and Releasing Displays
     pub fn CGDisplayCapture(display: CGDirectDisplayID) -> CGError;


### PR DESCRIPTION
Thanks for your work, this crate is very useful to me.
I have a use case to capture a portion of a display. originally I use the method `screenshot`, but this method will capture the mouse cursor, after some google I tried to put  `CGDisplayHideCursor` and `CGDisplayShowCursor` around the `screenshot`. But when my program is not the foreground the cursor won't hide. 
Then I found `CGDisplayCreateImage` and `CGDisplayCreateImageForRect` from apple [document](https://developer.apple.com/documentation/coregraphics/1454595-cgdisplaycreateimageforrect?language=objc), these two worked fine.
I also added a `image_for_rect` method to wrap this unsafe one, just like `image` which is already there. Because the `from_ptr` method is from `ForeignType` trait, and there are some break changes in the foreign-type crates, I think it's a little odd to import a crate that is used by core-display just for this function, and had to keep the same version.
Thanks very much.