### PR TITLE
feat: add link feature

### DIFF
--- a/cocoa-foundation/Cargo.toml
+++ b/cocoa-foundation/Cargo.toml
@@ -15,6 +15,12 @@ default-target = "x86_64-apple-darwin"
 block = "0.1"
 bitflags = "1.0"
 libc = "0.2"
-core-foundation = { path = "../core-foundation", version = "0.9" }
-core-graphics-types = { path = "../core-graphics-types", version = "0.1" }
+core-foundation = { default-features = false, path = "../core-foundation", version = "0.9" }
+core-graphics-types = { default-features = false, path = "../core-graphics-types", version = "0.1" }
 objc = "0.2.3"
+
+[features]
+default = ["link"]
+# Disable to manually link. Enabled by default.
+link = ["core-foundation/link", "core-graphics-types/link"]
+

--- a/cocoa-foundation/src/foundation.rs
+++ b/cocoa-foundation/src/foundation.rs
@@ -132,7 +132,7 @@ mod macos {
         NSRectMaxYEdge,
     }
 
-    #[link(name = "Foundation", kind = "framework")]
+    #[cfg_attr(feature = "link", link(name = "Foundation", kind = "framework"))]
     extern "C" {
         fn NSInsetRect(rect: NSRect, x: CGFloat, y: CGFloat) -> NSRect;
     }
@@ -167,7 +167,7 @@ impl NSRange {
     }
 }
 
-#[link(name = "Foundation", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "Foundation", kind = "framework"))]
 extern "C" {
     pub static NSDefaultRunLoopMode: id;
 }

--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -15,8 +15,13 @@ default-target = "x86_64-apple-darwin"
 block = "0.1"
 bitflags = "1.0"
 libc = "0.2"
-cocoa-foundation = { path = "../cocoa-foundation", version = "0.1" }
-core-foundation = { path = "../core-foundation", version = "0.9" }
-core-graphics = { path = "../core-graphics", version = "0.23" }
+cocoa-foundation = { default-features = false, path = "../cocoa-foundation", version = "0.1" }
+core-foundation = { default-features = false, path = "../core-foundation", version = "0.9" }
+core-graphics = { default-features = false, path = "../core-graphics", version = "0.23" }
 foreign-types = "0.5"
 objc = "0.2.3"
+
+[features]
+default = ["link"]
+# Disable to manually link. Enabled by default.
+link = ["core-foundation/link", "cocoa-foundation/link", "core-graphics/link"]

--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -31,7 +31,7 @@ pub type CGLContextObj = *mut c_void;
 
 pub type GLint = i32;
 
-#[link(name = "AppKit", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "AppKit", kind = "framework"))]
 extern "C" {
     pub static NSAppKitVersionNumber: f64;
 
@@ -3836,7 +3836,7 @@ impl NSImage for id {
     }
 }
 
-#[link(name = "AppKit", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "AppKit", kind = "framework"))]
 extern "C" {
     // Image hints (NSString* const)
     pub static NSImageHintCTM: id;

--- a/cocoa/src/quartzcore.rs
+++ b/cocoa/src/quartzcore.rs
@@ -1572,7 +1572,7 @@ impl CATransform3D {
     }
 }
 
-#[link(name = "QuartzCore", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "QuartzCore", kind = "framework"))]
 extern "C" {
     static kCARendererColorSpace: CFStringRef;
     static kCARendererMetalCommandQueue: CFStringRef;

--- a/core-foundation-sys/Cargo.toml
+++ b/core-foundation-sys/Cargo.toml
@@ -10,8 +10,11 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 
 [features]
+default = ["link"]
 mac_os_10_7_support = [] # backwards compatibility
 mac_os_10_8_features = [] # enables new features
+# Disable to manually link. Enabled by default.
+link = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core-foundation-sys/src/lib.rs
+++ b/core-foundation-sys/src/lib.rs
@@ -22,7 +22,10 @@
 // We don't use `target_vendor` since that is going to be deprecated:
 // https://github.com/rust-lang/lang-team/issues/102
 #[cfg_attr(
-    any(target_os = "macos", target_os = "ios", target_os = "tvos"),
+    all(
+        any(target_os = "macos", target_os = "ios", target_os = "tvos"),
+        feature = "link"
+    ),
     link(name = "CoreFoundation", kind = "framework")
 )]
 extern "C" {}

