### PR TITLE
Add missing CFRangeMake function

### DIFF
--- a/core-foundation-sys/src/base.rs
+++ b/core-foundation-sys/src/base.rs
@@ -169,5 +169,6 @@ extern {
     pub fn CFShow(obj: CFTypeRef);
 
     /* Base Utilities Reference */
+    pub fn CFRangeMake(loc: CFIndex, len: CFIndex) -> CFRange;
     // N.B. Some things missing here.
 }


### PR DESCRIPTION
Not really useful since we can initialize `CFRange` using the `init` method, however it makes the doc search much more better if it exists. As an alternative, I could add a doc alias. As you prefer.