### PR TITLE
sys: timezone: Add missing funcs, consts & sorting

### DIFF
--- a/core-foundation-sys/src/timezone.rs
+++ b/core-foundation-sys/src/timezone.rs
@@ -9,21 +9,61 @@
 
 use std::os::raw::c_void;
 
-use base::{CFAllocatorRef, CFTypeID};
+use base::{CFAllocatorRef, CFTypeID, Boolean, CFIndex};
 use date::{CFTimeInterval, CFAbsoluteTime};
 use string::CFStringRef;
+use array::CFArrayRef;
+use dictionary::CFDictionaryRef;
+use data::CFDataRef;
+use locale::CFLocaleRef;
 
 #[repr(C)]
 pub struct __CFTimeZone(c_void);
 
 pub type CFTimeZoneRef = *const __CFTimeZone;
+pub type CFTimeZoneNameStyle = CFIndex;
+
+/* Constants to specify styles for time zone names */
+pub const kCFTimeZoneNameStyleStandard: CFTimeZoneNameStyle = 0;
+pub const kCFTimeZoneNameStyleShortStandard: CFTimeZoneNameStyle = 1;
+pub const kCFTimeZoneNameStyleDaylightSaving: CFTimeZoneNameStyle = 2;
+pub const kCFTimeZoneNameStyleShortDaylightSaving: CFTimeZoneNameStyle = 3;
+pub const kCFTimeZoneNameStyleGeneric: CFTimeZoneNameStyle = 4;
+pub const kCFTimeZoneNameStyleShortGeneric: CFTimeZoneNameStyle = 5;
 
 extern {
-    pub fn CFTimeZoneCopySystem() -> CFTimeZoneRef;
-    pub fn CFTimeZoneCopyDefault() -> CFTimeZoneRef;
-    pub fn CFTimeZoneCreateWithTimeIntervalFromGMT(allocator: CFAllocatorRef, interval: CFTimeInterval) -> CFTimeZoneRef;
-    pub fn CFTimeZoneGetSecondsFromGMT(tz: CFTimeZoneRef, time: CFAbsoluteTime) -> CFTimeInterval;
+    /*
+     * CFTimeZone.h
+     */
 
-    pub fn CFTimeZoneGetTypeID() -> CFTypeID;
+    //pub static kCFTimeZoneSystemTimeZoneDidChangeNotification: CFNotificationName; // todo
+
+    /* Creating a Time Zone */
+    pub fn CFTimeZoneCreate(allocator: CFAllocatorRef, name: CFStringRef, data: CFDataRef) -> CFTimeZoneRef;
+    pub fn CFTimeZoneCreateWithName(allocator: CFAllocatorRef, name: CFStringRef, tryAbbrev: Boolean) -> CFTimeZoneRef;
+    pub fn CFTimeZoneCreateWithTimeIntervalFromGMT(allocator: CFAllocatorRef, interval: CFTimeInterval) -> CFTimeZoneRef;
+
+    /* System and Default Time Zones and Information */
+    pub fn CFTimeZoneCopyAbbreviationDictionary() -> CFDictionaryRef;
+    pub fn CFTimeZoneCopyAbbreviation(tz: CFTimeZoneRef, at: CFAbsoluteTime) -> CFStringRef;
+    pub fn CFTimeZoneCopyDefault() -> CFTimeZoneRef;
+    pub fn CFTimeZoneCopySystem() -> CFTimeZoneRef;
+    pub fn CFTimeZoneSetDefault(tz: CFTimeZoneRef);
+    pub fn CFTimeZoneCopyKnownNames() -> CFArrayRef;
+    pub fn CFTimeZoneResetSystem();
+    pub fn CFTimeZoneSetAbbreviationDictionary(dict: CFDictionaryRef);
+
+    /* Getting Information About Time Zones */
     pub fn CFTimeZoneGetName(tz: CFTimeZoneRef) -> CFStringRef;
+    pub fn CFTimeZoneCopyLocalizedName(tz: CFTimeZoneRef, style: CFTimeZoneNameStyle, locale: CFLocaleRef) -> CFStringRef;
+    pub fn CFTimeZoneGetSecondsFromGMT(tz: CFTimeZoneRef, time: CFAbsoluteTime) -> CFTimeInterval;
+    pub fn CFTimeZoneGetData(tz: CFTimeZoneRef) -> CFDataRef;
+
+    /* Getting Daylight Savings Time Information */
+    pub fn CFTimeZoneIsDaylightSavingTime(tz: CFTimeZoneRef, at: CFAbsoluteTime) -> Boolean;
+    pub fn CFTimeZoneGetDaylightSavingTimeOffset(tz: CFTimeZoneRef, at: CFAbsoluteTime) -> CFTimeInterval;
+    pub fn CFTimeZoneGetNextDaylightSavingTimeTransition(tz: CFTimeZoneRef, at: CFAbsoluteTime) -> CFAbsoluteTime;
+
+    /* Getting the CFTimeZone Type ID */
+    pub fn CFTimeZoneGetTypeID() -> CFTypeID;
 }


### PR DESCRIPTION
Adds missing functions of CFTimeZone, implements CFTimeZoneNameStyle type and consts related to it. Sorts all stuff in Apple docs order.