### PR TITLE
Remove remaining `chrono` code.

### DIFF
--- a/core-foundation/src/timezone.rs
+++ b/core-foundation/src/timezone.rs
@@ -16,9 +16,6 @@ use crate::base::TCFType;
 use crate::date::{CFDate, CFTimeInterval};
 use crate::string::CFString;
 
-#[cfg(feature = "with-chrono")]
-use chrono::{FixedOffset, NaiveDateTime};
-
 declare_TCFType! {
     /// A time zone.
     CFTimeZone, CFTimeZoneRef
@@ -56,17 +53,6 @@ impl CFTimeZone {
         unsafe { CFTimeZoneGetSecondsFromGMT(self.0, date.abs_time()) }
     }
 
-    #[cfg(feature = "with-chrono")]
-    pub fn offset_at_date(&self, date: NaiveDateTime) -> FixedOffset {
-        let date = CFDate::from_naive_utc(date);
-        FixedOffset::east(self.seconds_from_gmt(date) as i32)
-    }
-
-    #[cfg(feature = "with-chrono")]
-    pub fn from_offset(offset: FixedOffset) -> CFTimeZone {
-        CFTimeZone::new(offset.local_minus_utc() as f64)
-    }
-
     /// The timezone database ID that identifies the time zone. E.g. `"America/Los_Angeles" `or
     /// `"Europe/Paris"`.
     pub fn name(&self) -> CFString {
@@ -78,22 +64,10 @@ impl CFTimeZone {
 mod test {
     use super::CFTimeZone;
 
-    #[cfg(feature = "with-chrono")]
-    use chrono::{FixedOffset, NaiveDateTime};
-
     #[test]
     fn timezone_comparison() {
         let system = CFTimeZone::system();
         let default = CFTimeZone::default();
         assert_eq!(system, default);
-    }
-
-    #[test]
-    #[cfg(feature = "with-chrono")]
-    fn timezone_chrono_conversion() {
-        let offset = FixedOffset::west(28800);
-        let tz = CFTimeZone::from_offset(offset);
-        let converted = tz.offset_at_date(NaiveDateTime::from_timestamp(0, 0));
-        assert_eq!(offset, converted);
     }
 }


### PR DESCRIPTION
In 97216460536901804d5d92a80b4885bbd1ee0bb3, the `with-chrono` feature was removed, but this dead code lingered.