--- a/core-foundation/Cargo.toml
+++ b/core-foundation/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["macos", "framework", "objc"]
 
 [dependencies.core-foundation-sys]
 path = "../core-foundation-sys"
+default-features = false
 version = "0.8.5"
 
 [dependencies]
@@ -19,10 +20,15 @@ chrono = { version = "0.4", optional = true }
 uuid = { version = "0.5", optional = true }
 
 [features]
+default = ["link"]
+
 mac_os_10_7_support = ["core-foundation-sys/mac_os_10_7_support"] # backwards compatibility
 mac_os_10_8_features = ["core-foundation-sys/mac_os_10_8_features"] # enables new features
 with-chrono = ["chrono"]
 with-uuid = ["uuid"]
+# Disable to manually link. Enabled by default.
+link = ["core-foundation-sys/link"]
+
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -9,8 +9,13 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 bitflags = "1.0"
-core-foundation = { path = "../core-foundation", version = "0.9" }
+core-foundation = { default-features = false, path = "../core-foundation", version = "0.9" }
 libc = "0.2"
+
+[features]
+default = ["link"]
+# Disable to manually link. Enabled by default.
+link = ["core-foundation/link"]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/core-graphics-types/src/geometry.rs
+++ b/core-graphics-types/src/geometry.rs
@@ -166,7 +166,7 @@ mod ffi {
     use core_foundation::dictionary::CFDictionaryRef;
     use geometry::{CGAffineTransform, CGPoint, CGRect, CGSize};
 
-    #[link(name = "CoreGraphics", kind = "framework")]
+    #[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
     extern "C" {
         pub fn CGRectInset(rect: CGRect, dx: CGFloat, dy: CGFloat) -> CGRect;
         pub fn CGRectMakeWithDictionaryRepresentation(

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -8,14 +8,16 @@ authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 
 [features]
-default = []
+default = ["link"]
 elcapitan = []
 highsierra = []
+# Disable to manually link. Enabled by default.
+link = ["core-foundation/link", "core-graphics-types/link"]
 
 [dependencies]
 bitflags = "1.0"
-core-foundation = { path = "../core-foundation", version = "0.9" }
-core-graphics-types = { path = "../core-graphics-types", version = "0.1" }
+core-foundation = { default-features = false, path = "../core-foundation", version = "0.9" }
+core-graphics-types = { default-features = false, path = "../core-graphics-types", version = "0.1" }
 foreign-types = "0.5.0"
 libc = "0.2"
 

--- a/core-graphics/src/access.rs
+++ b/core-graphics/src/access.rs
@@ -18,7 +18,7 @@ impl ScreenCaptureAccess {
     }
 }
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     // Screen Capture Access
     fn CGRequestScreenCaptureAccess() -> boolean_t;

--- a/core-graphics/src/color.rs
+++ b/core-graphics/src/color.rs
@@ -28,7 +28,7 @@ impl CGColor {
     }
 }
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     fn CGColorCreateGenericRGB(
         red: CGFloat,

--- a/core-graphics/src/color_space.rs
+++ b/core-graphics/src/color_space.rs
@@ -53,7 +53,7 @@ impl CGColorSpace {
     }
 }
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     /// The Display P3 color space, created by Apple.
     pub static kCGColorSpaceDisplayP3: CFStringRef;

--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -615,7 +615,7 @@ fn create_bitmap_context_test() {
     assert_eq!(255, data.bytes()[3]);
 }
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     fn CGContextRetain(c: ::sys::CGContextRef) -> ::sys::CGContextRef;
     fn CGContextRelease(c: ::sys::CGContextRef);

--- a/core-graphics/src/data_provider.rs
+++ b/core-graphics/src/data_provider.rs
@@ -153,7 +153,7 @@ fn test_data_provider() {
     assert!(dropped.load(SeqCst))
 }
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     fn CGDataProviderCopyData(provider: ::sys::CGDataProviderRef) -> CFDataRef;
     //fn CGDataProviderCreateDirect

--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -640,7 +640,7 @@ impl CGDisplayMode {
     }
 }
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     pub static CGRectNull: CGRect;
     pub static CGRectInfinite: CGRect;

