### PR TITLE
Update `foreign-types` crate to v0.5

### DIFF
--- a/cocoa-foundation/Cargo.toml
+++ b/cocoa-foundation/Cargo.toml
@@ -17,5 +17,5 @@ bitflags = "1.0"
 libc = "0.2"
 core-foundation = { path = "../core-foundation", version = "0.9" }
 core-graphics-types = { path = "../core-graphics-types", version = "0.1" }
-foreign-types = "0.3"
+foreign-types = "0.5"
 objc = "0.2.3"

--- a/cocoa-foundation/Cargo.toml
+++ b/cocoa-foundation/Cargo.toml
@@ -17,5 +17,4 @@ bitflags = "1.0"
 libc = "0.2"
 core-foundation = { path = "../core-foundation", version = "0.9" }
 core-graphics-types = { path = "../core-graphics-types", version = "0.1" }
-foreign-types = "0.5"
 objc = "0.2.3"

--- a/cocoa-foundation/src/lib.rs
+++ b/cocoa-foundation/src/lib.rs
@@ -14,7 +14,6 @@ extern crate block;
 extern crate bitflags;
 extern crate core_foundation;
 extern crate core_graphics_types;
-extern crate foreign_types;
 extern crate libc;
 #[macro_use]
 extern crate objc;

--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -18,5 +18,5 @@ libc = "0.2"
 cocoa-foundation = { path = "../cocoa-foundation", version = "0.1" }
 core-foundation = { path = "../core-foundation", version = "0.9" }
 core-graphics = { path = "../core-graphics", version = "0.22" }
-foreign-types = "0.3"
+foreign-types = "0.5"
 objc = "0.2.3"

--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bitflags = "1.0"
 core-foundation = { path = "../core-foundation", version = "0.9" }
-foreign-types = "0.3.0"
 libc = "0.2"
 
 [package.metadata.docs.rs]

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -16,7 +16,7 @@ highsierra = []
 bitflags = "1.0"
 core-foundation = { path = "../core-foundation", version = "0.9" }
 core-graphics-types = { path = "../core-graphics-types", version = "0.1" }
-foreign-types = "0.3.0"
+foreign-types = "0.5.0"
 libc = "0.2"
 
 [package.metadata.docs.rs]

