### PR TITLE
Fix  TCFType macros for generic types

### DIFF
--- a/core-foundation/src/characterset.rs
+++ b/core-foundation/src/characterset.rs
@@ -11,8 +11,6 @@
 
 pub use core_foundation_sys::characterset::*;
 
-use crate::base::TCFType;
-
 declare_TCFType! {
     /// An immutable set of Unicode characters.
     CFCharacterSet, CFCharacterSetRef

--- a/core-foundation/src/lib.rs
+++ b/core-foundation/src/lib.rs
@@ -53,15 +53,24 @@ macro_rules! declare_TCFType {
         $(#[$doc:meta])*
         $ty:ident, $raw:ident
     ) => {
-        $(#[$doc])*
-        pub struct $ty($raw);
+        declare_TCFType!($(#[$doc])* $ty<>, $raw);
+    };
 
-        impl Drop for $ty {
+    (
+        $(#[$doc:meta])*
+        $ty:ident<$($p:ident $(: $bound:path)*),*>, $raw:ident
+    ) => {
+        $(#[$doc])*
+        pub struct $ty<$($p $(: $bound)*),*>($raw, $(::std::marker::PhantomData<$p>),*);
+
+        #[allow(unused_imports)]
+        impl<$($p $(: $bound)*),*> Drop for $ty<$($p),*> {
             fn drop(&mut self) {
+                use $crate::base::TCFType;
                 unsafe { $crate::base::CFRelease(self.as_CFTypeRef()) }
             }
         }
-    }
+    };
 }
 
 /// Provide an implementation of the [`TCFType`] trait for the Rust
@@ -82,6 +91,7 @@ macro_rules! impl_TCFType {
         impl<$($p $(: $bound)*),*> $crate::base::TCFType for $ty<$($p),*> {
             type Ref = $ty_ref;
 
+            #[allow(non_snake_case)]
             #[inline]
             fn as_concrete_TypeRef(&self) -> $ty_ref {
                 self.0
@@ -94,6 +104,7 @@ macro_rules! impl_TCFType {
                 $crate::base::TCFType::wrap_under_create_rule(reference)
             }
 
+            #[allow(non_snake_case)]
             #[inline]
             fn as_CFTypeRef(&self) -> $crate::base::CFTypeRef {
                 self.as_concrete_TypeRef() as $crate::base::CFTypeRef
@@ -115,39 +126,46 @@ macro_rules! impl_TCFType {
             }
         }
 
-        impl Clone for $ty {
+        #[allow(unused_imports)]
+        impl<$($p $(: $bound)*),*> Clone for $ty<$($p),*> {
             #[inline]
-            fn clone(&self) -> $ty {
+            fn clone(&self) -> Self {
+                use $crate::base::TCFType;
                 unsafe {
                     $ty::wrap_under_get_rule(self.0)
                 }
             }
         }
 
-        impl PartialEq for $ty {
+        #[allow(unused_imports)]
+        impl<$($p $(: $bound)*),*> PartialEq for $ty<$($p),*> {
             #[inline]
-            fn eq(&self, other: &$ty) -> bool {
+            fn eq(&self, other: &Self) -> bool {
+                use $crate::base::TCFType;
                 self.as_CFType().eq(&other.as_CFType())
             }
         }
 
-        impl Eq for $ty { }
+        impl<$($p $(: $bound)*),*> Eq for $ty<$($p),*> { }
 
-        unsafe impl<'a> $crate::base::ToVoid<$ty> for &'a $ty {
+        #[allow(unused_imports)]
+        unsafe impl<'a, $($p $(: $bound)*),*> $crate::base::ToVoid<$ty<$($p),*>> for &'a $ty<$($p),*> {
             fn to_void(&self) -> *const ::core::ffi::c_void {
-                use $crate::base::TCFTypeRef;
+                use $crate::base::{TCFType, TCFTypeRef};
                 self.as_concrete_TypeRef().as_void_ptr()
             }
         }
 
-        unsafe impl $crate::base::ToVoid<$ty> for $ty {
+        #[allow(unused_imports)]
+        unsafe impl<$($p $(: $bound)*),*> $crate::base::ToVoid<$ty<$($p),*>> for $ty<$($p),*> {
             fn to_void(&self) -> *const ::core::ffi::c_void {
-                use $crate::base::TCFTypeRef;
+                use $crate::base::{TCFType, TCFTypeRef};
                 self.as_concrete_TypeRef().as_void_ptr()
             }
         }
 
-        unsafe impl $crate::base::ToVoid<$ty> for $ty_ref {
+        #[allow(unused_imports)]
+        unsafe impl<$($p $(: $bound)*),*> $crate::base::ToVoid<$ty<$($p),*>> for $ty_ref {
             fn to_void(&self) -> *const ::core::ffi::c_void {
                 use $crate::base::TCFTypeRef;
                 self.as_void_ptr()
@@ -178,8 +196,10 @@ macro_rules! impl_CFTypeDescription {
         impl_CFTypeDescription!($ty<>);
     };
     ($ty:ident<$($p:ident $(: $bound:path)*),*>) => {
+        #[allow(unused_imports)]
         impl<$($p $(: $bound)*),*> ::std::fmt::Debug for $ty<$($p),*> {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                use $crate::base::TCFType;
                 self.as_CFType().fmt(f)
             }
         }

--- a/core-foundation/src/lib.rs
+++ b/core-foundation/src/lib.rs
@@ -209,9 +209,12 @@ macro_rules! impl_CFTypeDescription {
 #[macro_export]
 macro_rules! impl_CFComparison {
     ($ty:ident, $compare:ident) => {
-        impl PartialOrd for $ty {
+        impl_CFComparison!($ty<>, $compare);
+    };
+    ($ty:ident<$($p:ident $(: $bound:path)*),*>, $compare:ident) => {
+        impl<$($p $(: $bound)*),*> PartialOrd for $ty<$($p),*> {
             #[inline]
-            fn partial_cmp(&self, other: &$ty) -> Option<::std::cmp::Ordering> {
+            fn partial_cmp(&self, other: &$ty<$($p),*>) -> Option<::std::cmp::Ordering> {
                 unsafe {
                     Some(
                         $compare(
@@ -225,9 +228,9 @@ macro_rules! impl_CFComparison {
             }
         }
 
-        impl Ord for $ty {
+        impl<$($p $(: $bound)*),*> Ord for $ty<$($p),*> {
             #[inline]
-            fn cmp(&self, other: &$ty) -> ::std::cmp::Ordering {
+            fn cmp(&self, other: &$ty<$($p),*>) -> ::std::cmp::Ordering {
                 self.partial_cmp(other).unwrap()
             }
         }

--- a/core-foundation/tests/use_macro_outside_crate.rs
+++ b/core-foundation/tests/use_macro_outside_crate.rs
@@ -24,3 +24,8 @@ declare_TCFType!(CFFooBar, CFFooBarRef);
 impl_TCFType!(CFFooBar, CFFooBarRef, CFFooBarGetTypeID);
 impl_CFTypeDescription!(CFFooBar);
 impl_CFComparison!(CFFooBar, fake_compare);
+
+declare_TCFType!(CFGenericFooBar<T: Clone>, CFFooBarRef);
+impl_TCFType!(CFGenericFooBar<T: Clone>, CFFooBarRef, CFFooBarGetTypeID);
+impl_CFTypeDescription!(CFGenericFooBar<T: Clone>);
+impl_CFComparison!(CFGenericFooBar<T: Clone>, fake_compare);


### PR DESCRIPTION
`impl_TCFType!` accepts generic types but some of its impls are missing the generics. They work on types with defaulted generics, but only in the default case. This PR fixes that.

It also updates `declare_TCFType!` to accept generics as a convenience. We use one PhantomData per parameter, as is already done in `impl_TCFType!`.

In addition, some warnings are silenced, and the macros no longer depend on any traits being in scope in the caller.