### PR TITLE
Bump core-text version

### DIFF
--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "20.0.0"
+version = "20.1.0"
 authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Just exposing a couple of additional APIs.

(Motivation: to enable us to try using the `_and_options` API when instantiating fonts in webrender, for https://bugzilla.mozilla.org/show_bug.cgi?id=1803406.)