--- a/core-graphics/src/color_space.rs
+++ b/core-graphics/src/color_space.rs
@@ -13,11 +13,11 @@ use foreign_types::ForeignType;
 
 foreign_type! {
     #[doc(hidden)]
-    type CType = ::sys::CGColorSpace;
-    fn drop = |p| CFRelease(p as *mut _);
-    fn clone = |p| CFRetain(p as *const _) as *mut _;
-    pub struct CGColorSpace;
-    pub struct CGColorSpaceRef;
+    pub unsafe type CGColorSpace {
+        type CType = ::sys::CGColorSpace;
+        fn drop = |p| CFRelease(p as *mut _);
+        fn clone = |p| CFRetain(p as *const _) as *mut _;
+    }
 }
 
 impl CGColorSpace {

--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -109,11 +109,11 @@ pub enum CGInterpolationQuality {
 
 foreign_type! {
     #[doc(hidden)]
-    type CType = ::sys::CGContext;
-    fn drop = |cs| CGContextRelease(cs);
-    fn clone = |p| CGContextRetain(p);
-    pub struct CGContext;
-    pub struct CGContextRef;
+    pub unsafe type CGContext {
+        type CType = ::sys::CGContext;
+        fn drop = |cs| CGContextRelease(cs);
+        fn clone = |p| CGContextRetain(p);
+    }
 }
 
 impl CGContext {

--- a/core-graphics/src/data_provider.rs
+++ b/core-graphics/src/data_provider.rs
@@ -32,11 +32,11 @@ pub type CGDataProviderGetBytesAtPositionCallback = Option<unsafe extern fn (*mu
 
 foreign_type! {
     #[doc(hidden)]
-    type CType = ::sys::CGDataProvider;
-    fn drop = |cs| CFRelease(cs as *mut _);
-    fn clone = |p| CFRetain(p as *const _) as *mut _;
-    pub struct CGDataProvider;
-    pub struct CGDataProviderRef;
+    pub unsafe type CGDataProvider {
+        type CType = ::sys::CGDataProvider;
+        fn drop = |cs| CFRelease(cs as *mut _);
+        fn clone = |p| CFRetain(p as *const _) as *mut _;
+    }
 }
 
 impl CGDataProvider {

--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -116,11 +116,11 @@ pub struct CGDisplay {
 
 foreign_type! {
     #[doc(hidden)]
-    type CType = ::sys::CGDisplayMode;
-    fn drop = CGDisplayModeRelease;
-    fn clone = |p| CFRetain(p as *const _) as *mut _;
-    pub struct CGDisplayMode;
-    pub struct CGDisplayModeRef;
+    pub unsafe type CGDisplayMode {
+        type CType = ::sys::CGDisplayMode;
+        fn drop = CGDisplayModeRelease;
+        fn clone = |p| CFRetain(p as *const _) as *mut _;
+    }
 }
 
 impl CGDisplay {

--- a/core-graphics/src/event.rs
+++ b/core-graphics/src/event.rs
@@ -518,11 +518,11 @@ impl<'tap_life> CGEventTap<'tap_life> {
 
 foreign_type! {
     #[doc(hidden)]
-    type CType = ::sys::CGEvent;
-    fn drop = |p| CFRelease(p as *mut _);
-    fn clone = |p| CFRetain(p as *const _) as *mut _;
-    pub struct CGEvent;
-    pub struct CGEventRef;
+    pub unsafe type CGEvent {
+        type CType = ::sys::CGEvent;
+        fn drop = |p| CFRelease(p as *mut _);
+        fn clone = |p| CFRetain(p as *const _) as *mut _;
+    }
 }
 
 impl CGEvent {

--- a/core-graphics/src/event_source.rs
+++ b/core-graphics/src/event_source.rs
@@ -12,11 +12,11 @@ pub enum CGEventSourceStateID {
 
 foreign_type! {
     #[doc(hidden)]
-    type CType = ::sys::CGEventSource;
-    fn drop = |p| CFRelease(p as *mut _);
-    fn clone = |p| CFRetain(p as *const _) as *mut _;
-    pub struct CGEventSource;
-    pub struct CGEventSourceRef;
+    pub unsafe type CGEventSource {
+        type CType = ::sys::CGEventSource;
+        fn drop = |p| CFRelease(p as *mut _);
+        fn clone = |p| CFRetain(p as *const _) as *mut _;
+    }
 }
 
 impl CGEventSource {

--- a/core-graphics/src/gradient.rs
+++ b/core-graphics/src/gradient.rs
@@ -29,11 +29,11 @@ bitflags! {
 
 foreign_type! {
     #[doc(hidden)]
-    type CType = ::sys::CGGradient;
-    fn drop = |p| CFRelease(p as *mut _);
-    fn clone = |p| CFRetain(p as *const _) as *mut _;
-    pub struct CGGradient;
-    pub struct CGGradientRef;
+    pub unsafe type CGGradient {
+        type CType = ::sys::CGGradient;
+        fn drop = |p| CFRelease(p as *mut _);
+        fn clone = |p| CFRetain(p as *const _) as *mut _;
+    }
 }
 
 impl CGGradient {

--- a/core-graphics/src/image.rs
+++ b/core-graphics/src/image.rs
@@ -32,11 +32,11 @@ pub enum CGImageByteOrderInfo {
 
 foreign_type! {
     #[doc(hidden)]
-    type CType = ::sys::CGImage;
-    fn drop = CGImageRelease;
-    fn clone = |p| CFRetain(p as *const _) as *mut _;
-    pub struct CGImage;
-    pub struct CGImageRef;
+    pub unsafe type CGImage {
+        type CType = ::sys::CGImage;
+        fn drop = CGImageRelease;
+        fn clone = |p| CFRetain(p as *const _) as *mut _;
+    }
 }
 
 impl CGImage {

--- a/core-graphics/src/path.rs
+++ b/core-graphics/src/path.rs
@@ -21,11 +21,11 @@ use std::slice;
 
 foreign_type! {
     #[doc(hidden)]
-    type CType = ::sys::CGPath;
-    fn drop = |p| CFRelease(p as *mut _);
-    fn clone = |p| CFRetain(p as *const _) as *mut _;
-    pub struct CGPath;
-    pub struct CGPathRef;
+    pub unsafe type CGPath {
+        type CType = ::sys::CGPath;
+        fn drop = |p| CFRelease(p as *mut _);
+        fn clone = |p| CFRetain(p as *const _) as *mut _;
+    }
 }
 
 impl CGPath {
@@ -35,7 +35,7 @@ impl CGPath {
                 None => ptr::null(),
                 Some(transform) => transform as *const CGAffineTransform,
             };
-            CGPath(CGPathCreateWithRect(rect, transform))
+            CGPath::from_ptr(CGPathCreateWithRect(rect, transform))
         }
     }
 

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -16,7 +16,7 @@ default = ["mountainlion"]
 mountainlion = []
 
 [dependencies]
-foreign-types = "0.3"
+foreign-types = "0.5"
 libc = "0.2"
 core-foundation = { path = "../core-foundation", version = "0.9" }
 core-graphics = { path = "../core-graphics", version = "0.22.0" }


### PR DESCRIPTION
Splits out the `foreign-types` part of https://github.com/servo/core-foundation-rs/pull/545