### PR TITLE
Get tests passing on macOS 13

### DIFF
--- a/core-foundation/src/array.rs
+++ b/core-foundation/src/array.rs
@@ -162,13 +162,15 @@ impl<'a, T: FromVoid> IntoIterator for &'a CFArray<T> {
 
 #[cfg(test)]
 mod tests {
+    use crate::number::CFNumber;
+
     use super::*;
     use std::mem;
     use base::CFType;
 
     #[test]
     fn to_untyped_correct_retain_count() {
-        let array = CFArray::<CFType>::from_CFTypes(&[]);
+        let array = CFArray::<CFType>::from_CFTypes(&[CFNumber::from(4).as_CFType()]);
         assert_eq!(array.retain_count(), 1);
 
         let untyped_array = array.to_untyped();
@@ -181,7 +183,7 @@ mod tests {
 
     #[test]
     fn into_untyped() {
-        let array = CFArray::<CFType>::from_CFTypes(&[]);
+        let array = CFArray::<CFType>::from_CFTypes(&[CFNumber::from(4).as_CFType()]);
         let array2 = array.to_untyped();
         assert_eq!(array.retain_count(), 2);
 
@@ -196,7 +198,7 @@ mod tests {
     fn borrow() {
         use string::CFString;
 
-        let string = CFString::from_static_string("bar");
+        let string = CFString::from_static_string("alongerstring");
         assert_eq!(string.retain_count(), 1);
         let x;
         {
@@ -208,7 +210,7 @@ mod tests {
             {
                 x = arr.get(0).unwrap().clone();
                 assert_eq!(x.retain_count(), 2);
-                assert_eq!(x.to_string(), "bar");
+                assert_eq!(x.to_string(), "alongerstring");
             }
         }
         assert_eq!(x.retain_count(), 1);
@@ -219,7 +221,7 @@ mod tests {
         use string::{CFString, CFStringRef};
         use base::TCFTypeRef;
 
-        let cf_string = CFString::from_static_string("bar");
+        let cf_string = CFString::from_static_string("alongerstring");
         let array: CFArray = CFArray::from_CFTypes(&[cf_string.clone()]).into_untyped();
 
         let cf_strings = array.iter().map(|ptr| {
@@ -227,7 +229,7 @@ mod tests {
         }).collect::<Vec<_>>();
         let strings = cf_strings.iter().map(|s| s.to_string()).collect::<Vec<_>>();
         assert_eq!(cf_string.retain_count(), 3);
-        assert_eq!(&strings[..], &["bar"]);
+        assert_eq!(&strings[..], &["alongerstring"]);
     }
 
     #[test]

--- a/core-foundation/src/base.rs
+++ b/core-foundation/src/base.rs
@@ -413,7 +413,7 @@ mod tests {
 
     #[test]
     fn as_cftype_retain_count() {
-        let string = CFString::from_static_string("bar");
+        let string = CFString::from_static_string("alongerstring");
         assert_eq!(string.retain_count(), 1);
         let cftype = string.as_CFType();
         assert_eq!(cftype.retain_count(), 2);
@@ -423,7 +423,7 @@ mod tests {
 
     #[test]
     fn into_cftype_retain_count() {
-        let string = CFString::from_static_string("bar");
+        let string = CFString::from_static_string("alongerstring");
         assert_eq!(string.retain_count(), 1);
         let cftype = string.into_CFType();
         assert_eq!(cftype.retain_count(), 1);
@@ -431,10 +431,10 @@ mod tests {
 
     #[test]
     fn as_cftype_and_downcast() {
-        let string = CFString::from_static_string("bar");
+        let string = CFString::from_static_string("alongerstring");
         let cftype = string.as_CFType();
         let string2 = cftype.downcast::<CFString>().unwrap();
-        assert_eq!(string2.to_string(), "bar");
+        assert_eq!(string2.to_string(), "alongerstring");
 
         assert_eq!(string.retain_count(), 3);
         assert_eq!(cftype.retain_count(), 3);
@@ -443,10 +443,10 @@ mod tests {
 
     #[test]
     fn into_cftype_and_downcast_into() {
-        let string = CFString::from_static_string("bar");
+        let string = CFString::from_static_string("alongerstring");
         let cftype = string.into_CFType();
         let string2 = cftype.downcast_into::<CFString>().unwrap();
-        assert_eq!(string2.to_string(), "bar");
+        assert_eq!(string2.to_string(), "alongerstring");
         assert_eq!(string2.retain_count(), 1);
     }
 }

--- a/core-foundation/src/propertylist.rs
+++ b/core-foundation/src/propertylist.rs
@@ -281,7 +281,7 @@ pub mod test {
 
     #[test]
     fn to_propertylist_retain_count() {
-        let string = CFString::from_static_string("Bar");
+        let string = CFString::from_static_string("alongerstring");
         assert_eq!(string.retain_count(), 1);
 
         let propertylist = string.to_CFPropertyList();
@@ -308,7 +308,7 @@ pub mod test {
 
     #[test]
     fn downcast_into_fail() {
-        let string = CFString::from_static_string("Bar");
+        let string = CFString::from_static_string("alongerstring");
         let propertylist = string.to_CFPropertyList();
         assert_eq!(string.retain_count(), 2);
 
@@ -318,12 +318,12 @@ pub mod test {
 
     #[test]
     fn downcast_into() {
-        let string = CFString::from_static_string("Bar");
+        let string = CFString::from_static_string("alongerstring");
         let propertylist = string.to_CFPropertyList();
         assert_eq!(string.retain_count(), 2);
 
         let string2 = propertylist.downcast_into::<CFString>().unwrap();
-        assert_eq!(string2.to_string(), "Bar");
+        assert_eq!(string2.to_string(), "alongerstring");
         assert_eq!(string2.retain_count(), 2);
     }
 }

--- a/core-text/src/font.rs
+++ b/core-text/src/font.rs
@@ -839,7 +839,7 @@ fn out_of_range_variations() {
     // attributes greater than max are dropped on macOS <= 11
     // on macOS 12 they seem to be preserved as is.
     let var_attrs = var_attrs.find(variation_attribute);
-    if macos_version() >= (12, 0, 0) {
+    if macos_version() >= (12, 0, 0) && macos_version() < (13, 0, 0) {
         let var_attrs = var_attrs.unwrap().downcast::<CFDictionary>().unwrap();
         assert!(!var_attrs.is_empty());
         let var_attrs: CFDictionary<CFType, CFType> = unsafe { std::mem::transmute(var_attrs) };


### PR DESCRIPTION
macOS 13 uses NSTaggedPointerString for short CFStrings which means the retain counts aren't meaningful. Increasing the length of the strings avoids this.

Empty arrays also seem to refer to a shared constant object that doesn't have meaningful retain counts either.

Fixes #597