### PR TITLE
sys: Introduce CFXML functionality

### DIFF
--- a/core-foundation-sys/src/lib.rs
+++ b/core-foundation-sys/src/lib.rs
@@ -37,6 +37,7 @@ pub mod error;
 pub mod filedescriptor;
 pub mod file_security;
 pub mod locale;
+pub mod mach_port;
 pub mod messageport;
 pub mod notification_center;
 pub mod number;
@@ -57,4 +58,7 @@ pub mod url_enumerator;
 #[cfg(target_os = "macos")]
 pub mod user_notification;
 pub mod uuid;
-pub mod mach_port;
+#[cfg(target_os = "macos")]
+pub mod xml_node;
+#[cfg(target_os = "macos")]
+pub mod xml_parser;

--- a/core-foundation-sys/src/xml_node.rs
+++ b/core-foundation-sys/src/xml_node.rs
@@ -1,0 +1,141 @@
+// Copyright 2023 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::os::raw::{c_void, c_char};
+
+use base::{Boolean, CFIndex, CFAllocatorRef, CFTypeID};
+use tree::CFTreeRef;
+use dictionary::CFDictionaryRef;
+use array::CFArrayRef;
+use string::{CFStringRef, CFStringEncoding};
+use url::CFURLRef;
+
+#[repr(C)]
+pub struct __CFXMLNode(c_void);
+
+pub type CFXMLNodeRef = *mut __CFXMLNode;
+pub type CFXMLTreeRef = CFTreeRef;
+
+pub const kCFXMLNodeCurrentVersion: CFIndex = 1;
+
+pub type CFXMLNodeTypeCode = CFIndex;
+pub const kCFXMLNodeTypeDocument: CFXMLNodeTypeCode = 1;
+pub const kCFXMLNodeTypeElement: CFXMLNodeTypeCode = 2;
+pub const kCFXMLNodeTypeAttribute: CFXMLNodeTypeCode = 3;
+pub const kCFXMLNodeTypeProcessingInstruction: CFXMLNodeTypeCode = 4;
+pub const kCFXMLNodeTypeComment: CFXMLNodeTypeCode = 5;
+pub const kCFXMLNodeTypeText: CFXMLNodeTypeCode = 6;
+pub const kCFXMLNodeTypeCDATASection: CFXMLNodeTypeCode = 7;
+pub const kCFXMLNodeTypeDocumentFragment: CFXMLNodeTypeCode = 8;
+pub const kCFXMLNodeTypeEntity: CFXMLNodeTypeCode = 9;
+pub const kCFXMLNodeTypeEntityReference: CFXMLNodeTypeCode = 10;
+pub const kCFXMLNodeTypeDocumentType: CFXMLNodeTypeCode = 11;
+pub const kCFXMLNodeTypeWhitespace: CFXMLNodeTypeCode = 12;
+pub const kCFXMLNodeTypeNotation: CFXMLNodeTypeCode = 13;
+pub const kCFXMLNodeTypeElementTypeDeclaration: CFXMLNodeTypeCode = 14;
+pub const kCFXMLNodeTypeAttributeListDeclaration: CFXMLNodeTypeCode = 15;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CFXMLElementInfo {
+    pub attributes: CFDictionaryRef,
+    pub attributeOrder: CFArrayRef,
+    pub isEmpty: Boolean,
+    pub _reserved: [c_char; 3]
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CFXMLProcessingInstructionInfo {
+    pub dataString: CFStringRef
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CFXMLDocumentInfo {
+    pub sourceURL: CFURLRef,
+    pub encoding: CFStringEncoding
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CFXMLExternalID {
+    pub systemID: CFURLRef,
+    pub publicID: CFStringRef
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CFXMLDocumentTypeInfo {
+    pub externalID: CFXMLExternalID
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CFXMLNotationInfo {
+    pub externalID: CFXMLExternalID
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CFXMLElementTypeDeclarationInfo {
+    pub contentDescription: CFStringRef
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CFXMLAttributeDeclarationInfo {
+    pub attributeName: CFStringRef,
+    pub typeString: CFStringRef,
+    pub defaultString: CFStringRef
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CFXMLAttributeListDeclarationInfo {
+    pub numberOfAttributes: CFIndex,
+    pub attributes: *mut CFXMLAttributeDeclarationInfo
+}
+
+pub type CFXMLEntityTypeCode = CFIndex;
+pub const kCFXMLEntityTypeParameter: CFXMLEntityTypeCode = 0;
+pub const kCFXMLEntityTypeParsedInternal: CFXMLEntityTypeCode = 1;
+pub const kCFXMLEntityTypeParsedExternal: CFXMLEntityTypeCode = 2;
+pub const kCFXMLEntityTypeUnparsed: CFXMLEntityTypeCode = 3;
+pub const kCFXMLEntityTypeCharacter: CFXMLEntityTypeCode = 4;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CFXMLEntityInfo {
+    pub entityType: CFXMLEntityTypeCode,
+    pub replacementText: CFStringRef,
+    pub entityID: CFXMLExternalID,
+    pub notationName: CFStringRef
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CFXMLEntityReferenceInfo {
+    pub entityType: CFXMLEntityTypeCode
+}
+
+extern {
+    /*
+     * CFXMLNode.h
+     */
+    pub fn CFXMLNodeGetTypeID() -> CFTypeID;
+    pub fn CFXMLNodeCreate(alloc: CFAllocatorRef, xmlType: CFXMLNodeTypeCode, dataString: CFStringRef, additionalInfoPtr: *const c_void, version: CFIndex) -> CFXMLNodeRef;
+    pub fn CFXMLNodeCreateCopy(alloc: CFAllocatorRef, origNode: CFXMLNodeRef) -> CFXMLNodeRef;
+    pub fn CFXMLNodeGetTypeCode(node: CFXMLNodeRef) -> CFXMLNodeTypeCode;
+    pub fn CFXMLNodeGetString(node: CFXMLNodeRef) -> CFStringRef;
+    pub fn CFXMLNodeGetInfoPtr(node: CFXMLNodeRef) -> *const c_void;
+    pub fn CFXMLNodeGetVersion(node: CFXMLNodeRef) -> CFIndex;
+    pub fn CFXMLTreeCreateWithNode(alloc: CFAllocatorRef, node: CFXMLNodeRef) -> CFXMLTreeRef;
+    pub fn CFXMLTreeGetNode(xmlTree: CFXMLTreeRef) -> CFXMLNodeRef;
+}

--- a/core-foundation-sys/src/xml_parser.rs
+++ b/core-foundation-sys/src/xml_parser.rs
@@ -1,0 +1,114 @@
+// Copyright 2023 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::os::raw::c_void;
+
+use base::{CFOptionFlags, CFIndex, Boolean, CFAllocatorRef, CFTypeID};
+use xml_node::{CFXMLNodeRef, CFXMLTreeRef, CFXMLExternalID};
+use data::CFDataRef;
+use string::CFStringRef;
+use url::CFURLRef;
+use dictionary::CFDictionaryRef;
+
+#[repr(C)]
+pub struct __CFXMLParser(c_void);
+
+pub type CFXMLParserRef = *mut __CFXMLParser;
+
+pub type CFXMLParserOptions = CFOptionFlags;
+pub const kCFXMLParserValidateDocument: CFXMLParserOptions = 1 << 0;
+pub const kCFXMLParserSkipMetaData: CFXMLParserOptions = 1 << 1;
+pub const kCFXMLParserReplacePhysicalEntities: CFXMLParserOptions = 1 << 2;
+pub const kCFXMLParserSkipWhitespace: CFXMLParserOptions = 1 << 3;
+pub const kCFXMLParserResolveExternalEntities: CFXMLParserOptions = 1 << 4;
+pub const kCFXMLParserAddImpliedAttributes: CFXMLParserOptions = 1 << 5;
+pub const kCFXMLParserAllOptions: CFXMLParserOptions = 0x00FFFFFF;
+pub const kCFXMLParserNoOptions: CFXMLParserOptions = 0;
+
+pub type CFXMLParserStatusCode = CFIndex;
+pub const kCFXMLStatusParseNotBegun: CFIndex = -2;
+pub const kCFXMLStatusParseInProgress: CFIndex = -1;
+pub const kCFXMLStatusParseSuccessful: CFIndex = 0;
+pub const kCFXMLErrorUnexpectedEOF: CFIndex = 1;
+pub const kCFXMLErrorUnknownEncoding: CFIndex = 2;
+pub const kCFXMLErrorEncodingConversionFailure: CFIndex = 3;
+pub const kCFXMLErrorMalformedProcessingInstruction: CFIndex = 4;
+pub const kCFXMLErrorMalformedDTD: CFIndex = 5;
+pub const kCFXMLErrorMalformedName: CFIndex = 6;
+pub const kCFXMLErrorMalformedCDSect: CFIndex = 7;
+pub const kCFXMLErrorMalformedCloseTag: CFIndex = 8;
+pub const kCFXMLErrorMalformedStartTag: CFIndex = 9;
+pub const kCFXMLErrorMalformedDocument: CFIndex = 10;
+pub const kCFXMLErrorElementlessDocument: CFIndex = 11;
+pub const kCFXMLErrorMalformedComment: CFIndex = 12;
+pub const kCFXMLErrorMalformedCharacterReference: CFIndex = 13;
+pub const kCFXMLErrorMalformedParsedCharacterData: CFIndex = 14;
+pub const kCFXMLErrorNoData: CFIndex = 15;
+
+pub type CFXMLParserCreateXMLStructureCallBack = extern "C" fn (parser: CFXMLParserRef, nodeDesc: CFXMLNodeRef, info: *mut c_void) -> *mut c_void;
+pub type CFXMLParserAddChildCallBack = extern "C" fn (parser: CFXMLParserRef, parent: *mut c_void, child: *mut c_void, info: *mut c_void);
+pub type CFXMLParserEndXMLStructureCallBack = extern "C" fn (parser: CFXMLParserRef, xmlType: *mut c_void, info: *mut c_void);
+pub type CFXMLParserResolveExternalEntityCallBack = extern "C" fn (parser: CFXMLParserRef, extID: *mut CFXMLExternalID, info: *mut c_void) -> CFDataRef;
+pub type CFXMLParserHandleErrorCallBack = extern "C" fn (parser: CFXMLParserRef, error: CFXMLParserStatusCode, info: *mut c_void) -> Boolean;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CFXMLParserCallBacks {
+    pub version: CFIndex,
+    pub createXMLStructure: CFXMLParserCreateXMLStructureCallBack,
+    pub addChild: CFXMLParserAddChildCallBack,
+    pub endXMLStructure: CFXMLParserEndXMLStructureCallBack,
+    pub resolveExternalEntity: CFXMLParserResolveExternalEntityCallBack,
+    pub handleError: CFXMLParserHandleErrorCallBack,
+}
+
+pub type CFXMLParserRetainCallBack = extern "C" fn(info: *const c_void) -> *const c_void;
+pub type CFXMLParserReleaseCallBack = extern "C" fn (info: *const c_void);
+pub type CFXMLParserCopyDescriptionCallBack = extern "C" fn(info: *const c_void) -> CFStringRef;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CFXMLParserContext {
+    pub version: CFIndex,
+    pub info: *mut c_void,
+    pub retain: CFXMLParserRetainCallBack,
+    pub release: CFXMLParserReleaseCallBack,
+    pub copyDescription: CFXMLParserCopyDescriptionCallBack
+}
+
+extern {
+    /*
+     * CFXMLParser.h
+     */
+
+    pub static kCFXMLTreeErrorDescription: CFStringRef;
+    pub static kCFXMLTreeErrorLineNumber: CFStringRef;
+    pub static kCFXMLTreeErrorLocation: CFStringRef;
+    pub static kCFXMLTreeErrorStatusCode: CFStringRef;
+
+    pub fn CFXMLParserGetTypeID() -> CFTypeID;
+    pub fn CFXMLParserCreate(allocator: CFAllocatorRef, xmlData: CFDataRef, dataSource: CFURLRef, parseOptions: CFOptionFlags, versionOfNodes: CFIndex, callBacks: *mut CFXMLParserCallBacks, context: *mut CFXMLParserContext) -> CFXMLParserRef;
+    pub fn CFXMLParserCreateWithDataFromURL(allocator: CFAllocatorRef, dataSource: CFURLRef, parseOptions: CFOptionFlags, versionOfNodes: CFIndex, callBacks: *mut CFXMLParserCallBacks, context: *mut CFXMLParserContext) -> CFXMLParserRef;
+    pub fn CFXMLParserGetContext(parser: CFXMLParserRef, context: *mut CFXMLParserContext);
+    pub fn CFXMLParserGetCallBacks(parser: CFXMLParserRef, callBacks: *mut CFXMLParserCallBacks);
+    pub fn CFXMLParserGetSourceURL(parser: CFXMLParserRef) -> CFURLRef;
+    pub fn CFXMLParserGetLocation(parser: CFXMLParserRef) -> CFIndex;
+    pub fn CFXMLParserGetLineNumber(parser: CFXMLParserRef) -> CFIndex;
+    pub fn CFXMLParserGetDocument(parser: CFXMLParserRef) -> *mut c_void;
+    pub fn CFXMLParserGetStatusCode(parser: CFXMLParserRef) -> CFXMLParserStatusCode;
+    pub fn CFXMLParserCopyErrorDescription(parser: CFXMLParserRef) -> CFStringRef;
+    pub fn CFXMLParserAbort(parser: CFXMLParserRef, errorCode: CFXMLParserStatusCode, errorDescription: CFStringRef);
+    pub fn CFXMLParserParse(parser: CFXMLParserRef) -> Boolean;
+    pub fn CFXMLTreeCreateFromData(allocator: CFAllocatorRef, xmlData: CFDataRef, dataSource: CFURLRef, parseOptions: CFOptionFlags, versionOfNodes: CFIndex) -> CFXMLTreeRef;
+    pub fn CFXMLTreeCreateFromDataWithError(allocator: CFAllocatorRef, xmlData: CFDataRef, dataSource: CFURLRef, parseOptions: CFOptionFlags, versionOfNodes: CFIndex, errorDict: *mut CFDictionaryRef) -> CFXMLTreeRef;
+    pub fn CFXMLTreeCreateWithDataFromURL(allocator: CFAllocatorRef, dataSource: CFURLRef, parseOptions: CFOptionFlags, versionOfNodes: CFIndex) -> CFXMLTreeRef;
+    pub fn CFXMLTreeCreateXMLData(allocator: CFAllocatorRef, xmlTree: CFXMLTreeRef) -> CFDataRef;
+    pub fn CFXMLCreateStringByEscapingEntities(allocator: CFAllocatorRef, string: CFStringRef, entitiesDictionary: CFDictionaryRef) -> CFStringRef;
+    pub fn CFXMLCreateStringByUnescapingEntities(allocator: CFAllocatorRef, string: CFStringRef, entitiesDictionary: CFDictionaryRef) -> CFStringRef;
+}


### PR DESCRIPTION
Implements CFXMLNode, CFXMLTree and CFXMLParser functions and related constants and structures. Even though all of them are considered deprecated, these may be the last bits of fully implemented core-foundation-sys crate (with functionality of macOS 10.7 and 10.8 obviously).