### PR TITLE
ci: Remove usage of macos-11

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
           components: rustfmt
       - run: cargo fmt --check
   semver:
-    runs-on: macos-14.0
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - name: Check semver

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
           components: rustfmt
       - run: cargo fmt --check
   semver:
-    runs-on: macos-11.0
+    runs-on: macos-14.0
     steps:
     - uses: actions/checkout@v4
     - name: Check semver
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11.0, macos-12, macos-13, macos-14]
+        os: [macos-12, macos-13, macos-14]
         toolchain: [stable]
         include:
           - os: macos-14


### PR DESCRIPTION
This is being removed at GitHub on June 28, 2024.

Switch semver action to macos-14.
