### PR TITLE
Bump macOS GitHub actions to macOS 11

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11.0, macos-10.15]
+        os: [macos-11.0]
     steps:
     - uses: actions/checkout@v2
     - name: Build


### PR DESCRIPTION
macOS 10.15 runner image is removed since 8/30/22
(https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/).
Using it makes GitHub Actions stuck forever.