### PR TITLE
core-foundation: Use dep syntax for `with-uuid` feature.

### DIFF
--- a/core-foundation/Cargo.toml
+++ b/core-foundation/Cargo.toml
@@ -25,7 +25,7 @@ default = ["link"]
 
 mac_os_10_7_support = ["core-foundation-sys/mac_os_10_7_support"] # backwards compatibility
 mac_os_10_8_features = ["core-foundation-sys/mac_os_10_8_features"] # enables new features
-with-uuid = ["uuid"]
+with-uuid = ["dep:uuid"]
 # Disable to manually link. Enabled by default.
 link = ["core-foundation-sys/link"]
 


### PR DESCRIPTION
This removes an implicit feature due to the optional dependency `uuid`.

While this is user visible, any use of `uuid` as a feature previously would not have enabled the support code and so it wouldn't have had any benefit.

Bump the MSRV in CI to 1.64 (while only 1.60 is required here, other features from 1.64 will be used).