### PR TITLE
sys: uuid: Add missing funcs, add more attrs to a struct

### DIFF
--- a/core-foundation-sys/src/uuid.rs
+++ b/core-foundation-sys/src/uuid.rs
@@ -10,6 +10,7 @@
 use std::os::raw::c_void;
 
 use base::{CFAllocatorRef, CFTypeID};
+use string::CFStringRef;
 
 #[repr(C)]
 pub struct __CFUUID(c_void);
@@ -17,7 +18,7 @@ pub struct __CFUUID(c_void);
 pub type CFUUIDRef = *const __CFUUID;
 
 #[repr(C)]
-#[derive(Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct CFUUIDBytes {
     pub byte0:  u8,
     pub byte1:  u8,
@@ -41,9 +42,18 @@ extern {
     /*
      * CFUUID.h
      */
+
+    /* Creating CFUUID Objects */
     pub fn CFUUIDCreate(allocator: CFAllocatorRef) -> CFUUIDRef;
+    pub fn CFUUIDCreateFromString(alloc: CFAllocatorRef, uuidStr: CFStringRef) -> CFUUIDRef;
     pub fn CFUUIDCreateFromUUIDBytes(allocator: CFAllocatorRef, bytes: CFUUIDBytes) -> CFUUIDRef;
+    pub fn CFUUIDCreateWithBytes(alloc: CFAllocatorRef, byte0: u8, byte1: u8, byte2: u8, byte3: u8, byte4: u8, byte5: u8, byte6: u8, byte7: u8, byte8: u8, byte9: u8, byte10: u8, byte11: u8, byte12: u8, byte13: u8, byte14: u8, byte15: u8) -> CFUUIDRef;
+
+    /* Getting Information About CFUUID Objects */
+    pub fn CFUUIDCreateString(allocator: CFAllocatorRef, uid: CFUUIDRef) -> CFStringRef;
+    pub fn CFUUIDGetConstantUUIDWithBytes(alloc: CFAllocatorRef, byte0: u8, byte1: u8, byte2: u8, byte3: u8, byte4: u8, byte5: u8, byte6: u8, byte7: u8, byte8: u8, byte9: u8, byte10: u8, byte11: u8, byte12: u8, byte13: u8, byte14: u8, byte15: u8) -> CFUUIDRef;
     pub fn CFUUIDGetUUIDBytes(uuid: CFUUIDRef) -> CFUUIDBytes;
 
+    /* Getting the CFUUID Type Identifier */
     pub fn CFUUIDGetTypeID() -> CFTypeID;
 }


### PR DESCRIPTION
Adds missing functions of CFUUID, derives `Debug` and `PartialEq` attributes to CFUUIDBytes struct. All functions are sorted in Apple docs order.