### PR TITLE
Revert "mach_port: Removed redundant `pub use`"

### DIFF
--- a/core-foundation-sys/src/mach_port.rs
+++ b/core-foundation-sys/src/mach_port.rs
@@ -7,8 +7,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use base::{CFAllocatorRef, CFIndex, CFTypeID, Boolean, mach_port_t};
 use string::CFStringRef;
+pub use base::{CFAllocatorRef, CFIndex, CFTypeID};
+use base::{Boolean, mach_port_t};
 use runloop::CFRunLoopSourceRef;
 use std::os::raw::c_void;
 

--- a/core-foundation/src/mach_port.rs
+++ b/core-foundation/src/mach_port.rs
@@ -1,4 +1,4 @@
-use base::{TCFType, CFIndex};
+use base::TCFType;
 use core_foundation_sys::base::kCFAllocatorDefault;
 use runloop::CFRunLoopSource;
 pub use core_foundation_sys::mach_port::*;


### PR DESCRIPTION
This reverts commit 6d00383bafd95f7457a288e1948fc4111a34ae9e.

It broke semver because it removed the export of CFIndex which which older versions of the core-foundation crate are depending on.