### PR TITLE
sys: Fix CFComparatorFunction and move it to `base` module

### DIFF
--- a/core-foundation-sys/src/array.rs
+++ b/core-foundation-sys/src/array.rs
@@ -9,7 +9,7 @@
 
 use std::os::raw::c_void;
 
-use base::{CFRange, CFIndex, CFAllocatorRef, CFTypeID, Boolean, CFComparisonResult};
+use base::{CFRange, CFIndex, CFAllocatorRef, CFTypeID, Boolean, CFComparatorFunction};
 use string::CFStringRef;
 
 pub type CFArrayRetainCallBack = extern "C" fn(allocator: CFAllocatorRef, value: *const c_void) -> *const c_void;
@@ -17,7 +17,6 @@ pub type CFArrayReleaseCallBack = extern "C" fn(allocator: CFAllocatorRef, value
 pub type CFArrayCopyDescriptionCallBack = extern "C" fn(value: *const c_void) -> CFStringRef;
 pub type CFArrayEqualCallBack = extern "C" fn(value1: *const c_void, value2: *const c_void) -> Boolean;
 pub type CFArrayApplierFunction = extern "C" fn(value: *const c_void, context: *mut c_void);
-pub type CFComparatorFunction = extern "C" fn(val1: *const c_void, val2: *const c_void) -> CFComparisonResult;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]

--- a/core-foundation-sys/src/base.rs
+++ b/core-foundation-sys/src/base.rs
@@ -44,6 +44,8 @@ pub enum CFComparisonResult {
     GreaterThan = 1,
 }
 
+pub type CFComparatorFunction = extern "C" fn(val1: *const c_void, val2: *const c_void, context: *mut c_void) -> CFComparisonResult;
+
 impl Into<Ordering> for CFComparisonResult {
     fn into(self) -> Ordering {
         match self {


### PR DESCRIPTION
CFComparatorFunction declaration was missing one argument (void *context).
Here's its declaration from CFBase.h:
```c
typedef CFComparisonResult (*CFComparatorFunction)(const void *val1, const void *val2, void *context);
```
And its declaration in array.rs:
```rust
pub type CFComparatorFunction = extern "C" fn(val1: *const c_void, val2: *const c_void) -> CFComparisonResult;
```
Since it's declared in CFBase.h, I moved it to `base` module.