### PR TITLE
core-foundation-sys: Enable `no_std` environment

### DIFF
--- a/core-foundation-sys/src/array.rs
+++ b/core-foundation-sys/src/array.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFRange, CFIndex, CFAllocatorRef, CFTypeID, Boolean, CFComparatorFunction};
 use string::CFStringRef;

--- a/core-foundation-sys/src/attributed_string.rs
+++ b/core-foundation-sys/src/attributed_string.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 use base::{CFAllocatorRef, CFTypeRef, CFIndex, CFRange, CFTypeID, Boolean};
 use string::CFStringRef;
 use dictionary::CFDictionaryRef;

--- a/core-foundation-sys/src/bag.rs
+++ b/core-foundation-sys/src/bag.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFAllocatorRef, Boolean, CFHashCode, CFIndex, CFTypeID};
 use string::CFStringRef;

--- a/core-foundation-sys/src/base.rs
+++ b/core-foundation-sys/src/base.rs
@@ -7,8 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::cmp::Ordering;
-use std::os::raw::{c_uint, c_void, c_int, c_short, c_uchar, c_ushort};
+use core::cmp::Ordering;
+use core::ffi::{c_uint, c_void, c_int, c_short, c_uchar, c_ushort};
 use string::CFStringRef;
 
 pub type Boolean = u8;

--- a/core-foundation-sys/src/binary_heap.rs
+++ b/core-foundation-sys/src/binary_heap.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFTypeID, CFAllocatorRef, Boolean, CFIndex, CFComparisonResult};
 use string::CFStringRef;

--- a/core-foundation-sys/src/bit_vector.rs
+++ b/core-foundation-sys/src/bit_vector.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFAllocatorRef, Boolean, UInt32, CFIndex, CFTypeID, CFRange, UInt8};
 

--- a/core-foundation-sys/src/bundle.rs
+++ b/core-foundation-sys/src/bundle.rs
@@ -7,10 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFTypeID, CFAllocatorRef, Boolean, CFTypeRef, UInt32, SInt32};
-use std::os::raw::{c_uint, c_int};
+use core::ffi::{c_uint, c_int};
 use url::CFURLRef;
 use dictionary::CFDictionaryRef;
 use string::CFStringRef;
@@ -27,7 +27,7 @@ pub type CFBundleRefNum = c_int;
 #[allow(unused)]
 #[inline(always)]
 pub unsafe fn CFCopyLocalizedString(key: CFStringRef, comment: CFStringRef) -> CFStringRef {
-    CFBundleCopyLocalizedString(CFBundleGetMainBundle(), key, key, std::ptr::null())
+    CFBundleCopyLocalizedString(CFBundleGetMainBundle(), key, key, core::ptr::null())
 }
 #[allow(unused)]
 #[inline(always)]

--- a/core-foundation-sys/src/calendar.rs
+++ b/core-foundation-sys/src/calendar.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::{c_void, c_char};
+use core::ffi::{c_void, c_char};
 
 use base::{CFAllocatorRef, CFTypeID, Boolean, CFIndex, CFOptionFlags, CFRange};
 use locale::{CFCalendarIdentifier, CFLocaleRef};

--- a/core-foundation-sys/src/characterset.rs
+++ b/core-foundation-sys/src/characterset.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 use base::{Boolean, CFAllocatorRef, CFIndex, CFRange, CFTypeID, UTF32Char};
 use data::CFDataRef;
 use string::{CFStringRef, UniChar};

--- a/core-foundation-sys/src/data.rs
+++ b/core-foundation-sys/src/data.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 use base::{CFAllocatorRef, CFTypeID, CFIndex, CFRange, CFOptionFlags};
 
 #[repr(C)]

--- a/core-foundation-sys/src/date.rs
+++ b/core-foundation-sys/src/date.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFAllocatorRef, CFComparisonResult, CFTypeID};
 

--- a/core-foundation-sys/src/date_formatter.rs
+++ b/core-foundation-sys/src/date_formatter.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFIndex, CFOptionFlags, CFAllocatorRef, CFTypeID, CFTypeRef, CFRange, Boolean};
 use string::CFStringRef;

--- a/core-foundation-sys/src/dictionary.rs
+++ b/core-foundation-sys/src/dictionary.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFAllocatorRef, CFHashCode, CFIndex, CFTypeID, Boolean};
 use string::CFStringRef;

