### PR TITLE
Drop #[no_mangle] from cg_event_tap_callback_internal

### DIFF
--- a/core-graphics/src/event.rs
+++ b/core-graphics/src/event.rs
@@ -423,7 +423,6 @@ type CGEventTapCallBackInternal = unsafe extern "C" fn(
     user_info: *const c_void,
 ) -> ::sys::CGEventRef;
 
-#[no_mangle]
 unsafe extern "C" fn cg_event_tap_callback_internal(
     _proxy: CGEventTapProxy,
     _etype: CGEventType,


### PR DESCRIPTION
This allows multiple versions of core-graphics to be linked into the same binaries without getting "duplicate symbol: cg_event_tap_callback_internal"