### PR TITLE
Run tests for MSRV, on macOS versions, and fix toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - "build"
-      - "msrv"
       - "semver"
     steps:
       - name: Mark the job as successful

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,24 +27,19 @@ jobs:
     - uses: actions/checkout@v2
     - name: Check semver
       uses: obi1kenobi/cargo-semver-checks-action@v2
-  msrv:
-    runs-on: macos-11.0
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.56.1
-        override: true
-    - name: Build
-      run: cargo build --verbose
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-11.0, macos-12, macos-13]
+        toolchain: [stable, 1.56.1]
     steps:
     - uses: actions/checkout@v2
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.toolchain }}
+        override: true
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
   semver:
     runs-on: macos-11.0
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check semver
       uses: obi1kenobi/cargo-semver-checks-action@v2
   build:
@@ -34,7 +34,7 @@ jobs:
         os: [macos-11.0, macos-12, macos-13]
         toolchain: [stable, 1.56.1]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@master
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,10 +36,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.toolchain }}
-        override: true
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
#611 added the MSRV to CI, but doesn't run any tests, or run it against the same set of macOS versions as regular tests.

This puts the MSRV in as a build matrix entry for the normal builds, so it'll run the same way for all.

This also switches to `dtolnay/rust-toolchain`, because [`actions-rs/toolchain` is unmaintained](https://old.reddit.com/r/rust/comments/vyx4oj/actionsrs_organization_became_unmaintained/ig54zv7/) and doesn't actually work properly anymore (it'll still build with Rust stable!).

CI run: https://github.com/micolous/core-foundation-rs/actions/runs/5514991574