--- a/core-foundation-sys/src/error.rs
+++ b/core-foundation-sys/src/error.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFTypeID, CFIndex, CFAllocatorRef};
 use string::CFStringRef;

--- a/core-foundation-sys/src/file_security.rs
+++ b/core-foundation-sys/src/file_security.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFAllocatorRef, Boolean, CFTypeID};
 #[cfg(feature="mac_os_10_8_features")]

--- a/core-foundation-sys/src/filedescriptor.rs
+++ b/core-foundation-sys/src/filedescriptor.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::{c_int, c_void};
+use core::ffi::{c_int, c_void};
 
 use base::{Boolean, CFIndex, CFTypeID, CFOptionFlags, CFAllocatorRef};
 use string::CFStringRef;

--- a/core-foundation-sys/src/lib.rs
+++ b/core-foundation-sys/src/lib.rs
@@ -6,6 +6,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![no_std]
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, improper_ctypes)]
 
 #![cfg_attr(all(feature="mac_os_10_7_support", feature="mac_os_10_8_features"), feature(linkage))] // back-compat requires weak linkage

--- a/core-foundation-sys/src/locale.rs
+++ b/core-foundation-sys/src/locale.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 use base::{CFIndex, CFAllocatorRef, CFTypeRef, LangCode, RegionCode, CFTypeID};
 use array::CFArrayRef;
 use string::CFStringRef;

--- a/core-foundation-sys/src/mach_port.rs
+++ b/core-foundation-sys/src/mach_port.rs
@@ -10,7 +10,7 @@
 use base::{CFAllocatorRef, CFIndex, CFTypeID, Boolean, mach_port_t};
 use string::CFStringRef;
 use runloop::CFRunLoopSourceRef;
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 #[repr(C)]
 pub struct __CFMachPort(c_void);

--- a/core-foundation-sys/src/messageport.rs
+++ b/core-foundation-sys/src/messageport.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFAllocatorRef, CFIndex, CFTypeID, Boolean, SInt32};
 use data::CFDataRef;

--- a/core-foundation-sys/src/notification_center.rs
+++ b/core-foundation-sys/src/notification_center.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFOptionFlags, CFIndex, CFTypeID, Boolean};
 use dictionary::CFDictionaryRef;

--- a/core-foundation-sys/src/number.rs
+++ b/core-foundation-sys/src/number.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFAllocatorRef, CFTypeID, CFComparisonResult, Boolean, CFIndex};
 

--- a/core-foundation-sys/src/number_formatter.rs
+++ b/core-foundation-sys/src/number_formatter.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::{c_void, c_double};
+use core::ffi::{c_void, c_double};
 
 use base::{CFIndex, CFOptionFlags, CFAllocatorRef, CFTypeID, CFRange, Boolean, CFTypeRef};
 use string::CFStringRef;

--- a/core-foundation-sys/src/plugin.rs
+++ b/core-foundation-sys/src/plugin.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFAllocatorRef, CFTypeID, Boolean, CFIndex};
 use bundle::{CFPlugInRef, CFBundleRef};

--- a/core-foundation-sys/src/runloop.rs
+++ b/core-foundation-sys/src/runloop.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use array::CFArrayRef;
 use base::{Boolean, CFIndex, CFTypeID, CFAllocatorRef, CFOptionFlags, CFHashCode, mach_port_t};

--- a/core-foundation-sys/src/set.rs
+++ b/core-foundation-sys/src/set.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFAllocatorRef, CFIndex, CFTypeID, Boolean, CFHashCode};
 use string::CFStringRef;

--- a/core-foundation-sys/src/socket.rs
+++ b/core-foundation-sys/src/socket.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFIndex, CFOptionFlags, SInt32, CFTypeID, CFAllocatorRef, UInt16, Boolean};
 use data::CFDataRef;
@@ -25,9 +25,9 @@ pub type CFSocketError = CFIndex;
 pub type CFSocketCallBackType = CFOptionFlags;
 pub type CFSocketCallBack = extern "C" fn (s: CFSocketRef, _type: CFSocketCallBackType, address: CFDataRef, cdata: *const c_void, info: *mut c_void);
 #[cfg(not(target_os = "windows"))]