--- a/core-graphics/src/event.rs
+++ b/core-graphics/src/event.rs
@@ -673,7 +673,7 @@ impl CGEvent {
     }
 }
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     /// Return the type identifier for the opaque type `CGEventRef'.
     fn CGEventGetTypeID() -> CFTypeID;

--- a/core-graphics/src/event_source.rs
+++ b/core-graphics/src/event_source.rs
@@ -36,7 +36,7 @@ impl CGEventSource {
     }
 }
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     /// Return the type identifier for the opaque type `CGEventSourceRef'.
     fn CGEventSourceGetTypeID() -> CFTypeID;

--- a/core-graphics/src/font.rs
+++ b/core-graphics/src/font.rs
@@ -138,7 +138,7 @@ impl CGFont {
     }
 }
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     // TODO: basically nothing has bindings (even commented-out) besides what we use.
     fn CGFontCreateWithDataProvider(provider: ::sys::CGDataProviderRef) -> ::sys::CGFontRef;

--- a/core-graphics/src/gradient.rs
+++ b/core-graphics/src/gradient.rs
@@ -72,7 +72,7 @@ impl CGGradient {
     }
 }
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     fn CGGradientCreateWithColorComponents(
         color_space: ::sys::CGColorSpaceRef,

--- a/core-graphics/src/image.rs
+++ b/core-graphics/src/image.rs
@@ -125,7 +125,7 @@ impl CGImageRef {
     }
 }
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     fn CGImageGetTypeID() -> CFTypeID;
     fn CGImageGetWidth(image: ::sys::CGImageRef) -> size_t;

