### PR TITLE
Release cocoa patch to match up with latest core-graphics patch

### DIFF
--- a/cocoa-foundation/Cargo.toml
+++ b/cocoa-foundation/Cargo.toml
@@ -4,7 +4,7 @@ name = "cocoa-foundation"
 description = "Bindings to Cocoa Foundation for macOS"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 

--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -4,7 +4,7 @@ name = "cocoa"
 description = "Bindings to Cocoa for macOS"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.24.1"
+version = "0.24.2"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 

--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics-types"
 description = "Bindings for some fundamental Core Graphics types"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Related to https://github.com/servo/core-foundation-rs/pull/560 

resolves #561 

This release is needed for cocoa@0.24 to build