### PR TITLE
Make CFRunLoopMode a safe wrapper with a lifetime

### DIFF
--- a/core-foundation/src/filedescriptor.rs
+++ b/core-foundation/src/filedescriptor.rs
@@ -154,7 +154,7 @@ mod test {
         let run_loop = CFRunLoop::get_current();
         let source = CFRunLoopSource::from_file_descriptor(&cf_fd, 0);
         assert!(source.is_some());
-        run_loop.add_source(&source.unwrap(), CFRunLoopMode::default());
+        run_loop.add_source(&source.unwrap(), CFRunLoopMode::default_mode());
 
         info.value = 0;
         cf_fd.enable_callbacks(kCFFileDescriptorReadCallBack);

--- a/core-foundation/src/runloop.rs
+++ b/core-foundation/src/runloop.rs
@@ -29,12 +29,12 @@ impl<'a> CFRunLoopMode<'a> {
     }
 
     #[doc(alias = "kCFRunLoopCommonModes")]
-    pub fn common() -> CFRunLoopMode<'static> {
+    pub fn common_modes() -> CFRunLoopMode<'static> {
         unsafe { CFRunLoopMode(kCFRunLoopCommonModes, PhantomData) }
     }
 
     #[doc(alias = "kCFRunLoopDefaultMode")]
-    pub fn default() -> CFRunLoopMode<'static> {
+    pub fn default_mode() -> CFRunLoopMode<'static> {
         unsafe { CFRunLoopMode(kCFRunLoopDefaultMode, PhantomData) }
     }
 }
@@ -240,7 +240,7 @@ mod test {
 
         let run_loop_timer =
             CFRunLoopTimer::new(now + 0.20f64, 0f64, 0, 0, timer_popped, &mut context);
-        run_loop.add_timer(&run_loop_timer, CFRunLoopMode::default());
+        run_loop.add_timer(&run_loop_timer, CFRunLoopMode::default_mode());
 
         CFRunLoop::run_current();
         let elapsed = elapsed_rx.try_recv().unwrap();
@@ -294,7 +294,7 @@ mod test {
             };
 
             let runloop = CFRunLoop::get_current();
-            runloop.add_observer(&observer, CFRunLoopMode::default());
+            runloop.add_observer(&observer, CFRunLoopMode::default_mode());
 
             let timer = CFRunLoopTimer::new(
                 CFDate::now().abs_time() + 1f64,
@@ -304,10 +304,13 @@ mod test {
                 observe_timer_popped,
                 null_mut(),
             );
-            runloop.add_timer(&timer, CFRunLoopMode::default());
+            runloop.add_timer(&timer, CFRunLoopMode::default_mode());
 
-            let result =
-                CFRunLoop::run_in_mode(CFRunLoopMode::default(), Duration::from_secs(10), false);
+            let result = CFRunLoop::run_in_mode(
+                CFRunLoopMode::default_mode(),
+                Duration::from_secs(10),
+                false,
+            );
 
             assert_eq!(result, CFRunLoopRunResult::Stopped);
 

--- a/core-graphics/src/event.rs
+++ b/core-graphics/src/event.rs
@@ -461,7 +461,7 @@ unsafe extern "C" fn cg_event_tap_callback_internal(
 ///             .mach_port
 ///             .create_runloop_source(0)
 ///             .expect("Somethings is bad ");
-///         current.add_source(&loop_source, CFRunLoopMode::common());
+///         current.add_source(&loop_source, CFRunLoopMode::common_modes());
 ///         tap.enable();
 ///         CFRunLoop::run_current();
 ///     },


### PR DESCRIPTION
Fixes https://github.com/servo/core-foundation-rs/issues/648: the safe methods that take `CFRunLoopMode` are currently unsound because it is a raw pointer that is not necessarily valid.

As a bonus, this allows use of `kCFRunLoopCommonModes` and `kCFRunLoopDefaultMode` constants without `unsafe`.

I considered just making `mode` a `&CFString`, but it seems that the [implementation compares the pointer values](https://github.com/apple-oss-distributions/CF/blob/dc54c6bb1c1e5e0b9486c1d26dd5bef110b20bf3/CFRunLoop.c#L2824), so this way ensures that the constants are passed as the pointers it expects. I don't understand the purpose or usage of `mode` very well, so correct me if this is not ideal.