--- a/core-graphics/src/path.rs
+++ b/core-graphics/src/path.rs
@@ -125,7 +125,7 @@ impl CGPathElement {
 
 type CGPathApplierFunction = unsafe extern "C" fn(info: *mut c_void, element: *const CGPathElement);
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     fn CGPathCreateWithRect(rect: CGRect, transform: *const CGAffineTransform) -> ::sys::CGPathRef;
     fn CGPathApply(path: ::sys::CGPathRef, info: *mut c_void, function: CGPathApplierFunction);

--- a/core-graphics/src/private.rs
+++ b/core-graphics/src/private.rs
@@ -96,7 +96,7 @@ mod ffi {
     pub type CGSRegionRef = *mut CGSRegionObject;
     pub type OSStatus = i32;
 
-    #[link(name = "CoreGraphics", kind = "framework")]
+    #[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
     extern "C" {
         pub fn CGSRegionRelease(region: CGSRegionRef);
         pub fn CGSNewRegionWithRect(rect: *const CGRect, outRegion: *mut CGSRegionRef) -> CGError;

--- a/core-graphics/src/window.rs
+++ b/core-graphics/src/window.rs
@@ -125,7 +125,7 @@ pub fn create_image_from_array(
     }
 }
 
-#[link(name = "CoreGraphics", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     pub static kCGWindowNumber: CFStringRef;
     pub static kCGWindowStoreType: CFStringRef;

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -11,13 +11,15 @@ all-features = true
 default-target = "x86_64-apple-darwin"
 
 [features]
-default = ["mountainlion"]
+default = ["mountainlion", "link"]
 # For OS X 10.7 compat, exclude this feature. It will exclude some things from
 # the exposed APIs in the crate.
 mountainlion = []
+# Disable to manually link. Enabled by default.
+link = ["core-foundation/link", "core-graphics/link"]
 
 [dependencies]
 foreign-types = "0.5"
 libc = "0.2"
-core-foundation = { path = "../core-foundation", version = "0.9" }
-core-graphics = { path = "../core-graphics", version = "0.23.0" }
+core-foundation = { default-features = false, path = "../core-foundation", version = "0.9" }
+core-graphics = { default-features = false, path = "../core-graphics", version = "0.23.0" }

--- a/core-text/src/font.rs
+++ b/core-text/src/font.rs
@@ -594,7 +594,7 @@ pub fn cascade_list_for_languages(
     }
 }
 
-#[link(name = "CoreText", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreText", kind = "framework"))]
 extern "C" {
     /*
      * CTFont.h

--- a/core-text/src/frame.rs
+++ b/core-text/src/frame.rs
@@ -84,7 +84,7 @@ impl CTFrame {
     }
 }
 
-#[link(name = "CoreText", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreText", kind = "framework"))]
 extern "C" {
     fn CTFrameGetTypeID() -> CFTypeID;
     fn CTFrameGetLines(frame: CTFrameRef) -> CFArrayRef;

--- a/core-text/src/framesetter.rs
+++ b/core-text/src/framesetter.rs
@@ -74,7 +74,7 @@ impl CTFramesetter {
     }
 }
 
-#[link(name = "CoreText", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreText", kind = "framework"))]
 extern "C" {
     fn CTFramesetterGetTypeID() -> CFTypeID;
     fn CTFramesetterCreateWithAttributedString(string: CFAttributedStringRef) -> CTFramesetterRef;

--- a/core-text/src/line.rs
+++ b/core-text/src/line.rs
@@ -91,7 +91,7 @@ impl CTLine {
     }
 }
 
-#[link(name = "CoreText", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreText", kind = "framework"))]
 extern "C" {
     fn CTLineGetTypeID() -> CFTypeID;
     fn CTLineGetGlyphRuns(line: CTLineRef) -> CFArrayRef;

--- a/core-text/src/run.rs
+++ b/core-text/src/run.rs
@@ -145,7 +145,7 @@ fn create_runs() {
     }
 }
 
-#[link(name = "CoreText", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "CoreText", kind = "framework"))]
 extern "C" {
     fn CTRunGetTypeID() -> CFTypeID;
     fn CTRunGetAttributes(run: CTRunRef) -> CFDictionaryRef;

--- a/io-surface/Cargo.toml
+++ b/io-surface/Cargo.toml
@@ -12,7 +12,12 @@ default-target = "x86_64-apple-darwin"
 
 [dependencies]
 libc = "0.2"
-core-foundation = { path = "../core-foundation", version = "0.9" }
-core-foundation-sys = { path = "../core-foundation-sys", version = "0.8" }
+core-foundation = { default-features = false, path = "../core-foundation", version = "0.9" }
+core-foundation-sys = { default-features = false, path = "../core-foundation-sys", version = "0.8" }
 cgl = "0.3"
 leaky-cow = "0.1.1"
+
+[features]
+default = ["link"]
+# Disable to manually link. Enabled by default.
+link = ["core-foundation/link", "core-foundation-sys/link"]

--- a/io-surface/src/lib.rs
+++ b/io-surface/src/lib.rs
@@ -166,7 +166,7 @@ impl IOSurface {
     }
 }
 
-#[link(name = "IOSurface", kind = "framework")]
+#[cfg_attr(feature = "link", link(name = "IOSurface", kind = "framework"))]
 extern "C" {
     pub static kIOSurfaceAllocSize: CFStringRef;
     pub static kIOSurfaceWidth: CFStringRef;


### PR DESCRIPTION
The reason for this is that weak linking required for Deno to bring back webgpu support, and as we use the wgpu crate which depends on core-foundation, this feature flag needs to be added to core-foundation as well, as we are not going to be building with nightly or unstable rust features.