### PR TITLE
CFError (sys): Add missing functions & consts

### DIFF
--- a/core-foundation-sys/src/error.rs
+++ b/core-foundation-sys/src/error.rs
@@ -32,6 +32,7 @@ extern "C" {
 
     /* Keys for the user info dictionary */
     pub static kCFErrorLocalizedDescriptionKey: CFStringRef;
+    // pub static kCFErrorLocalizedFailureKey: CFStringRef; // macos(10.13)+
     pub static kCFErrorLocalizedFailureReasonKey: CFStringRef;
     pub static kCFErrorLocalizedRecoverySuggestionKey: CFStringRef;
     pub static kCFErrorDescriptionKey: CFStringRef;

--- a/core-foundation-sys/src/error.rs
+++ b/core-foundation-sys/src/error.rs
@@ -9,24 +9,48 @@
 
 use std::os::raw::c_void;
 
-use base::{CFTypeID, CFIndex};
+use base::{CFTypeID, CFIndex, CFAllocatorRef};
 use string::CFStringRef;
+use dictionary::CFDictionaryRef;
 
 #[repr(C)]
 pub struct __CFError(c_void);
 
 pub type CFErrorRef = *mut __CFError;
+pub type CFErrorDomain = CFStringRef;
 
 extern "C" {
-    pub fn CFErrorGetTypeID() -> CFTypeID;
+    /*
+     * CFError.h
+     */
 
+    /* Error domains */
     pub static kCFErrorDomainPOSIX: CFStringRef;
     pub static kCFErrorDomainOSStatus: CFStringRef;
     pub static kCFErrorDomainMach: CFStringRef;
     pub static kCFErrorDomainCocoa: CFStringRef;
 
+    /* Keys for the user info dictionary */
+    pub static kCFErrorLocalizedDescriptionKey: CFStringRef;
+    pub static kCFErrorLocalizedFailureReasonKey: CFStringRef;
+    pub static kCFErrorLocalizedRecoverySuggestionKey: CFStringRef;
+    pub static kCFErrorDescriptionKey: CFStringRef;
+    pub static kCFErrorUnderlyingErrorKey: CFStringRef;
+    pub static kCFErrorURLKey: CFStringRef;
+    pub static kCFErrorFilePathKey: CFStringRef;
+
+    /* Creating a CFError */
+    pub fn CFErrorCreate(allocator: CFAllocatorRef, domain: CFErrorDomain, code: CFIndex, userInfo: CFDictionaryRef) -> CFErrorRef;
+    //pub fn CFErrorCreateWithUserInfoKeysAndValues
+
+    /* Getting Information About an Error */
     pub fn CFErrorGetDomain(err: CFErrorRef) -> CFStringRef;
     pub fn CFErrorGetCode(err: CFErrorRef) -> CFIndex;
-
+    pub fn CFErrorCopyUserInfo(err: CFErrorRef) -> CFDictionaryRef;
     pub fn CFErrorCopyDescription(err: CFErrorRef) -> CFStringRef;
+    pub fn CFErrorCopyFailureReason(err: CFErrorRef) -> CFStringRef;
+    pub fn CFErrorCopyRecoverySuggestion(err: CFErrorRef) -> CFStringRef;
+
+    /* Getting the CFError Type ID */
+    pub fn CFErrorGetTypeID() -> CFTypeID;
 }


### PR DESCRIPTION
Adds missing functions and consts of CFError and sorts them in Apple docs order.