### PR TITLE
sys: Introduce CFSocket

### DIFF
--- a/core-foundation-sys/src/base.rs
+++ b/core-foundation-sys/src/base.rs
@@ -21,6 +21,7 @@ pub type StringPtr = *mut c_uchar;
 pub type ConstStringPtr = *const c_uchar;
 pub type OSStatus = i32;
 pub type UInt8 = c_uchar;
+pub type UInt16 = c_ushort;
 pub type SInt16 = c_short;
 pub type SInt32 = c_int;
 pub type UInt32 = c_uint;

--- a/core-foundation-sys/src/lib.rs
+++ b/core-foundation-sys/src/lib.rs
@@ -38,6 +38,7 @@ pub mod plugin;
 pub mod propertylist;
 pub mod runloop;
 pub mod set;
+pub mod socket;
 pub mod stream;
 pub mod string;
 pub mod timezone;

--- a/core-foundation-sys/src/socket.rs
+++ b/core-foundation-sys/src/socket.rs
@@ -66,7 +66,7 @@ pub const kCFSocketAutomaticallyReenableWriteCallBack: CFOptionFlags = 8;
 pub const kCFSocketLeaveErrors: CFOptionFlags = 64;
 pub const kCFSocketCloseOnInvalidate: CFOptionFlags = 128;
 
