### PR TITLE
Add binding for ScreenCaptureAccess

### DIFF
--- a/core-graphics/src/access.rs
+++ b/core-graphics/src/access.rs
@@ -1,8 +1,26 @@
 pub use base::boolean_t;
 
+#[derive(Default)]
+pub struct ScreenCaptureAccess;
+
+impl ScreenCaptureAccess {
+    /// If current app not in list, will open window.
+    /// Return the same result as preflight.
+    #[inline]
+    pub fn request(&self) -> bool {
+        unsafe { CGRequestScreenCaptureAccess() == 1 }
+    }
+
+    /// Return true if has access
+    #[inline]
+    pub fn preflight(&self) -> bool {
+        unsafe { CGPreflightScreenCaptureAccess() == 1 }
+    }
+}
+
 #[link(name = "CoreGraphics", kind = "framework")]
 extern "C" {
     // Screen Capture Access
-    pub fn CGRequestScreenCaptureAccess() -> boolean_t;
-    pub fn CGPreflightScreenCaptureAccess() -> boolean_t;
+    fn CGRequestScreenCaptureAccess() -> boolean_t;
+    fn CGPreflightScreenCaptureAccess() -> boolean_t;
 }

--- a/core-graphics/src/access.rs
+++ b/core-graphics/src/access.rs
@@ -1,0 +1,8 @@
+pub use base::boolean_t;
+
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    // Screen Capture Access
+    pub fn CGRequestScreenCaptureAccess() -> boolean_t;
+    pub fn CGPreflightScreenCaptureAccess() -> boolean_t;
+}

--- a/core-graphics/src/lib.rs
+++ b/core-graphics/src/lib.rs
@@ -41,3 +41,5 @@ pub mod private;
 pub mod image;
 pub mod path;
 pub mod sys;
+#[cfg(target_os = "macos")]
+pub mod access;


### PR DESCRIPTION
Add binding for [CGRequestScreenCaptureAccess](https://developer.apple.com/documentation/coregraphics/3656524-cgrequestscreencaptureaccess) and [CGPreflightScreenCaptureAccess](https://developer.apple.com/documentation/coregraphics/3656523-cgpreflightscreencaptureaccess) 

 to check if the app has screen recording permission on macOS