### PR TITLE
sys: Uncomment functions

### DIFF
--- a/core-foundation-sys/src/attributed_string.rs
+++ b/core-foundation-sys/src/attributed_string.rs
@@ -11,6 +11,7 @@ use std::os::raw::c_void;
 use base::{CFAllocatorRef, CFTypeRef, CFIndex, CFRange, CFTypeID, Boolean};
 use string::CFStringRef;
 use dictionary::CFDictionaryRef;
+use string::CFMutableStringRef;
 
 #[repr(C)]
 pub struct __CFAttributedString(c_void);
@@ -48,7 +49,7 @@ extern {
     /* Modifying a CFMutableAttributedString */
     pub fn CFAttributedStringBeginEditing(aStr: CFMutableAttributedStringRef);
     pub fn CFAttributedStringEndEditing(aStr: CFMutableAttributedStringRef);
-    // pub fn CFAttributedStringGetMutableString(aStr: CFMutableAttributedStringRef) -> CFMutableStringRef; //todo
+    pub fn CFAttributedStringGetMutableString(aStr: CFMutableAttributedStringRef) -> CFMutableStringRef;
     pub fn CFAttributedStringRemoveAttribute(aStr: CFMutableAttributedStringRef, range: CFRange, attrName: CFStringRef);
     pub fn CFAttributedStringReplaceString(aStr: CFMutableAttributedStringRef, range: CFRange, replacement: CFStringRef);
     pub fn CFAttributedStringReplaceAttributedString(aStr: CFMutableAttributedStringRef, range: CFRange, replacement: CFAttributedStringRef);

--- a/core-foundation-sys/src/locale.rs
+++ b/core-foundation-sys/src/locale.rs
@@ -12,6 +12,7 @@ use base::{CFIndex, CFAllocatorRef, CFTypeRef, LangCode, RegionCode, CFTypeID};
 use array::CFArrayRef;
 use string::CFStringRef;
 use dictionary::CFDictionaryRef;
+use notification_center::CFNotificationName;
 
 #[repr(C)]
 pub struct __CFLocale(c_void);
@@ -34,7 +35,7 @@ extern {
      */
 
     /* Locale Change Notification */
-    //pub static kCFLocaleCurrentLocaleDidChangeNotification: CFNotificationName;
+    pub static kCFLocaleCurrentLocaleDidChangeNotification: CFNotificationName;
 
     /* Locale Property Keys */
     pub static kCFLocaleIdentifier: CFLocaleKey;

--- a/core-foundation-sys/src/timezone.rs
+++ b/core-foundation-sys/src/timezone.rs
@@ -16,6 +16,7 @@ use array::CFArrayRef;
 use dictionary::CFDictionaryRef;
 use data::CFDataRef;
 use locale::CFLocaleRef;
+use notification_center::CFNotificationName;
 
 #[repr(C)]
 pub struct __CFTimeZone(c_void);
@@ -36,7 +37,7 @@ extern {
      * CFTimeZone.h
      */
 
-    //pub static kCFTimeZoneSystemTimeZoneDidChangeNotification: CFNotificationName; // todo
+    pub static kCFTimeZoneSystemTimeZoneDidChangeNotification: CFNotificationName;
 
     /* Creating a Time Zone */
     pub fn CFTimeZoneCreate(allocator: CFAllocatorRef, name: CFStringRef, data: CFDataRef) -> CFTimeZoneRef;


### PR DESCRIPTION
Uncomments functions that uses already implemented structures (CFNotificationName, CFMutableStringRef).