### PR TITLE
Rename `master` branch to `main`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     branches: ["**"]
   merge_group:


### PR DESCRIPTION
This is in line with a decision made about the Servo organization by the Servo TSC. We consider `main` to be shorter, easier to type, and more modern, so we are standardizing on this branch name.