### PR TITLE
Avoid UB if the CFData pointer is NULL

### DIFF
--- a/core-foundation/src/data.rs
+++ b/core-foundation/src/data.rs
@@ -81,7 +81,14 @@ impl CFData {
     /// read-only.
     #[inline]
     pub fn bytes(&self) -> &[u8] {
-        unsafe { slice::from_raw_parts(CFDataGetBytePtr(self.0), self.len() as usize) }
+        unsafe {
+            let ptr = CFDataGetBytePtr(self.0);
+            // Rust slice must never have a NULL pointer
+            if ptr.is_null() {
+                return &[];
+            }
+            slice::from_raw_parts(ptr, self.len() as usize)
+        }
     }
 
     /// Returns the length of this byte buffer.


### PR DESCRIPTION
There's no guarantee that `CFDataGetBytePtr` will return a non-NULL pointer, and therefore creating a slice from it can be Undefined Behavior in Rust.

https://github.com/kornelski/rust-security-framework/issues/206
