### PR TITLE
Bump the version of core-graphics-types

### DIFF
--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics-types"
 description = "Bindings for some fundamental Core Graphics types"
 homepage = "https://github.com/servo/core-foundation-rs"
 repository = "https://github.com/servo/core-foundation-rs"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
This is needed for a release that doesn't depend on foreign-types