### PR TITLE
Bump core-text, core-graphics and cocoa

### DIFF
--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -4,7 +4,7 @@ name = "cocoa"
 description = "Bindings to Cocoa for macOS"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.24.1"
+version = "0.25.0"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 
@@ -17,6 +17,6 @@ bitflags = "1.0"
 libc = "0.2"
 cocoa-foundation = { path = "../cocoa-foundation", version = "0.1" }
 core-foundation = { path = "../core-foundation", version = "0.9" }
-core-graphics = { path = "../core-graphics", version = "0.22" }
+core-graphics = { path = "../core-graphics", version = "0.23" }
 foreign-types = "0.5"
 objc = "0.2.3"

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics"
 description = "Bindings to Core Graphics for macOS"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.22.4"
+version = "0.23.0"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "19.2.0"
+version = "19.3.0"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT OR Apache-2.0"
@@ -19,4 +19,4 @@ mountainlion = []
 foreign-types = "0.5"
 libc = "0.2"
 core-foundation = { path = "../core-foundation", version = "0.9" }
-core-graphics = { path = "../core-graphics", version = "0.22.0" }
+core-graphics = { path = "../core-graphics", version = "0.23.0" }

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "19.3.0"
+version = "20.0.0"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
We need the updated foreign-types dependency in Gecko.