### PR TITLE
CFArray (sys): Add missing functions & sorting

### DIFF
--- a/core-foundation-sys/src/array.rs
+++ b/core-foundation-sys/src/array.rs
@@ -20,7 +20,7 @@ pub type CFArrayApplierFunction = extern "C" fn(value: *const c_void, context: *
 pub type CFComparatorFunction = extern "C" fn(val1: *const c_void, val2: *const c_void) -> CFComparisonResult;
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct CFArrayCallBacks {
     pub version: CFIndex,
     pub retain: CFArrayRetainCallBack,
@@ -39,29 +39,41 @@ extern {
     /*
      * CFArray.h
      */
+
     pub static kCFTypeArrayCallBacks: CFArrayCallBacks;
 
-    pub fn CFArrayGetTypeID() -> CFTypeID;
+    /* CFArray */
+    /* Creating an Array */
     pub fn CFArrayCreate(allocator: CFAllocatorRef, values: *const *const c_void, numValues: CFIndex, callBacks: *const CFArrayCallBacks) -> CFArrayRef;
     pub fn CFArrayCreateCopy(allocator: CFAllocatorRef , theArray: CFArrayRef) -> CFArrayRef;
-    pub fn CFArrayCreateMutable(allocator: CFAllocatorRef, capacity: CFIndex, callBacks: *const CFArrayCallBacks) -> CFMutableArrayRef;
-    pub fn CFArrayCreateMutableCopy(allocator: CFAllocatorRef, capacity: CFIndex, theArray: CFArrayRef)-> CFMutableArrayRef;
+
+    /* Examining an Array */
+    pub fn CFArrayBSearchValues(theArray: CFArrayRef, range: CFRange, value: *const c_void, comparator: CFComparatorFunction, context: *mut c_void) -> CFIndex;
+    pub fn CFArrayContainsValue(theArray: CFArrayRef, range: CFRange, value: *const c_void) -> Boolean;
     pub fn CFArrayGetCount(theArray: CFArrayRef) -> CFIndex;
     pub fn CFArrayGetCountOfValue(theArray: CFArrayRef, range: CFRange, value: *const c_void) -> CFIndex;
-    pub fn CFArrayContainsValue(theArray: CFArrayRef, range: CFRange, value: *const c_void) -> Boolean;
-    pub fn CFArrayGetValueAtIndex(theArray: CFArrayRef, idx: CFIndex) -> *const c_void;
-    pub fn CFArrayGetValues(theArray: CFArrayRef, range: CFRange, values: *mut *const c_void);
-    pub fn CFArrayApplyFunction(theArray: CFArrayRef, range: CFRange, applier: CFArrayApplierFunction, context: *mut c_void);
     pub fn CFArrayGetFirstIndexOfValue(theArray: CFArrayRef, range: CFRange, value: *const c_void) -> CFIndex;
     pub fn CFArrayGetLastIndexOfValue(theArray: CFArrayRef, range: CFRange, value: *const c_void) -> CFIndex;
-    pub fn CFArrayBSearchValues(theArray: CFArrayRef, range: CFRange, value: *const c_void, comparator: CFComparatorFunction, context: *mut c_void) -> CFIndex;
+    pub fn CFArrayGetValues(theArray: CFArrayRef, range: CFRange, values: *mut *const c_void);
+    pub fn CFArrayGetValueAtIndex(theArray: CFArrayRef, idx: CFIndex) -> *const c_void;
+
+    /* Applying a Function to Elements */
+    pub fn CFArrayApplyFunction(theArray: CFArrayRef, range: CFRange, applier: CFArrayApplierFunction, context: *mut c_void);
+
+    /* Getting the CFArray Type ID */
+    pub fn CFArrayGetTypeID() -> CFTypeID;
+
+    /* CFMutableArray */
+    /* CFMutableArray Miscellaneous Functions */
+    pub fn CFArrayAppendArray(theArray: CFMutableArrayRef, otherArray: CFArrayRef, otherRange: CFRange);
     pub fn CFArrayAppendValue(theArray: CFMutableArrayRef, value: *const c_void);
-    pub fn CFArrayInsertValueAtIndex(theArray: CFMutableArrayRef, idx: CFIndex, value: *const c_void);
-    pub fn CFArraySetValueAtIndex(theArray: CFMutableArrayRef, idx: CFIndex, value: *const c_void);
-    pub fn CFArrayRemoveValueAtIndex(theArray: CFMutableArrayRef, idx: CFIndex);
-    pub fn CFArrayRemoveAllValues(theArray: CFMutableArrayRef);
-    pub fn CFArrayReplaceValues(theArray: CFMutableArrayRef, range: CFRange, newValues: *mut *const c_void, newCount: CFIndex);
+    pub fn CFArrayCreateMutable(allocator: CFAllocatorRef, capacity: CFIndex, callBacks: *const CFArrayCallBacks) -> CFMutableArrayRef;
+    pub fn CFArrayCreateMutableCopy(allocator: CFAllocatorRef, capacity: CFIndex, theArray: CFArrayRef)-> CFMutableArrayRef;
     pub fn CFArrayExchangeValuesAtIndices(theArray: CFMutableArrayRef, idx1: CFIndex, idx2: CFIndex);
+    pub fn CFArrayInsertValueAtIndex(theArray: CFMutableArrayRef, idx: CFIndex, value: *const c_void);
+    pub fn CFArrayRemoveAllValues(theArray: CFMutableArrayRef);
+    pub fn CFArrayRemoveValueAtIndex(theArray: CFMutableArrayRef, idx: CFIndex);
+    pub fn CFArrayReplaceValues(theArray: CFMutableArrayRef, range: CFRange, newValues: *mut *const c_void, newCount: CFIndex);
+    pub fn CFArraySetValueAtIndex(theArray: CFMutableArrayRef, idx: CFIndex, value: *const c_void);
     pub fn CFArraySortValues(theArray: CFMutableArrayRef, range: CFRange, comparator: CFComparatorFunction, context: *mut c_void);
-    pub fn CFArrayAppendArray(theArray: CFMutableArrayRef, otherArray: CFArrayRef, otherRange: CFRange );
 }


### PR DESCRIPTION
Adds missings functions for CFArray and sorts them in Apple docs order (https://developer.apple.com/documentation/corefoundation/cfarray?language=objc and https://developer.apple.com/documentation/corefoundation/cfmutablearray?language=objc).