### PR TITLE
CFCharacterSet (sys): Add missing functions & sorting

### DIFF
--- a/core-foundation-sys/src/characterset.rs
+++ b/core-foundation-sys/src/characterset.rs
@@ -8,9 +8,9 @@
 // except according to those terms.
 
 use std::os::raw::c_void;
-use base::{Boolean, CFAllocatorRef, CFIndex, CFRange, CFTypeID};
+use base::{Boolean, CFAllocatorRef, CFIndex, CFRange, CFTypeID, UTF32Char, UniChar};
 use data::CFDataRef;
-use string::{CFStringRef, UniChar};
+use string::CFStringRef;
 
 pub type CFCharacterSetPredefinedSet = CFIndex;
 
@@ -35,24 +35,49 @@ pub static kCFCharacterSetNewline: CFCharacterSetPredefinedSet = 15;
 pub struct __CFCharacterSet(c_void);
 
 pub type CFCharacterSetRef = *const __CFCharacterSet;
-pub type CFMutableCharacterSetRef = *const __CFCharacterSet;
+pub type CFMutableCharacterSetRef = *mut __CFCharacterSet;
 
 extern {
-    pub fn CFCharacterSetGetTypeID() -> CFTypeID;
-    pub fn CFCharacterSetGetPredefined(theSetIdentifier: CFCharacterSetPredefinedSet) -> CFCharacterSetRef;
+    /*
+     * CFCharacterSet.h
+     */
+
+    /* CFCharacterSet */
+    /* Creating Character Sets */
+    pub fn CFCharacterSetCreateCopy(alloc: CFAllocatorRef, theSet: CFCharacterSetRef) -> CFCharacterSetRef;
+    pub fn CFCharacterSetCreateInvertedSet(alloc: CFAllocatorRef, theSet: CFCharacterSetRef) -> CFCharacterSetRef;
     pub fn CFCharacterSetCreateWithCharactersInRange(alloc: CFAllocatorRef, theRange: CFRange) -> CFCharacterSetRef;
     pub fn CFCharacterSetCreateWithCharactersInString(alloc: CFAllocatorRef, theString: CFStringRef) -> CFCharacterSetRef;
     pub fn CFCharacterSetCreateWithBitmapRepresentation(alloc: CFAllocatorRef, theData: CFDataRef) -> CFCharacterSetRef;
-    pub fn CFCharacterSetCreateMutable(alloc: CFAllocatorRef) -> CFMutableCharacterSetRef;
-    pub fn CFCharacterSetCreateCopy(alloc: CFAllocatorRef, theSet: CFCharacterSetRef) -> CFCharacterSetRef;
-    pub fn CFCharacterSetCreateMutableCopy(alloc: CFAllocatorRef, theSet: CFCharacterSetRef) -> CFMutableCharacterSetRef;
-    pub fn CFCharacterSetIsCharacterMember(theSet: CFCharacterSetRef, theChar: UniChar) -> Boolean;
+
+    /* Getting Predefined Character Sets */
+    pub fn CFCharacterSetGetPredefined(theSetIdentifier: CFCharacterSetPredefinedSet) -> CFCharacterSetRef;
+
+    /* Querying Character Sets */
     pub fn CFCharacterSetCreateBitmapRepresentation(alloc: CFAllocatorRef, theSet: CFCharacterSetRef) -> CFDataRef;
+    pub fn CFCharacterSetHasMemberInPlane(theSet: CFCharacterSetRef, thePlane: CFIndex) -> Boolean;
+    pub fn CFCharacterSetIsCharacterMember(theSet: CFCharacterSetRef, theChar: UniChar) -> Boolean;
+    pub fn CFCharacterSetIsLongCharacterMember(theSet: CFCharacterSetRef, theChar: UTF32Char) -> Boolean;
+    pub fn CFCharacterSetIsSupersetOfSet(theSet: CFCharacterSetRef, theOtherset: CFCharacterSetRef) -> Boolean;
+
+    /* Getting the Character Set Type Identifier */
+    pub fn CFCharacterSetGetTypeID() -> CFTypeID;
+
+    /* CFMutableCharacterSet */
+    /* Creating a Mutable Character Set */
+    pub fn CFCharacterSetCreateMutable(alloc: CFAllocatorRef) -> CFMutableCharacterSetRef;
+    pub fn CFCharacterSetCreateMutableCopy(alloc: CFAllocatorRef, theSet: CFCharacterSetRef) -> CFMutableCharacterSetRef;
+
+    /* Adding Characters */
     pub fn CFCharacterSetAddCharactersInRange(theSet: CFMutableCharacterSetRef, theRange: CFRange);
+    pub fn CFCharacterSetAddCharactersInString(theSet: CFMutableCharacterSetRef, theString: CFStringRef);
+
+    /* Removing Characters */
     pub fn CFCharacterSetRemoveCharactersInRange(theSet: CFMutableCharacterSetRef, theRange: CFRange);
-    pub fn CFCharacterSetAddCharactersInString(theSet: CFMutableCharacterSetRef,  theString: CFStringRef);
     pub fn CFCharacterSetRemoveCharactersInString(theSet: CFMutableCharacterSetRef, theString: CFStringRef);
-    pub fn CFCharacterSetUnion(theSet: CFMutableCharacterSetRef, theOtherSet: CFCharacterSetRef);
+
+    /* Logical Operations */
     pub fn CFCharacterSetIntersect(theSet: CFMutableCharacterSetRef, theOtherSet: CFCharacterSetRef);
     pub fn CFCharacterSetInvert(theSet: CFMutableCharacterSetRef);
+    pub fn CFCharacterSetUnion(theSet: CFMutableCharacterSetRef, theOtherSet: CFCharacterSetRef);
 }


### PR DESCRIPTION
Adds missing functions and sorts them in Apple docs order. CFMutableCharacterSetRef is a mutable pointer now as it should be, according to CFCharacterSet.h.