### PR TITLE
Only import `SInt32` on macOS.

### DIFF
--- a/core-foundation-sys/src/bundle.rs
+++ b/core-foundation-sys/src/bundle.rs
@@ -10,7 +10,9 @@
 use std::os::raw::c_void;
 
 use array::CFArrayRef;
-use base::{Boolean, CFAllocatorRef, CFTypeID, CFTypeRef, SInt32, UInt32};
+#[cfg(target_os = "macos")]
+use base::SInt32;
+use base::{Boolean, CFAllocatorRef, CFTypeID, CFTypeRef, UInt32};
 use dictionary::CFDictionaryRef;
 use error::CFErrorRef;
 use std::os::raw::{c_int, c_uint};


### PR DESCRIPTION
It is only used on macOS, so having it when building for other targets (like iOS) results in a warning.