### PR TITLE
sys: set: Add missing stuff, implement CFMutableSet

### DIFF
--- a/core-foundation-sys/src/set.rs
+++ b/core-foundation-sys/src/set.rs
@@ -9,15 +9,15 @@
 
 use std::os::raw::c_void;
 
-use base::{CFAllocatorRef, CFIndex, CFTypeID, Boolean};
+use base::{CFAllocatorRef, CFIndex, CFTypeID, Boolean, CFHashCode};
+use string::CFStringRef;
 
-pub type CFSetApplierFunction = extern "C" fn (value: *const c_void,
-                                               context: *const c_void);
-pub type CFSetRetainCallBack = *const u8;
-pub type CFSetReleaseCallBack = *const u8;
-pub type CFSetCopyDescriptionCallBack = *const u8;
-pub type CFSetEqualCallBack = *const u8;
-pub type CFSetHashCallBack = *const u8;
+pub type CFSetApplierFunction = extern "C" fn (value: *const c_void, context: *const c_void);
+pub type CFSetRetainCallBack = extern "C" fn (allocator: CFAllocatorRef, value: *const c_void) -> *const c_void;
+pub type CFSetReleaseCallBack = extern "C" fn (allocator: CFAllocatorRef, value: *const c_void);
+pub type CFSetCopyDescriptionCallBack = extern "C" fn (value: *const c_void) -> CFStringRef;
+pub type CFSetEqualCallBack = extern "C" fn (value1: *const c_void, value2: *const c_void) -> Boolean;
+pub type CFSetHashCallBack = extern "C" fn (value: *const c_void) -> CFHashCode;
 
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/core-foundation-sys/src/set.rs
+++ b/core-foundation-sys/src/set.rs
@@ -34,6 +34,7 @@ pub struct CFSetCallBacks {
 pub struct __CFSet(c_void);
 
 pub type CFSetRef = *const __CFSet;
+pub type CFMutableSetRef = *mut __CFSet;
 
 extern {
     /*
@@ -41,10 +42,11 @@ extern {
      */
 
     pub static kCFTypeSetCallBacks: CFSetCallBacks;
+    pub static kCFCopyStringSetCallBacks: CFSetCallBacks;
 
+    /* CFSet */
     /* Creating Sets */
-    pub fn CFSetCreate(allocator: CFAllocatorRef, values: *const *const c_void, numValues: CFIndex,
-                       callBacks: *const CFSetCallBacks) -> CFSetRef;
+    pub fn CFSetCreate(allocator: CFAllocatorRef, values: *const *const c_void, numValues: CFIndex, callBacks: *const CFSetCallBacks) -> CFSetRef;
     pub fn CFSetCreateCopy(allocator: CFAllocatorRef, theSet: CFSetRef) -> CFSetRef;
 
     /* Examining a Set */
@@ -56,11 +58,18 @@ extern {
     pub fn CFSetGetValues(theSet: CFSetRef, values: *mut *const c_void);
 
     /* Applying a Function to Set Members */
-    pub fn CFSetApplyFunction(theSet: CFSetRef,
-                              applier: CFSetApplierFunction,
-                              context: *const c_void);
+    pub fn CFSetApplyFunction(theSet: CFSetRef, applier: CFSetApplierFunction, context: *const c_void);
 
     /* Getting the CFSet Type ID */
     pub fn CFSetGetTypeID() -> CFTypeID;
-}
 
+    /* CFMutableSet */
+    /* CFMutableSet Miscellaneous Functions */
+    pub fn CFSetAddValue(theSet: CFMutableSetRef, value: *const c_void);
+    pub fn CFSetCreateMutable(allocator: CFAllocatorRef, capacity: CFIndex, callBacks: *const CFSetCallBacks) -> CFMutableSetRef;
+    pub fn CFSetCreateMutableCopy(allocator: CFAllocatorRef, capacity: CFIndex, theSet: CFSetRef) -> CFMutableSetRef;
+    pub fn CFSetRemoveAllValues(theSet: CFMutableSetRef);
+    pub fn CFSetRemoveValue(theSet: CFMutableSetRef, value: *const c_void);
+    pub fn CFSetReplaceValue(theSet: CFMutableSetRef, value: *const c_void);
+    pub fn CFSetSetValue(theSet: CFMutableSetRef, value: *const c_void);
+}


### PR DESCRIPTION
Implements CFMutableSet and a missing const. Sorts all functions in Apple docs order. Replaces pointer placeholders of callbacks with actual function declarations.