### PR TITLE
sys: propertylist: Add missing functions and consts, sort them

### DIFF
--- a/core-foundation-sys/src/propertylist.rs
+++ b/core-foundation-sys/src/propertylist.rs
@@ -7,9 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use base::{CFAllocatorRef, CFIndex, CFOptionFlags, CFTypeRef};
+use base::{CFAllocatorRef, CFIndex, CFOptionFlags, CFTypeRef, Boolean};
 use data::CFDataRef;
 use error::CFErrorRef;
+use string::CFStringRef;
 
 pub type CFPropertyListRef = CFTypeRef;
 
@@ -30,23 +31,23 @@ pub const kCFPropertyListReadStreamError: CFIndex = 3842;
 pub const kCFPropertyListWriteStreamError: CFIndex = 3851;
 
 extern "C" {
-    // CFPropertyList.h
-    //
+    /*
+     * CFPropertyList.h
+     */
 
-    // fn CFPropertyListCreateDeepCopy
-    // fn CFPropertyListIsValid
-    pub fn CFPropertyListCreateWithData(allocator: CFAllocatorRef,
-                                        data: CFDataRef,
-                                        options: CFPropertyListMutabilityOptions,
-                                        format: *mut CFPropertyListFormat,
-                                        error: *mut CFErrorRef)
-                                        -> CFPropertyListRef;
-    // fn CFPropertyListCreateWithStream
-    // fn CFPropertyListWrite
-    pub fn CFPropertyListCreateData(allocator: CFAllocatorRef,
-                                    propertyList: CFPropertyListRef,
-                                    format: CFPropertyListFormat,
-                                    options: CFOptionFlags,
-                                    error: *mut CFErrorRef)
-                                    -> CFDataRef;
+    /* Creating a Property List */
+    pub fn CFPropertyListCreateWithData(allocator: CFAllocatorRef, data: CFDataRef, options: CFPropertyListMutabilityOptions, format: *mut CFPropertyListFormat, error: *mut CFErrorRef) -> CFPropertyListRef;
+    //pub fn CFPropertyListCreateWithStream(allocator: CFAllocatorRef, stream: CFReadStreamRef, streamLength: CFIndex, options: CFOptionFlags, format: *mut CFPropertyListFormat, error: *mut CFErrorRef) -> CFPropertyListRef;
+    pub fn CFPropertyListCreateDeepCopy(allocator: CFAllocatorRef, propertyList: CFPropertyListRef, mutabilityOption: CFOptionFlags) -> CFPropertyListRef;
+    pub fn CFPropertyListCreateFromXMLData(allocator: CFAllocatorRef, xmlData: CFDataRef, mutabilityOption: CFOptionFlags, errorString: *mut CFStringRef) -> CFPropertyListRef; // deprecated
+    //pub fn CFPropertyListCreateFromStream(allocator: CFAllocatorRef, stream: CFReadStreamRef, streamLength: CFIndex, mutabilityOption: CFOptionFlags, format: *mut CFPropertyListFormat, errorString: *mut CFStringRef) -> CFPropertyListRef; // deprecated
+
+    /* Exporting a Property List */
+    pub fn CFPropertyListCreateData(allocator: CFAllocatorRef, propertyList: CFPropertyListRef, format: CFPropertyListFormat, options: CFOptionFlags, error: *mut CFErrorRef) -> CFDataRef;
+    //pub fn CFPropertyListWrite(propertyList: CFPropertyListRef, stream: CFWriteStreamRef, format: CFPropertyListFormat, options: CFOptionFlags, error: *mut CFErrorRef) -> CFIndex;
+    pub fn CFPropertyListCreateXMLData(allocator: CFAllocatorRef, propertyList: CFPropertyListRef) -> CFDataRef; // deprecated
+    //pub fn CFPropertyListWriteToStream(propertyList: CFPropertyListRef, stream: CFWriteStreamRef, format: CFPropertyListFormat, errorString: *mut CFStringRef) -> CFIndex;
+
+    /* Validating a Property List */
+    pub fn CFPropertyListIsValid(plist: CFPropertyListRef, format: CFPropertyListFormat) -> Boolean;
 }

--- a/core-foundation-sys/src/propertylist.rs
+++ b/core-foundation-sys/src/propertylist.rs
@@ -23,6 +23,12 @@ pub const kCFPropertyListImmutable: CFPropertyListMutabilityOptions = 0;
 pub const kCFPropertyListMutableContainers: CFPropertyListMutabilityOptions = 1;
 pub const kCFPropertyListMutableContainersAndLeaves: CFPropertyListMutabilityOptions = 2;
 
+/* Reading and Writing Error Codes */
+pub const kCFPropertyListReadCorruptError: CFIndex = 3840;
+pub const kCFPropertyListReadUnknownVersionError: CFIndex = 3841;
+pub const kCFPropertyListReadStreamError: CFIndex = 3842;
+pub const kCFPropertyListWriteStreamError: CFIndex = 3851;
+
 extern "C" {
     // CFPropertyList.h
     //


### PR DESCRIPTION
Adds missing functions and constants of CFPropertyList and sorts them in Apple docs order. Some of them are commented out because some types are not implemented yet.