### PR TITLE
fix(core-graphics): add composite events to CGEventType

### DIFF
--- a/core-graphics/src/event.rs
+++ b/core-graphics/src/event.rs
@@ -126,6 +126,11 @@ pub enum CGEventType {
     KeyUp = 11,
     FlagsChanged = 12,
 
+    // Composite events.
+    AppKitDefined = 13,
+    SystemDefined = 14,
+    ApplicationDefined = 15,
+
     // Specialized control devices.
     ScrollWheel = 22,
     TabletPointer = 23,


### PR DESCRIPTION
I need to listen to a `NX_SYSDEFINED` event. I found it was not coded in the `CGEventType` enum but on the http://opensource.apple.com/source/IOHIDFamily/IOHIDFamily-700/IOHIDSystem/IOKit/hidsystem/IOLLEvent.h
