### PR TITLE
sys: messageport: Sort functions, add error codes

### DIFF
--- a/core-foundation-sys/src/messageport.rs
+++ b/core-foundation-sys/src/messageport.rs
@@ -9,15 +9,14 @@
 
 use std::os::raw::c_void;
 
-use base::{CFAllocatorRef, CFIndex, CFTypeID, Boolean};
+use base::{CFAllocatorRef, CFIndex, CFTypeID, Boolean, SInt32};
 use data::CFDataRef;
 use date::CFTimeInterval;
 use runloop::CFRunLoopSourceRef;
 use string::CFStringRef;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct CFMessagePortContext {
     pub version: CFIndex,
     pub info: *mut c_void,
@@ -36,6 +35,14 @@ pub type CFMessagePortCallBack = Option<
 pub type CFMessagePortInvalidationCallBack = Option<
     unsafe extern "C" fn(ms: CFMessagePortRef, info: *mut c_void)>;
 
+/* CFMessagePortSendRequest Error Codes */
+pub const kCFMessagePortSuccess: SInt32 = 0;
+pub const kCFMessagePortSendTimeout: SInt32 = -1;
+pub const kCFMessagePortReceiveTimeout: SInt32 = -2;
+pub const kCFMessagePortIsInvalid: SInt32 = -3;
+pub const kCFMessagePortTransportError: SInt32 = -4;
+pub const kCFMessagePortBecameInvalidError: SInt32 = -5;
+
 #[repr(C)]
 pub struct __CFMessagePort(c_void);
 pub type CFMessagePortRef = *mut __CFMessagePort;
@@ -44,36 +51,28 @@ extern {
     /*
      * CFMessagePort.h
      */
-    pub fn CFMessagePortGetTypeID() -> CFTypeID;
-    pub fn CFMessagePortCreateLocal(allocator: CFAllocatorRef,
-                                    name: CFStringRef,
-                                    callout: CFMessagePortCallBack,
-                                    context: *const CFMessagePortContext,
-                                    shouldFreeInfo: *mut Boolean)
-        -> CFMessagePortRef;
-    pub fn CFMessagePortCreateRemote(allocator: CFAllocatorRef,
-                                     name: CFStringRef) -> CFMessagePortRef;
-    pub fn CFMessagePortIsRemote(ms: CFMessagePortRef) -> Boolean;
-    pub fn CFMessagePortGetName(ms: CFMessagePortRef) -> CFStringRef;
-    pub fn CFMessagePortSetName(ms: CFMessagePortRef, newName: CFStringRef)
-        -> Boolean;
-    pub fn CFMessagePortGetContext(ms: CFMessagePortRef,
-                                   context: *mut CFMessagePortContext);
+
+    /* Creating a CFMessagePort Object */
+    pub fn CFMessagePortCreateLocal(allocator: CFAllocatorRef, name: CFStringRef, callout: CFMessagePortCallBack, context: *const CFMessagePortContext, shouldFreeInfo: *mut Boolean) -> CFMessagePortRef;
+    pub fn CFMessagePortCreateRemote(allocator: CFAllocatorRef, name: CFStringRef) -> CFMessagePortRef;
+
+    /* Configuring a CFMessagePort Object */
+    pub fn CFMessagePortCreateRunLoopSource(allocator: CFAllocatorRef, local: CFMessagePortRef, order: CFIndex) -> CFRunLoopSourceRef;
+    pub fn CFMessagePortSetInvalidationCallBack(ms: CFMessagePortRef, callout: CFMessagePortInvalidationCallBack);
+    pub fn CFMessagePortSetName(ms: CFMessagePortRef, newName: CFStringRef) -> Boolean;
+
+    /* Using a Message Port */
     pub fn CFMessagePortInvalidate(ms: CFMessagePortRef);
+    pub fn CFMessagePortSendRequest(remote: CFMessagePortRef, msgid: i32, data: CFDataRef, sendTimeout: CFTimeInterval, rcvTimeout: CFTimeInterval, replyMode: CFStringRef, returnData: *mut CFDataRef) -> i32;
+    //pub fn CFMessagePortSetDispatchQueue(ms: CFMessagePortRef, queue: dispatch_queue_t);
+
+    /* Examining a Message Port */
+    pub fn CFMessagePortGetContext(ms: CFMessagePortRef, context: *mut CFMessagePortContext);
+    pub fn CFMessagePortGetInvalidationCallBack(ms: CFMessagePortRef) -> CFMessagePortInvalidationCallBack;
+    pub fn CFMessagePortGetName(ms: CFMessagePortRef) -> CFStringRef;
+    pub fn CFMessagePortIsRemote(ms: CFMessagePortRef) -> Boolean;
     pub fn CFMessagePortIsValid(ms: CFMessagePortRef) -> Boolean;
-    pub fn CFMessagePortGetInvalidationCallBack(ms: CFMessagePortRef)
-        -> CFMessagePortInvalidationCallBack;
-    pub fn CFMessagePortSetInvalidationCallBack(ms: CFMessagePortRef,
-                                                callout: CFMessagePortInvalidationCallBack);
-    pub fn CFMessagePortSendRequest(remote: CFMessagePortRef, msgid: i32,
-                                    data: CFDataRef,
-                                    sendTimeout: CFTimeInterval,
-                                    rcvTimeout: CFTimeInterval,
-                                    replyMode: CFStringRef,
-                                    returnData: *mut CFDataRef) -> i32;
-    pub fn CFMessagePortCreateRunLoopSource(allocator: CFAllocatorRef,
-                                            local: CFMessagePortRef,
-                                            order: CFIndex)
-        -> CFRunLoopSourceRef;
-    // CFMessagePortSetDispatchQueue
+
+    /* Getting the CFMessagePort Type ID */
+    pub fn CFMessagePortGetTypeID() -> CFTypeID;
 }


### PR DESCRIPTION
Sorts all functions of CFMessagePort in Apple docs order, adds constants of CFMessagePortSendRequest Error Codes.