### PR TITLE
Add visionOS and watchOS to linking to CoreFoundation framework

### DIFF
--- a/core-foundation-sys/src/lib.rs
+++ b/core-foundation-sys/src/lib.rs
@@ -23,7 +23,13 @@
 // https://github.com/rust-lang/lang-team/issues/102
 #[cfg_attr(
     all(
-        any(target_os = "macos", target_os = "ios", target_os = "tvos"),
+        any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "visionos"
+        ),
         feature = "link"
     ),
     link(name = "CoreFoundation", kind = "framework")


### PR DESCRIPTION
When using a [few patches for various tls and security framework features to build for visionOS and watchOS (among other apple targets)](https://github.com/liveview-native/liveview-native-core/blob/764510b73967d31cfe6c243ea1c03bc81e60ce98/Cargo.toml#L45-L46), I ran into a linking error.

In https://github.com/rust-lang/rust/pull/125225, linking to Foundation was removed which I think caused some link errors for visionOS and watchOS on rust nightly-2024-05-22.

These are the fixes to those errors.