-extern "C" {
+extern {
     /*
      * CFSocket.h
      */

--- a/core-foundation-sys/src/socket.rs
+++ b/core-foundation-sys/src/socket.rs
@@ -1,0 +1,116 @@
+// Copyright 2023 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::os::raw::c_void;
+
+use base::{CFIndex, CFOptionFlags, SInt32, CFTypeID, CFAllocatorRef, UInt16, Boolean};
+use data::CFDataRef;
+use string::CFStringRef;
+use date::CFTimeInterval;
+use runloop::CFRunLoopSourceRef;
+use propertylist::CFPropertyListRef;
+
+#[repr(C)]
+pub struct __CFSocket(c_void);
+
+pub type CFSocketRef = *mut __CFSocket;
+
+pub type CFSocketError = CFIndex;
+pub type CFSocketCallBackType = CFOptionFlags;
+pub type CFSocketCallBack = extern "C" fn (s: CFSocketRef, _type: CFSocketCallBackType, address: CFDataRef, cdata: *const c_void, info: *mut c_void);
+#[cfg(not(target_os = "windows"))]
+pub type CFSocketNativeHandle = std::os::raw::c_int;
+#[cfg(target_os = "windows")]
+pub type CFSocketNativeHandle = std::os::raw::c_ulong;
+
+pub const kCFSocketSuccess: CFSocketError = 0;
+pub const kCFSocketError: CFSocketError = -1;
+pub const kCFSocketTimeout: CFSocketError = -2;
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct CFSocketSignature {
+    pub protocolFamily: SInt32,
+    pub socketType: SInt32,
+    pub protocol: SInt32,
+    pub address: CFDataRef
+}
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct CFSocketContext {
+    pub version: CFIndex,
+    pub info: *mut c_void,
+    pub retain: extern "C" fn (info: *const c_void) -> *const c_void,
+    pub release: extern "C" fn (info: *const c_void),
+    pub copyDescription: extern "C" fn (info: *const c_void) -> CFStringRef,
+}
+
+pub const kCFSocketNoCallBack: CFSocketError = 0;
+pub const kCFSocketReadCallBack: CFSocketError = 1;
+pub const kCFSocketAcceptCallBack: CFSocketError = 2;
+pub const kCFSocketDataCallBack: CFSocketError = 3;
+pub const kCFSocketConnectCallBack: CFSocketError = 4;
+pub const kCFSocketWriteCallBack: CFSocketError = 8;
+
+pub const kCFSocketAutomaticallyReenableReadCallBack: CFOptionFlags = 1;
+pub const kCFSocketAutomaticallyReenableAcceptCallBack: CFOptionFlags = 2;
+pub const kCFSocketAutomaticallyReenableDataCallBack: CFOptionFlags = 3;
+pub const kCFSocketAutomaticallyReenableWriteCallBack: CFOptionFlags = 8;
+pub const kCFSocketLeaveErrors: CFOptionFlags = 64;
+pub const kCFSocketCloseOnInvalidate: CFOptionFlags = 128;
+
+extern "C" {
+    /*
+     * CFSocket.h
+     */
+
+    /* CFSocket Name Server Keys: Not used */
+    pub static kCFSocketCommandKey: CFStringRef;
+    pub static kCFSocketNameKey: CFStringRef;
+    pub static kCFSocketValueKey: CFStringRef;
+    pub static kCFSocketResultKey: CFStringRef;
+    pub static kCFSocketErrorKey: CFStringRef;
+    pub static kCFSocketRegisterCommand: CFStringRef;
+    pub static kCFSocketRetrieveCommand: CFStringRef;
+
+    /* Creating Sockets */
+    pub fn CFSocketCreate(allocator: CFAllocatorRef, protocolFamily: SInt32, socketType: SInt32, protocol: SInt32, callBackTypes: CFOptionFlags, callout: CFSocketCallBack, context: *const CFSocketContext) -> CFSocketRef;
+    pub fn CFSocketCreateConnectedToSocketSignature(allocator: CFAllocatorRef, signature: *const CFSocketSignature, callBackTypes: CFOptionFlags, callout: CFSocketCallBack, context: *const CFSocketContext, timeout: CFTimeInterval) -> CFSocketRef;
+    pub fn CFSocketCreateWithNative(allocator: CFAllocatorRef, sock: CFSocketNativeHandle, callBackTypes: CFOptionFlags, callout: CFSocketCallBack, context: *const CFSocketContext) -> CFSocketRef;
+    pub fn CFSocketCreateWithSocketSignature(allocator: CFAllocatorRef, signature: *const CFSocketSignature, callBackTypes: CFOptionFlags, callout: CFSocketCallBack, context: *const CFSocketContext) -> CFSocketRef;
+
+    /* Configuring Sockets */
+    pub fn CFSocketCopyAddress(s: CFSocketRef) -> CFDataRef;
+    pub fn CFSocketCopyPeerAddress(s: CFSocketRef) -> CFDataRef;
+    pub fn CFSocketDisableCallBacks(s: CFSocketRef, callBackTypes: CFOptionFlags);
+    pub fn CFSocketEnableCallBacks(s: CFSocketRef, callBackTypes: CFOptionFlags);
+    pub fn CFSocketGetContext(s: CFSocketRef, context: *mut CFSocketContext);
+    pub fn CFSocketGetNative(s: CFSocketRef) -> CFSocketNativeHandle;
+    pub fn CFSocketGetSocketFlags(s: CFSocketRef) -> CFOptionFlags;
+    pub fn CFSocketSetAddress(s: CFSocketRef, address: CFDataRef) -> CFSocketError;
+    pub fn CFSocketSetSocketFlags(s: CFSocketRef, flags: CFOptionFlags);
+
+    /* Using Sockets */
+    pub fn CFSocketConnectToAddress(s: CFSocketRef, address: CFDataRef, timeout: CFTimeInterval) -> CFSocketError;
+    pub fn CFSocketCreateRunLoopSource(allocator: CFAllocatorRef, s: CFSocketRef, order: CFIndex) -> CFRunLoopSourceRef;
+    pub fn CFSocketGetTypeID() -> CFTypeID;
+    pub fn CFSocketInvalidate(s: CFSocketRef);
+    pub fn CFSocketIsValid(s: CFSocketRef) -> Boolean;
+    pub fn CFSocketSendData(s: CFSocketRef, address: CFDataRef, data: CFDataRef, timeout: CFTimeInterval) -> CFSocketError;
+
+    /* Socket Name Server Utilities */
+    pub fn CFSocketCopyRegisteredSocketSignature(nameServerSignature: *const CFSocketSignature, timeout: CFTimeInterval, name: CFStringRef, signature: *mut CFSocketSignature, nameServerAddress: *mut CFDataRef) -> CFSocketError;
+    pub fn CFSocketCopyRegisteredValue(nameServerSignature: *const CFSocketSignature, timeout: CFTimeInterval, name: CFStringRef, value: *mut CFPropertyListRef, nameServerAddress: *mut CFDataRef) -> CFSocketError;
+    pub fn CFSocketGetDefaultNameRegistryPortNumber() -> UInt16;
+    pub fn CFSocketRegisterSocketSignature(nameServerSignature: *const CFSocketSignature, timeout: CFTimeInterval, name: CFStringRef, signature: *const CFSocketSignature) -> CFSocketError;
+    pub fn CFSocketRegisterValue(nameServerSignature: *const CFSocketSignature, timeout: CFTimeInterval, name: CFStringRef, value: CFPropertyListRef) -> CFSocketError;
+    pub fn CFSocketSetDefaultNameRegistryPortNumber(port: UInt16);
+    pub fn CFSocketUnregister(nameServerSignature: *const CFSocketSignature, timeout: CFTimeInterval, name: CFStringRef) -> CFSocketError;
+}

--- a/core-foundation-sys/src/stream.rs
+++ b/core-foundation-sys/src/stream.rs
@@ -9,11 +9,12 @@
 
 use std::os::raw::{c_void, c_int};
 
-use base::{CFIndex, CFOptionFlags, SInt32, CFTypeID, CFAllocatorRef, UInt8, Boolean, CFTypeRef};
+use base::{CFIndex, CFOptionFlags, SInt32, CFTypeID, CFAllocatorRef, UInt8, Boolean, CFTypeRef, UInt32};
 use string::CFStringRef;
 use url::CFURLRef;
 use error::CFErrorRef;
 use runloop::CFRunLoopRef;
+use socket::{CFSocketNativeHandle, CFSocketSignature};
 
 #[repr(C)]
 pub struct __CFReadStream(c_void);
@@ -109,9 +110,9 @@ extern {
     pub static kCFStreamErrorDomainSSL: c_int;
 
     /* CFStream: Creating Streams */
-    //pub fn CFStreamCreatePairWithPeerSocketSignature(alloc: CFAllocatorRef, signature: *const CFSocketSignature,readStream: *mut CFReadStreamRef, writeStream: *mut CFWriteStreamRef); // deprecated
-    //pub fn CFStreamCreatePairWithSocketToHost(alloc: CFAllocatorRef, host: CFStringRef, port: UInt32, readStream: *mut CFReadStreamRef, writeStream: *mut CFWriteStreamRef); // deprecated
-    //pub fn CFStreamCreatePairWithSocket(alloc: CFAllocatorRef, sock: CFSocketNativeHandle, readStream: *mut CFReadStreamRef, writeStream: *mut CFWriteStreamRef); // deprecated
+    pub fn CFStreamCreatePairWithPeerSocketSignature(alloc: CFAllocatorRef, signature: *const CFSocketSignature,readStream: *mut CFReadStreamRef, writeStream: *mut CFWriteStreamRef); // deprecated
+    pub fn CFStreamCreatePairWithSocketToHost(alloc: CFAllocatorRef, host: CFStringRef, port: UInt32, readStream: *mut CFReadStreamRef, writeStream: *mut CFWriteStreamRef); // deprecated
+    pub fn CFStreamCreatePairWithSocket(alloc: CFAllocatorRef, sock: CFSocketNativeHandle, readStream: *mut CFReadStreamRef, writeStream: *mut CFWriteStreamRef); // deprecated
     pub fn CFStreamCreateBoundPair(alloc: CFAllocatorRef, readStream: *mut CFReadStreamRef, writeStream: *mut CFWriteStreamRef, transferBufferSize: CFIndex);
 
     //pub fn CFReadStreamSetDispatchQueue(stream: CFReadStreamRef, q: dispatch_queue_t); // macos(10.9)+


### PR DESCRIPTION
Implements `CFSocket` with all its functions and constants sorted in Apple docs order, adds a new type `UInt16` to `base` module and uncomments CFSocket related functions in `stream` module.