-pub type CFSocketNativeHandle = std::os::raw::c_int;
+pub type CFSocketNativeHandle = core::ffi::c_int;
 #[cfg(target_os = "windows")]
-pub type CFSocketNativeHandle = std::os::raw::c_ulong;
+pub type CFSocketNativeHandle = core::ffi::c_ulong;
 
 pub const kCFSocketSuccess: CFSocketError = 0;
 pub const kCFSocketError: CFSocketError = -1;

--- a/core-foundation-sys/src/stream.rs
+++ b/core-foundation-sys/src/stream.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::{c_void, c_int};
+use core::ffi::{c_void, c_int};
 
 use base::{CFIndex, CFOptionFlags, SInt32, CFTypeID, CFAllocatorRef, UInt8, Boolean, CFTypeRef, UInt32};
 use string::CFStringRef;

--- a/core-foundation-sys/src/string.rs
+++ b/core-foundation-sys/src/string.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::{c_char, c_void, c_ulong, c_double, c_ushort};
+use core::ffi::{c_char, c_void, c_ulong, c_double, c_ushort};
 use base::{Boolean, CFOptionFlags, CFIndex, CFAllocatorRef, ConstStr255Param, CFRange, CFTypeID, SInt32, UInt32, UInt8, CFComparisonResult, StringPtr, ConstStringPtr, UTF32Char};
 use array::CFArrayRef;
 use data::CFDataRef;

--- a/core-foundation-sys/src/string_tokenizer.rs
+++ b/core-foundation-sys/src/string_tokenizer.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFAllocatorRef, CFTypeID, CFRange, CFIndex, CFOptionFlags, CFTypeRef};
 use string::CFStringRef;

--- a/core-foundation-sys/src/timezone.rs
+++ b/core-foundation-sys/src/timezone.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFAllocatorRef, CFTypeID, Boolean, CFIndex};
 use date::{CFTimeInterval, CFAbsoluteTime};

--- a/core-foundation-sys/src/tree.rs
+++ b/core-foundation-sys/src/tree.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFIndex, CFTypeID, CFAllocatorRef, CFComparatorFunction};
 use string::CFStringRef;

--- a/core-foundation-sys/src/url.rs
+++ b/core-foundation-sys/src/url.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFOptionFlags, CFIndex, CFAllocatorRef, Boolean, CFTypeID, CFTypeRef, SInt32, CFRange};
 use data::CFDataRef;

--- a/core-foundation-sys/src/url_enumerator.rs
+++ b/core-foundation-sys/src/url_enumerator.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFOptionFlags, CFIndex, CFTypeID, CFAllocatorRef, Boolean};
 use url::CFURLRef;

--- a/core-foundation-sys/src/user_notification.rs
+++ b/core-foundation-sys/src/user_notification.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFOptionFlags, CFIndex, CFAllocatorRef, CFTypeID, SInt32};
 use dictionary::CFDictionaryRef;

--- a/core-foundation-sys/src/uuid.rs
+++ b/core-foundation-sys/src/uuid.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFAllocatorRef, CFTypeID};
 use string::CFStringRef;

--- a/core-foundation-sys/src/xml_node.rs
+++ b/core-foundation-sys/src/xml_node.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::{c_void, c_char};
+use core::ffi::{c_void, c_char};
 
 use base::{Boolean, CFIndex, CFAllocatorRef, CFTypeID};
 use tree::CFTreeRef;

--- a/core-foundation-sys/src/xml_parser.rs
+++ b/core-foundation-sys/src/xml_parser.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use base::{CFOptionFlags, CFIndex, Boolean, CFAllocatorRef, CFTypeID};
 use xml_node::{CFXMLNodeRef, CFXMLTreeRef, CFXMLExternalID};


### PR DESCRIPTION
Since the purpose of this crate is the bindings to an external library and they're pretty much complete, we can see that the only thing we use in libstd are the pointer types and `std::cmp`. In fact they're defined in libcore and then exported through libstd. I doubt that we will ever need any libstd only stuff such as heap allocation, vectors, hashmaps, etc. I propose making core-foundation-sys a `no_std` crate. It maybe useful in some rare situations. For instance, windows-sys crate (Microsoft's official Rust bindings) is no_std and it can be used for writing kernel drivers.