### PR TITLE
Use `core::ffi` over `std::os::raw` and `libc::c_*`

### DIFF
--- a/cocoa-foundation/Cargo.toml
+++ b/cocoa-foundation/Cargo.toml
@@ -16,7 +16,6 @@ default-target = "x86_64-apple-darwin"
 [dependencies]
 block = "0.1"
 bitflags = "2"
-libc = "0.2"
 core-foundation = { default-features = false, path = "../core-foundation", version = "0.10" }
 core-graphics-types = { default-features = false, path = "../core-graphics-types", version = "0.2" }
 objc = "0.2.3"

--- a/cocoa-foundation/src/foundation.rs
+++ b/cocoa-foundation/src/foundation.rs
@@ -12,20 +12,19 @@
 use crate::base::{id, nil, BOOL, NO, SEL};
 use bitflags::bitflags;
 use block::Block;
-use libc;
+use core::ffi::{c_char, c_double, c_ulong, c_ulonglong, c_void};
 use objc::{class, msg_send, sel, sel_impl};
-use std::os::raw::c_void;
 use std::ptr;
 
 #[cfg(target_pointer_width = "32")]
-pub type NSInteger = libc::c_int;
+pub type NSInteger = core::ffi::c_int;
 #[cfg(target_pointer_width = "32")]
-pub type NSUInteger = libc::c_uint;
+pub type NSUInteger = core::ffi::c_uint;
 
 #[cfg(target_pointer_width = "64")]
-pub type NSInteger = libc::c_long;
+pub type NSInteger = core::ffi::c_long;
 #[cfg(target_pointer_width = "64")]
-pub type NSUInteger = libc::c_ulong;
+pub type NSUInteger = core::ffi::c_ulong;
 
 pub const NSIntegerMax: NSInteger = NSInteger::max_value();
 pub const NSNotFound: NSInteger = NSIntegerMax;
@@ -245,7 +244,7 @@ impl NSProcessInfo for id {
     }
 }
 
-pub type NSTimeInterval = libc::c_double;
+pub type NSTimeInterval = c_double;
 
 pub trait NSArray: Sized {
     unsafe fn array(_: Self) -> id {
@@ -401,7 +400,7 @@ pub trait NSDictionary: Sized {
     unsafe fn fileOwnerAccountID(self) -> id;
     unsafe fn fileOwnerAccountName(self) -> id;
     unsafe fn filePosixPermissions(self) -> NSUInteger;
-    unsafe fn fileSize(self) -> libc::c_ulonglong;
+    unsafe fn fileSize(self) -> c_ulonglong;
     unsafe fn fileSystemFileNumber(self) -> NSUInteger;
     unsafe fn fileSystemNumber(self) -> NSInteger;
     unsafe fn fileType(self) -> id;
@@ -581,7 +580,7 @@ impl NSDictionary for id {
         msg_send![self, filePosixPermissions]
     }
 
-    unsafe fn fileSize(self) -> libc::c_ulonglong {
+    unsafe fn fileSize(self) -> c_ulonglong {
         msg_send![self, fileSize]
     }
 
@@ -616,7 +615,7 @@ impl NSDictionary for id {
 
 bitflags! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    pub struct NSEnumerationOptions: libc::c_ulonglong {
+    pub struct NSEnumerationOptions: c_ulonglong {
         const NSEnumerationConcurrent = 1 << 0;
         const NSEnumerationReverse = 1 << 1;
     }
@@ -639,7 +638,7 @@ pub trait NSString: Sized {
 
     unsafe fn stringByAppendingString_(self, other: id) -> id;
     unsafe fn init_str(self, string: &str) -> Self;
-    unsafe fn UTF8String(self) -> *const libc::c_char;
+    unsafe fn UTF8String(self) -> *const c_char;
     unsafe fn len(self) -> usize;
     unsafe fn isEqualToString(self, string: &str) -> bool;
     unsafe fn substringWithRange(self, range: NSRange) -> id;
@@ -667,7 +666,7 @@ impl NSString for id {
         msg_send![self, lengthOfBytesUsingEncoding: UTF8_ENCODING]
     }
 
-    unsafe fn UTF8String(self) -> *const libc::c_char {
+    unsafe fn UTF8String(self) -> *const c_char {
         msg_send![self, UTF8String]
     }
 
@@ -690,10 +689,10 @@ impl NSDate for id {}
 
 #[repr(C)]
 struct NSFastEnumerationState {
-    pub state: libc::c_ulong,
+    pub state: c_ulong,
     pub items_ptr: *mut id,
-    pub mutations_ptr: *mut libc::c_ulong,
-    pub extra: [libc::c_ulong; 5],
+    pub mutations_ptr: *mut c_ulong,
+    pub extra: [c_ulong; 5],
 }
 
 const NS_FAST_ENUM_BUF_SIZE: usize = 16;
@@ -701,7 +700,7 @@ const NS_FAST_ENUM_BUF_SIZE: usize = 16;
 pub struct NSFastIterator {
     state: NSFastEnumerationState,
     buffer: [id; NS_FAST_ENUM_BUF_SIZE],
-    mut_val: Option<libc::c_ulong>,
+    mut_val: Option<c_ulong>,
     len: usize,
     idx: usize,
     object: id,
@@ -1596,7 +1595,7 @@ impl NSData for id {
 
 bitflags! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    pub struct NSDataReadingOptions: libc::c_ulonglong {
+    pub struct NSDataReadingOptions: c_ulonglong {
        const NSDataReadingMappedIfSafe = 1 << 0;
        const NSDataReadingUncached = 1 << 1;
        const NSDataReadingMappedAlways = 1 << 3;
@@ -1605,7 +1604,7 @@ bitflags! {
 
 bitflags! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    pub struct NSDataBase64EncodingOptions: libc::c_ulonglong {
+    pub struct NSDataBase64EncodingOptions: c_ulonglong {
         const NSDataBase64Encoding64CharacterLineLength = 1 << 0;
         const NSDataBase64Encoding76CharacterLineLength = 1 << 1;
         const NSDataBase64EncodingEndLineWithCarriageReturn = 1 << 4;
@@ -1615,14 +1614,14 @@ bitflags! {
 
 bitflags! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    pub struct NSDataBase64DecodingOptions: libc::c_ulonglong {
+    pub struct NSDataBase64DecodingOptions: c_ulonglong {
        const NSDataBase64DecodingIgnoreUnknownCharacters = 1 << 0;
     }
 }
 
 bitflags! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    pub struct NSDataWritingOptions: libc::c_ulonglong {
+    pub struct NSDataWritingOptions: c_ulonglong {
         const NSDataWritingAtomic = 1 << 0;
         const NSDataWritingWithoutOverwriting = 1 << 1;
     }
@@ -1630,7 +1629,7 @@ bitflags! {
 
 bitflags! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    pub struct NSDataSearchOptions: libc::c_ulonglong {
+    pub struct NSDataSearchOptions: c_ulonglong {
         const NSDataSearchBackwards = 1 << 0;
         const NSDataSearchAnchored = 1 << 1;
     }

--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -15,6 +15,7 @@ use crate::foundation::{
 };
 use bitflags::bitflags;
 use block::Block;
+use core::ffi::{c_float, c_int, c_ulonglong, c_ushort, c_void};
 use libc;
 use objc::{class, msg_send, sel, sel_impl};
 
@@ -27,7 +28,6 @@ pub use self::NSBackingStoreType::*;
 pub use self::NSEventType::*;
 pub use self::NSOpenGLPFAOpenGLProfiles::*;
 pub use self::NSOpenGLPixelFormatAttribute::*;
-use std::os::raw::c_void;
 
 pub type CGLContextObj = *mut c_void;
 
@@ -281,7 +281,7 @@ bitflags! {
 
 bitflags! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    pub struct NSAlignmentOptions: libc::c_ulonglong {
+    pub struct NSAlignmentOptions: c_ulonglong {
         const NSAlignMinXInward         = 1 << 0;
         const NSAlignMinYInward         = 1 << 1;
         const NSAlignMaxXInward         = 1 << 2;
@@ -1060,7 +1060,7 @@ impl NSMenuItem for id {
     }
 }
 
-pub type NSWindowDepth = libc::c_int;
+pub type NSWindowDepth = c_int;
 
 bitflags! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -2620,43 +2620,43 @@ pub enum NSEventType {
 
 bitflags! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    pub struct NSEventMask: libc::c_ulonglong {
-        const NSLeftMouseDownMask         = 1 << NSLeftMouseDown as libc::c_ulonglong;
-        const NSLeftMouseUpMask           = 1 << NSLeftMouseUp as libc::c_ulonglong;
-        const NSRightMouseDownMask        = 1 << NSRightMouseDown as libc::c_ulonglong;
-        const NSRightMouseUpMask          = 1 << NSRightMouseUp as libc::c_ulonglong;
-        const NSMouseMovedMask            = 1 << NSMouseMoved as libc::c_ulonglong;
-        const NSLeftMouseDraggedMask      = 1 << NSLeftMouseDragged as libc::c_ulonglong;
-        const NSRightMouseDraggedMask     = 1 << NSRightMouseDragged as libc::c_ulonglong;
-        const NSMouseEnteredMask          = 1 << NSMouseEntered as libc::c_ulonglong;
-        const NSMouseExitedMask           = 1 << NSMouseExited as libc::c_ulonglong;
-        const NSKeyDownMask               = 1 << NSKeyDown as libc::c_ulonglong;
-        const NSKeyUpMask                 = 1 << NSKeyUp as libc::c_ulonglong;
-        const NSFlagsChangedMask          = 1 << NSFlagsChanged as libc::c_ulonglong;
-        const NSAppKitDefinedMask         = 1 << NSAppKitDefined as libc::c_ulonglong;
-        const NSSystemDefinedMask         = 1 << NSSystemDefined as libc::c_ulonglong;
-        const NSApplicationDefinedMask    = 1 << NSApplicationDefined as libc::c_ulonglong;
-        const NSPeriodicMask              = 1 << NSPeriodic as libc::c_ulonglong;
-        const NSCursorUpdateMask          = 1 << NSCursorUpdate as libc::c_ulonglong;
-        const NSScrollWheelMask           = 1 << NSScrollWheel as libc::c_ulonglong;
-        const NSTabletPointMask           = 1 << NSTabletPoint as libc::c_ulonglong;
-        const NSTabletProximityMask       = 1 << NSTabletProximity as libc::c_ulonglong;
-        const NSOtherMouseDownMask        = 1 << NSOtherMouseDown as libc::c_ulonglong;
-        const NSOtherMouseUpMask          = 1 << NSOtherMouseUp as libc::c_ulonglong;
-        const NSOtherMouseDraggedMask     = 1 << NSOtherMouseDragged as libc::c_ulonglong;
-        const NSEventMaskGesture          = 1 << NSEventTypeGesture as libc::c_ulonglong;
-        const NSEventMaskSwipe            = 1 << NSEventTypeSwipe as libc::c_ulonglong;
-        const NSEventMaskRotate           = 1 << NSEventTypeRotate as libc::c_ulonglong;
-        const NSEventMaskBeginGesture     = 1 << NSEventTypeBeginGesture as libc::c_ulonglong;
-        const NSEventMaskEndGesture       = 1 << NSEventTypeEndGesture as libc::c_ulonglong;
-        const NSEventMaskPressure         = 1 << NSEventTypePressure as libc::c_ulonglong;
+    pub struct NSEventMask: c_ulonglong {
+        const NSLeftMouseDownMask         = 1 << NSLeftMouseDown as c_ulonglong;
+        const NSLeftMouseUpMask           = 1 << NSLeftMouseUp as c_ulonglong;
+        const NSRightMouseDownMask        = 1 << NSRightMouseDown as c_ulonglong;
+        const NSRightMouseUpMask          = 1 << NSRightMouseUp as c_ulonglong;
+        const NSMouseMovedMask            = 1 << NSMouseMoved as c_ulonglong;
+        const NSLeftMouseDraggedMask      = 1 << NSLeftMouseDragged as c_ulonglong;
+        const NSRightMouseDraggedMask     = 1 << NSRightMouseDragged as c_ulonglong;
+        const NSMouseEnteredMask          = 1 << NSMouseEntered as c_ulonglong;
+        const NSMouseExitedMask           = 1 << NSMouseExited as c_ulonglong;
+        const NSKeyDownMask               = 1 << NSKeyDown as c_ulonglong;
+        const NSKeyUpMask                 = 1 << NSKeyUp as c_ulonglong;
+        const NSFlagsChangedMask          = 1 << NSFlagsChanged as c_ulonglong;
+        const NSAppKitDefinedMask         = 1 << NSAppKitDefined as c_ulonglong;
+        const NSSystemDefinedMask         = 1 << NSSystemDefined as c_ulonglong;
+        const NSApplicationDefinedMask    = 1 << NSApplicationDefined as c_ulonglong;
+        const NSPeriodicMask              = 1 << NSPeriodic as c_ulonglong;
+        const NSCursorUpdateMask          = 1 << NSCursorUpdate as c_ulonglong;
+        const NSScrollWheelMask           = 1 << NSScrollWheel as c_ulonglong;
+        const NSTabletPointMask           = 1 << NSTabletPoint as c_ulonglong;
+        const NSTabletProximityMask       = 1 << NSTabletProximity as c_ulonglong;
+        const NSOtherMouseDownMask        = 1 << NSOtherMouseDown as c_ulonglong;
+        const NSOtherMouseUpMask          = 1 << NSOtherMouseUp as c_ulonglong;
+        const NSOtherMouseDraggedMask     = 1 << NSOtherMouseDragged as c_ulonglong;
+        const NSEventMaskGesture          = 1 << NSEventTypeGesture as c_ulonglong;
+        const NSEventMaskSwipe            = 1 << NSEventTypeSwipe as c_ulonglong;
+        const NSEventMaskRotate           = 1 << NSEventTypeRotate as c_ulonglong;
+        const NSEventMaskBeginGesture     = 1 << NSEventTypeBeginGesture as c_ulonglong;
+        const NSEventMaskEndGesture       = 1 << NSEventTypeEndGesture as c_ulonglong;
+        const NSEventMaskPressure         = 1 << NSEventTypePressure as c_ulonglong;
         const NSAnyEventMask              = 0xffffffffffffffff;
     }
 }
 
 impl NSEventMask {
     pub fn from_type(ty: NSEventType) -> NSEventMask {
-        NSEventMask::from_bits_truncate(1 << ty as libc::c_ulonglong)
+        NSEventMask::from_bits_truncate(1 << ty as c_ulonglong)
     }
 }
 
@@ -2707,78 +2707,78 @@ pub enum NSEventSubtype {
     NSAWTEventType = 16,
 }
 
-pub const NSUpArrowFunctionKey: libc::c_ushort = 0xF700;
-pub const NSDownArrowFunctionKey: libc::c_ushort = 0xF701;
-pub const NSLeftArrowFunctionKey: libc::c_ushort = 0xF702;
-pub const NSRightArrowFunctionKey: libc::c_ushort = 0xF703;
-pub const NSF1FunctionKey: libc::c_ushort = 0xF704;
-pub const NSF2FunctionKey: libc::c_ushort = 0xF705;
-pub const NSF3FunctionKey: libc::c_ushort = 0xF706;
-pub const NSF4FunctionKey: libc::c_ushort = 0xF707;
-pub const NSF5FunctionKey: libc::c_ushort = 0xF708;
-pub const NSF6FunctionKey: libc::c_ushort = 0xF709;
-pub const NSF7FunctionKey: libc::c_ushort = 0xF70A;
-pub const NSF8FunctionKey: libc::c_ushort = 0xF70B;
-pub const NSF9FunctionKey: libc::c_ushort = 0xF70C;
-pub const NSF10FunctionKey: libc::c_ushort = 0xF70D;
-pub const NSF11FunctionKey: libc::c_ushort = 0xF70E;
-pub const NSF12FunctionKey: libc::c_ushort = 0xF70F;
-pub const NSF13FunctionKey: libc::c_ushort = 0xF710;
-pub const NSF14FunctionKey: libc::c_ushort = 0xF711;
-pub const NSF15FunctionKey: libc::c_ushort = 0xF712;
-pub const NSF16FunctionKey: libc::c_ushort = 0xF713;
-pub const NSF17FunctionKey: libc::c_ushort = 0xF714;
-pub const NSF18FunctionKey: libc::c_ushort = 0xF715;
-pub const NSF19FunctionKey: libc::c_ushort = 0xF716;
-pub const NSF20FunctionKey: libc::c_ushort = 0xF717;
-pub const NSF21FunctionKey: libc::c_ushort = 0xF718;
-pub const NSF22FunctionKey: libc::c_ushort = 0xF719;
-pub const NSF23FunctionKey: libc::c_ushort = 0xF71A;
-pub const NSF24FunctionKey: libc::c_ushort = 0xF71B;
-pub const NSF25FunctionKey: libc::c_ushort = 0xF71C;
-pub const NSF26FunctionKey: libc::c_ushort = 0xF71D;
-pub const NSF27FunctionKey: libc::c_ushort = 0xF71E;
-pub const NSF28FunctionKey: libc::c_ushort = 0xF71F;
-pub const NSF29FunctionKey: libc::c_ushort = 0xF720;
-pub const NSF30FunctionKey: libc::c_ushort = 0xF721;
-pub const NSF31FunctionKey: libc::c_ushort = 0xF722;
-pub const NSF32FunctionKey: libc::c_ushort = 0xF723;
-pub const NSF33FunctionKey: libc::c_ushort = 0xF724;
-pub const NSF34FunctionKey: libc::c_ushort = 0xF725;
-pub const NSF35FunctionKey: libc::c_ushort = 0xF726;
-pub const NSInsertFunctionKey: libc::c_ushort = 0xF727;
-pub const NSDeleteFunctionKey: libc::c_ushort = 0xF728;
-pub const NSHomeFunctionKey: libc::c_ushort = 0xF729;
-pub const NSBeginFunctionKey: libc::c_ushort = 0xF72A;
-pub const NSEndFunctionKey: libc::c_ushort = 0xF72B;
-pub const NSPageUpFunctionKey: libc::c_ushort = 0xF72C;
-pub const NSPageDownFunctionKey: libc::c_ushort = 0xF72D;
-pub const NSPrintScreenFunctionKey: libc::c_ushort = 0xF72E;
-pub const NSScrollLockFunctionKey: libc::c_ushort = 0xF72F;
-pub const NSPauseFunctionKey: libc::c_ushort = 0xF730;
-pub const NSSysReqFunctionKey: libc::c_ushort = 0xF731;
-pub const NSBreakFunctionKey: libc::c_ushort = 0xF732;
-pub const NSResetFunctionKey: libc::c_ushort = 0xF733;
-pub const NSStopFunctionKey: libc::c_ushort = 0xF734;
-pub const NSMenuFunctionKey: libc::c_ushort = 0xF735;
-pub const NSUserFunctionKey: libc::c_ushort = 0xF736;
-pub const NSSystemFunctionKey: libc::c_ushort = 0xF737;
-pub const NSPrintFunctionKey: libc::c_ushort = 0xF738;
-pub const NSClearLineFunctionKey: libc::c_ushort = 0xF739;
-pub const NSClearDisplayFunctionKey: libc::c_ushort = 0xF73A;
-pub const NSInsertLineFunctionKey: libc::c_ushort = 0xF73B;
-pub const NSDeleteLineFunctionKey: libc::c_ushort = 0xF73C;
-pub const NSInsertCharFunctionKey: libc::c_ushort = 0xF73D;
-pub const NSDeleteCharFunctionKey: libc::c_ushort = 0xF73E;
-pub const NSPrevFunctionKey: libc::c_ushort = 0xF73F;
-pub const NSNextFunctionKey: libc::c_ushort = 0xF740;
-pub const NSSelectFunctionKey: libc::c_ushort = 0xF741;
-pub const NSExecuteFunctionKey: libc::c_ushort = 0xF742;
-pub const NSUndoFunctionKey: libc::c_ushort = 0xF743;
-pub const NSRedoFunctionKey: libc::c_ushort = 0xF744;
-pub const NSFindFunctionKey: libc::c_ushort = 0xF745;
-pub const NSHelpFunctionKey: libc::c_ushort = 0xF746;
-pub const NSModeSwitchFunctionKey: libc::c_ushort = 0xF747;
+pub const NSUpArrowFunctionKey: c_ushort = 0xF700;
+pub const NSDownArrowFunctionKey: c_ushort = 0xF701;
+pub const NSLeftArrowFunctionKey: c_ushort = 0xF702;
+pub const NSRightArrowFunctionKey: c_ushort = 0xF703;
+pub const NSF1FunctionKey: c_ushort = 0xF704;
+pub const NSF2FunctionKey: c_ushort = 0xF705;
+pub const NSF3FunctionKey: c_ushort = 0xF706;
+pub const NSF4FunctionKey: c_ushort = 0xF707;
+pub const NSF5FunctionKey: c_ushort = 0xF708;
+pub const NSF6FunctionKey: c_ushort = 0xF709;
+pub const NSF7FunctionKey: c_ushort = 0xF70A;
+pub const NSF8FunctionKey: c_ushort = 0xF70B;
+pub const NSF9FunctionKey: c_ushort = 0xF70C;
+pub const NSF10FunctionKey: c_ushort = 0xF70D;
+pub const NSF11FunctionKey: c_ushort = 0xF70E;
+pub const NSF12FunctionKey: c_ushort = 0xF70F;
+pub const NSF13FunctionKey: c_ushort = 0xF710;
+pub const NSF14FunctionKey: c_ushort = 0xF711;
+pub const NSF15FunctionKey: c_ushort = 0xF712;
+pub const NSF16FunctionKey: c_ushort = 0xF713;
+pub const NSF17FunctionKey: c_ushort = 0xF714;
+pub const NSF18FunctionKey: c_ushort = 0xF715;
+pub const NSF19FunctionKey: c_ushort = 0xF716;
+pub const NSF20FunctionKey: c_ushort = 0xF717;
+pub const NSF21FunctionKey: c_ushort = 0xF718;
+pub const NSF22FunctionKey: c_ushort = 0xF719;
+pub const NSF23FunctionKey: c_ushort = 0xF71A;
+pub const NSF24FunctionKey: c_ushort = 0xF71B;
+pub const NSF25FunctionKey: c_ushort = 0xF71C;
+pub const NSF26FunctionKey: c_ushort = 0xF71D;
+pub const NSF27FunctionKey: c_ushort = 0xF71E;
+pub const NSF28FunctionKey: c_ushort = 0xF71F;
+pub const NSF29FunctionKey: c_ushort = 0xF720;
+pub const NSF30FunctionKey: c_ushort = 0xF721;
+pub const NSF31FunctionKey: c_ushort = 0xF722;
+pub const NSF32FunctionKey: c_ushort = 0xF723;
+pub const NSF33FunctionKey: c_ushort = 0xF724;
+pub const NSF34FunctionKey: c_ushort = 0xF725;
+pub const NSF35FunctionKey: c_ushort = 0xF726;
+pub const NSInsertFunctionKey: c_ushort = 0xF727;
+pub const NSDeleteFunctionKey: c_ushort = 0xF728;
+pub const NSHomeFunctionKey: c_ushort = 0xF729;
+pub const NSBeginFunctionKey: c_ushort = 0xF72A;
+pub const NSEndFunctionKey: c_ushort = 0xF72B;
+pub const NSPageUpFunctionKey: c_ushort = 0xF72C;
+pub const NSPageDownFunctionKey: c_ushort = 0xF72D;
+pub const NSPrintScreenFunctionKey: c_ushort = 0xF72E;
+pub const NSScrollLockFunctionKey: c_ushort = 0xF72F;
+pub const NSPauseFunctionKey: c_ushort = 0xF730;
+pub const NSSysReqFunctionKey: c_ushort = 0xF731;
+pub const NSBreakFunctionKey: c_ushort = 0xF732;
+pub const NSResetFunctionKey: c_ushort = 0xF733;
+pub const NSStopFunctionKey: c_ushort = 0xF734;
+pub const NSMenuFunctionKey: c_ushort = 0xF735;
+pub const NSUserFunctionKey: c_ushort = 0xF736;
+pub const NSSystemFunctionKey: c_ushort = 0xF737;
+pub const NSPrintFunctionKey: c_ushort = 0xF738;
+pub const NSClearLineFunctionKey: c_ushort = 0xF739;
+pub const NSClearDisplayFunctionKey: c_ushort = 0xF73A;
+pub const NSInsertLineFunctionKey: c_ushort = 0xF73B;
+pub const NSDeleteLineFunctionKey: c_ushort = 0xF73C;
+pub const NSInsertCharFunctionKey: c_ushort = 0xF73D;
+pub const NSDeleteCharFunctionKey: c_ushort = 0xF73E;
+pub const NSPrevFunctionKey: c_ushort = 0xF73F;
+pub const NSNextFunctionKey: c_ushort = 0xF740;
+pub const NSSelectFunctionKey: c_ushort = 0xF741;
+pub const NSExecuteFunctionKey: c_ushort = 0xF742;
+pub const NSUndoFunctionKey: c_ushort = 0xF743;
+pub const NSRedoFunctionKey: c_ushort = 0xF744;
+pub const NSFindFunctionKey: c_ushort = 0xF745;
+pub const NSHelpFunctionKey: c_ushort = 0xF746;
+pub const NSModeSwitchFunctionKey: c_ushort = 0xF747;
 
 pub trait NSEvent: Sized {
     // Creating Events
@@ -2793,7 +2793,7 @@ pub trait NSEvent: Sized {
         characters: id,      /* (NSString *) */
         unmodCharacters: id, /* (NSString *) */
         repeatKey: BOOL,
-        code: libc::c_ushort,
+        code: c_ushort,
     ) -> id /* (NSEvent *) */;
     unsafe fn mouseEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_clickCount_pressure_(
         _: Self,
@@ -2805,7 +2805,7 @@ pub trait NSEvent: Sized {
         context: id, /* (NSGraphicsContext *) */
         eventNumber: NSInteger,
         clickCount: NSInteger,
-        pressure: libc::c_float,
+        pressure: c_float,
     ) -> id /* (NSEvent *) */;
     unsafe fn enterExitEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_trackingNumber_userData_(
         _: Self,
@@ -2853,7 +2853,7 @@ pub trait NSEvent: Sized {
     unsafe fn keyRepeatInterval(_: Self) -> NSTimeInterval;
     unsafe fn characters(self) -> id /* (NSString *) */;
     unsafe fn charactersIgnoringModifiers(self) -> id /* (NSString *) */;
-    unsafe fn keyCode(self) -> libc::c_ushort;
+    unsafe fn keyCode(self) -> c_ushort;
     unsafe fn isARepeat(self) -> BOOL;
 
     // Getting Mouse Event Information
@@ -2862,7 +2862,7 @@ pub trait NSEvent: Sized {
     unsafe fn mouseLocation(_: Self) -> NSPoint;
     unsafe fn buttonNumber(self) -> NSInteger;
     unsafe fn clickCount(self) -> NSInteger;
-    unsafe fn pressure(self) -> libc::c_float;
+    unsafe fn pressure(self) -> c_float;
     unsafe fn stage(self) -> NSInteger;
     unsafe fn setMouseCoalescingEnabled_(_: Self, flag: BOOL);
     unsafe fn isMouseCoalescingEnabled(_: Self) -> BOOL;
@@ -2891,7 +2891,7 @@ pub trait NSEvent: Sized {
     unsafe fn pointingDeviceType(self) -> NSPointingDeviceType;
     unsafe fn systemTabletID(self) -> NSUInteger;
     unsafe fn tabletID(self) -> NSUInteger;
-    unsafe fn uniqueID(self) -> libc::c_ulonglong;
+    unsafe fn uniqueID(self) -> c_ulonglong;
     unsafe fn vendorID(self) -> NSUInteger;
     unsafe fn vendorPointingDeviceType(self) -> NSUInteger;
 
@@ -2900,8 +2900,8 @@ pub trait NSEvent: Sized {
     unsafe fn absoluteY(self) -> NSInteger;
     unsafe fn absoluteZ(self) -> NSInteger;
     unsafe fn buttonMask(self) -> NSEventButtonMask;
-    unsafe fn rotation(self) -> libc::c_float;
-    unsafe fn tangentialPressure(self) -> libc::c_float;
+    unsafe fn rotation(self) -> c_float;
+    unsafe fn tangentialPressure(self) -> c_float;
     unsafe fn tilt(self) -> NSPoint;
     unsafe fn vendorDefined(self) -> id;
 
@@ -2953,7 +2953,7 @@ impl NSEvent for id {
         characters: id,      /* (NSString *) */
         unmodCharacters: id, /* (NSString *) */
         repeatKey: BOOL,
-        code: libc::c_ushort,
+        code: c_ushort,
     ) -> id /* (NSEvent *) */ {
         msg_send![class!(NSEvent), keyEventWithType:eventType
                                             location:location
@@ -2977,7 +2977,7 @@ impl NSEvent for id {
         context: id, /* (NSGraphicsContext *) */
         eventNumber: NSInteger,
         clickCount: NSInteger,
-        pressure: libc::c_float,
+        pressure: c_float,
     ) -> id /* (NSEvent *) */ {
         msg_send![class!(NSEvent), mouseEventWithType:eventType
                                               location:location
@@ -3107,7 +3107,7 @@ impl NSEvent for id {
         msg_send![self, charactersIgnoringModifiers]
     }
 
-    unsafe fn keyCode(self) -> libc::c_ushort {
+    unsafe fn keyCode(self) -> c_ushort {
         msg_send![self, keyCode]
     }
 
@@ -3137,7 +3137,7 @@ impl NSEvent for id {
         msg_send![self, clickCount]
     }
 
-    unsafe fn pressure(self) -> libc::c_float {
+    unsafe fn pressure(self) -> c_float {
         msg_send![self, pressure]
     }
 
@@ -3229,7 +3229,7 @@ impl NSEvent for id {
         msg_send![self, tabletID]
     }
 
-    unsafe fn uniqueID(self) -> libc::c_ulonglong {
+    unsafe fn uniqueID(self) -> c_ulonglong {
         msg_send![self, uniqueID]
     }
 
@@ -3259,11 +3259,11 @@ impl NSEvent for id {
         msg_send![self, buttonMask]
     }
 
-    unsafe fn rotation(self) -> libc::c_float {
+    unsafe fn rotation(self) -> c_float {
         msg_send![self, rotation]
     }
 
-    unsafe fn tangentialPressure(self) -> libc::c_float {
+    unsafe fn tangentialPressure(self) -> c_float {
         msg_send![self, tangentialPressure]
     }
 
@@ -4335,7 +4335,7 @@ impl NSTabView for id {
         msg_send![self, drawsBackground]
     }
     unsafe fn setDrawsBackground_(self, drawsBackground: BOOL) {
-        msg_send![self, setDrawsBackground: drawsBackground as libc::c_int]
+        msg_send![self, setDrawsBackground: drawsBackground as c_int]
     }
 
     unsafe fn minimumSize(self) -> id {
@@ -4357,7 +4357,7 @@ impl NSTabView for id {
     unsafe fn setAllowsTruncatedLabels_(self, allowTruncatedLabels: BOOL) {
         msg_send![
             self,
-            setAllowsTruncatedLabels: allowTruncatedLabels as libc::c_int
+            setAllowsTruncatedLabels: allowTruncatedLabels as c_int
         ]
     }
 
@@ -4413,7 +4413,7 @@ impl NSTabViewItem for id {
     }
 
     unsafe fn drawLabel_inRect_(self, shouldTruncateLabel: BOOL, labelRect: NSRect) {
-        msg_send![self, drawLabel:shouldTruncateLabel as libc::c_int inRect:labelRect]
+        msg_send![self, drawLabel:shouldTruncateLabel as c_int inRect:labelRect]
     }
 
     unsafe fn label(self) -> id {
@@ -4424,7 +4424,7 @@ impl NSTabViewItem for id {
     }
 
     unsafe fn sizeOfLabel_(self, computeMin: BOOL) {
-        msg_send![self, sizeOfLabel: computeMin as libc::c_int]
+        msg_send![self, sizeOfLabel: computeMin as c_int]
     }
 
     unsafe fn tabState(self) -> NSTabState {

--- a/core-foundation-sys/src/array.rs
+++ b/core-foundation-sys/src/array.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{Boolean, CFAllocatorRef, CFComparatorFunction, CFIndex, CFRange, CFTypeID};
 use crate::string::CFStringRef;

--- a/core-foundation-sys/src/attributed_string.rs
+++ b/core-foundation-sys/src/attributed_string.rs
@@ -11,7 +11,7 @@ use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFRange, CFTypeID, CFTypeRef
 use crate::dictionary::CFDictionaryRef;
 use crate::string::CFMutableStringRef;
 use crate::string::CFStringRef;
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 #[repr(C)]
 pub struct __CFAttributedString(c_void);

--- a/core-foundation-sys/src/bag.rs
+++ b/core-foundation-sys/src/bag.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{Boolean, CFAllocatorRef, CFHashCode, CFIndex, CFTypeID};
 use crate::string::CFStringRef;

--- a/core-foundation-sys/src/base.rs
+++ b/core-foundation-sys/src/base.rs
@@ -8,8 +8,8 @@
 // except according to those terms.
 
 use crate::string::CFStringRef;
+use core::ffi::{c_int, c_short, c_uchar, c_uint, c_ushort, c_void};
 use std::cmp::Ordering;
-use std::os::raw::{c_int, c_short, c_uchar, c_uint, c_ushort, c_void};
 
 pub type Boolean = u8;
 pub type mach_port_t = c_uint;

--- a/core-foundation-sys/src/binary_heap.rs
+++ b/core-foundation-sys/src/binary_heap.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{Boolean, CFAllocatorRef, CFComparisonResult, CFIndex, CFTypeID};
 use crate::string::CFStringRef;

--- a/core-foundation-sys/src/bit_vector.rs
+++ b/core-foundation-sys/src/bit_vector.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFRange, CFTypeID, UInt32, UInt8};
 

--- a/core-foundation-sys/src/bundle.rs
+++ b/core-foundation-sys/src/bundle.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::array::CFArrayRef;
 #[cfg(target_os = "macos")]
@@ -17,7 +17,7 @@ use crate::dictionary::CFDictionaryRef;
 use crate::error::CFErrorRef;
 use crate::string::CFStringRef;
 use crate::url::CFURLRef;
-use std::os::raw::{c_int, c_uint};
+use core::ffi::{c_int, c_uint};
 
 #[repr(C)]
 pub struct __CFBundle(c_void);

--- a/core-foundation-sys/src/calendar.rs
+++ b/core-foundation-sys/src/calendar.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::{c_char, c_void};
+use core::ffi::{c_char, c_void};
 
 use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFOptionFlags, CFRange, CFTypeID};
 use crate::date::{CFAbsoluteTime, CFTimeInterval};

--- a/core-foundation-sys/src/characterset.rs
+++ b/core-foundation-sys/src/characterset.rs
@@ -10,7 +10,7 @@
 use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFRange, CFTypeID, UTF32Char};
 use crate::data::CFDataRef;
 use crate::string::{CFStringRef, UniChar};
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 pub type CFCharacterSetPredefinedSet = CFIndex;
 

--- a/core-foundation-sys/src/data.rs
+++ b/core-foundation-sys/src/data.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use crate::base::{CFAllocatorRef, CFIndex, CFOptionFlags, CFRange, CFTypeID};
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 #[repr(C)]
 pub struct __CFData(c_void);

--- a/core-foundation-sys/src/date.rs
+++ b/core-foundation-sys/src/date.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{CFAllocatorRef, CFComparisonResult, CFTypeID};
 

--- a/core-foundation-sys/src/date_formatter.rs
+++ b/core-foundation-sys/src/date_formatter.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFOptionFlags, CFRange, CFTypeID, CFTypeRef};
 use crate::date::{CFAbsoluteTime, CFDateRef};

--- a/core-foundation-sys/src/dictionary.rs
+++ b/core-foundation-sys/src/dictionary.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{Boolean, CFAllocatorRef, CFHashCode, CFIndex, CFTypeID};
 use crate::string::CFStringRef;

--- a/core-foundation-sys/src/error.rs
+++ b/core-foundation-sys/src/error.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{CFAllocatorRef, CFIndex, CFTypeID};
 use crate::dictionary::CFDictionaryRef;

--- a/core-foundation-sys/src/file_security.rs
+++ b/core-foundation-sys/src/file_security.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 #[cfg(feature = "mac_os_10_8_features")]
 use crate::base::CFOptionFlags;

--- a/core-foundation-sys/src/filedescriptor.rs
+++ b/core-foundation-sys/src/filedescriptor.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::{c_int, c_void};
+use core::ffi::{c_int, c_void};
 
 use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFOptionFlags, CFTypeID};
 use crate::runloop::CFRunLoopSourceRef;

--- a/core-foundation-sys/src/locale.rs
+++ b/core-foundation-sys/src/locale.rs
@@ -12,7 +12,7 @@ use crate::base::{CFAllocatorRef, CFIndex, CFTypeID, CFTypeRef, LangCode, Region
 use crate::dictionary::CFDictionaryRef;
 use crate::notification_center::CFNotificationName;
 use crate::string::CFStringRef;
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 #[repr(C)]
 pub struct __CFLocale(c_void);

--- a/core-foundation-sys/src/mach_port.rs
+++ b/core-foundation-sys/src/mach_port.rs
@@ -11,7 +11,7 @@ use crate::base::{mach_port_t, Boolean};
 pub use crate::base::{CFAllocatorRef, CFIndex, CFTypeID};
 use crate::runloop::CFRunLoopSourceRef;
 use crate::string::CFStringRef;
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 #[repr(C)]
 pub struct __CFMachPort(c_void);

--- a/core-foundation-sys/src/messageport.rs
+++ b/core-foundation-sys/src/messageport.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFTypeID, SInt32};
 use crate::data::CFDataRef;

--- a/core-foundation-sys/src/notification_center.rs
+++ b/core-foundation-sys/src/notification_center.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{Boolean, CFIndex, CFOptionFlags, CFTypeID};
 use crate::dictionary::CFDictionaryRef;

--- a/core-foundation-sys/src/number.rs
+++ b/core-foundation-sys/src/number.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{Boolean, CFAllocatorRef, CFComparisonResult, CFIndex, CFTypeID};
 

--- a/core-foundation-sys/src/number_formatter.rs
+++ b/core-foundation-sys/src/number_formatter.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::{c_double, c_void};
+use core::ffi::{c_double, c_void};
 
 use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFOptionFlags, CFRange, CFTypeID, CFTypeRef};
 use crate::locale::CFLocaleRef;

--- a/core-foundation-sys/src/plugin.rs
+++ b/core-foundation-sys/src/plugin.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::array::CFArrayRef;
 use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFTypeID};

--- a/core-foundation-sys/src/runloop.rs
+++ b/core-foundation-sys/src/runloop.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::array::CFArrayRef;
 use crate::base::{

--- a/core-foundation-sys/src/set.rs
+++ b/core-foundation-sys/src/set.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{Boolean, CFAllocatorRef, CFHashCode, CFIndex, CFTypeID};
 use crate::string::CFStringRef;

--- a/core-foundation-sys/src/socket.rs
+++ b/core-foundation-sys/src/socket.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFOptionFlags, CFTypeID, SInt32, UInt16};
 use crate::data::CFDataRef;
@@ -31,9 +31,9 @@ pub type CFSocketCallBack = extern "C" fn(
     info: *mut c_void,
 );
 #[cfg(not(target_os = "windows"))]
-pub type CFSocketNativeHandle = std::os::raw::c_int;
+pub type CFSocketNativeHandle = core::ffi::c_int;
 #[cfg(target_os = "windows")]
-pub type CFSocketNativeHandle = std::os::raw::c_ulong;
+pub type CFSocketNativeHandle = core::ffi::c_ulong;
 
 pub const kCFSocketSuccess: CFSocketError = 0;
 pub const kCFSocketError: CFSocketError = -1;

--- a/core-foundation-sys/src/stream.rs
+++ b/core-foundation-sys/src/stream.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::{c_int, c_void};
+use core::ffi::{c_int, c_void};
 
 use crate::base::{
     Boolean, CFAllocatorRef, CFIndex, CFOptionFlags, CFTypeID, CFTypeRef, SInt32, UInt32, UInt8,

--- a/core-foundation-sys/src/string.rs
+++ b/core-foundation-sys/src/string.rs
@@ -16,7 +16,7 @@ use crate::characterset::CFCharacterSetRef;
 use crate::data::CFDataRef;
 use crate::dictionary::CFDictionaryRef;
 use crate::locale::CFLocaleRef;
-use std::os::raw::{c_char, c_double, c_ulong, c_ushort, c_void};
+use core::ffi::{c_char, c_double, c_ulong, c_ushort, c_void};
 
 pub type CFStringCompareFlags = CFOptionFlags;
 pub const kCFCompareCaseInsensitive: CFStringCompareFlags = 1;

--- a/core-foundation-sys/src/string_tokenizer.rs
+++ b/core-foundation-sys/src/string_tokenizer.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::array::CFMutableArrayRef;
 use crate::base::{CFAllocatorRef, CFIndex, CFOptionFlags, CFRange, CFTypeID, CFTypeRef};

--- a/core-foundation-sys/src/timezone.rs
+++ b/core-foundation-sys/src/timezone.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::array::CFArrayRef;
 use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFTypeID};

--- a/core-foundation-sys/src/tree.rs
+++ b/core-foundation-sys/src/tree.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{CFAllocatorRef, CFComparatorFunction, CFIndex, CFTypeID};
 use crate::string::CFStringRef;

--- a/core-foundation-sys/src/url.rs
+++ b/core-foundation-sys/src/url.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::array::CFArrayRef;
 use crate::base::{

--- a/core-foundation-sys/src/url_enumerator.rs
+++ b/core-foundation-sys/src/url_enumerator.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::array::CFArrayRef;
 use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFOptionFlags, CFTypeID};

--- a/core-foundation-sys/src/user_notification.rs
+++ b/core-foundation-sys/src/user_notification.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{CFAllocatorRef, CFIndex, CFOptionFlags, CFTypeID, SInt32};
 use crate::date::CFTimeInterval;

--- a/core-foundation-sys/src/uuid.rs
+++ b/core-foundation-sys/src/uuid.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{CFAllocatorRef, CFTypeID};
 use crate::string::CFStringRef;

--- a/core-foundation-sys/src/xml_node.rs
+++ b/core-foundation-sys/src/xml_node.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::{c_char, c_void};
+use core::ffi::{c_char, c_void};
 
 use crate::array::CFArrayRef;
 use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFTypeID};

--- a/core-foundation-sys/src/xml_parser.rs
+++ b/core-foundation-sys/src/xml_parser.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use crate::base::{Boolean, CFAllocatorRef, CFIndex, CFOptionFlags, CFTypeID};
 use crate::data::CFDataRef;

--- a/core-foundation/src/array.rs
+++ b/core-foundation/src/array.rs
@@ -10,12 +10,12 @@
 //! Heterogeneous immutable arrays.
 
 use crate::ConcreteCFType;
+use core::ffi::c_void;
 pub use core_foundation_sys::array::*;
 pub use core_foundation_sys::base::CFIndex;
 use core_foundation_sys::base::{kCFAllocatorDefault, CFRelease, CFTypeRef};
 use std::marker::PhantomData;
 use std::mem;
-use std::os::raw::c_void;
 use std::ptr;
 
 use crate::base::{CFIndexConvertible, CFRange, TCFType};

--- a/core-foundation/src/base.rs
+++ b/core-foundation/src/base.rs
@@ -7,13 +7,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::ffi::c_void;
 use std;
 use std::fmt;
 use std::marker::PhantomData;
 use std::mem;
 use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
-use std::os::raw::c_void;
 
 pub use core_foundation_sys::base::*;
 
@@ -373,19 +373,19 @@ unsafe impl ToVoid<*const c_void> for *const c_void {
 }
 
 unsafe impl<'a> ToVoid<CFType> for &'a CFType {
-    fn to_void(&self) -> *const ::std::os::raw::c_void {
+    fn to_void(&self) -> *const c_void {
         self.as_concrete_TypeRef().as_void_ptr()
     }
 }
 
 unsafe impl ToVoid<CFType> for CFType {
-    fn to_void(&self) -> *const ::std::os::raw::c_void {
+    fn to_void(&self) -> *const c_void {
         self.as_concrete_TypeRef().as_void_ptr()
     }
 }
 
 unsafe impl ToVoid<CFType> for CFTypeRef {
-    fn to_void(&self) -> *const ::std::os::raw::c_void {
+    fn to_void(&self) -> *const c_void {
         self.as_void_ptr()
     }
 }

--- a/core-foundation/src/bundle.rs
+++ b/core-foundation/src/bundle.rs
@@ -9,6 +9,7 @@
 
 //! Core Foundation Bundle Type
 
+use core::ffi::c_void;
 use core_foundation_sys::base::kCFAllocatorDefault;
 pub use core_foundation_sys::bundle::*;
 use core_foundation_sys::url::kCFURLPOSIXPathStyle;
@@ -18,7 +19,6 @@ use crate::base::{CFType, TCFType};
 use crate::dictionary::CFDictionary;
 use crate::string::CFString;
 use crate::url::CFURL;
-use std::os::raw::c_void;
 
 declare_TCFType! {
     /// A Bundle type.

--- a/core-foundation/src/data.rs
+++ b/core-foundation/src/data.rs
@@ -41,7 +41,7 @@ impl CFData {
     /// Creates a [`CFData`] referencing `buffer` without creating a copy
     pub fn from_arc<T: AsRef<[u8]> + Sync + Send>(buffer: Arc<T>) -> Self {
         use crate::base::{CFAllocator, CFAllocatorContext};
-        use std::os::raw::c_void;
+        use core::ffi::c_void;
 
         unsafe {
             let ptr = (*buffer).as_ref().as_ptr() as *const _;

--- a/core-foundation/src/dictionary.rs
+++ b/core-foundation/src/dictionary.rs
@@ -11,10 +11,10 @@
 
 pub use core_foundation_sys::dictionary::*;
 
+use core::ffi::c_void;
 use core_foundation_sys::base::{kCFAllocatorDefault, CFRelease, CFTypeRef};
 use std::marker::PhantomData;
 use std::mem;
-use std::os::raw::c_void;
 use std::ptr;
 
 use crate::base::{CFIndexConvertible, TCFType};

--- a/core-foundation/src/filedescriptor.rs
+++ b/core-foundation/src/filedescriptor.rs
@@ -99,11 +99,11 @@ impl AsRawFd for CFFileDescriptor {
 mod test {
     use super::*;
     use crate::runloop::CFRunLoop;
+    use core::ffi::c_void;
     use core_foundation_sys::base::CFOptionFlags;
     use core_foundation_sys::runloop::kCFRunLoopDefaultMode;
     use libc::O_RDWR;
     use std::ffi::CString;
-    use std::os::raw::c_void;
 
     #[test]
     fn test_unconsumed() {

--- a/core-foundation/src/lib.rs
+++ b/core-foundation/src/lib.rs
@@ -90,7 +90,7 @@ macro_rules! impl_TCFType {
             #[inline]
             unsafe fn wrap_under_get_rule(reference: $ty_ref) -> Self {
                 assert!(!reference.is_null(), "Attempted to create a NULL object.");
-                let reference = $crate::base::CFRetain(reference as *const ::std::os::raw::c_void) as $ty_ref;
+                let reference = $crate::base::CFRetain(reference as *const ::core::ffi::c_void) as $ty_ref;
                 $crate::base::TCFType::wrap_under_create_rule(reference)
             }
 
@@ -134,21 +134,21 @@ macro_rules! impl_TCFType {
         impl Eq for $ty { }
 
         unsafe impl<'a> $crate::base::ToVoid<$ty> for &'a $ty {
-            fn to_void(&self) -> *const ::std::os::raw::c_void {
+            fn to_void(&self) -> *const ::core::ffi::c_void {
                 use $crate::base::TCFTypeRef;
                 self.as_concrete_TypeRef().as_void_ptr()
             }
         }
 
         unsafe impl $crate::base::ToVoid<$ty> for $ty {
-            fn to_void(&self) -> *const ::std::os::raw::c_void {
+            fn to_void(&self) -> *const ::core::ffi::c_void {
                 use $crate::base::TCFTypeRef;
                 self.as_concrete_TypeRef().as_void_ptr()
             }
         }
 
         unsafe impl $crate::base::ToVoid<$ty> for $ty_ref {
-            fn to_void(&self) -> *const ::std::os::raw::c_void {
+            fn to_void(&self) -> *const ::core::ffi::c_void {
                 use $crate::base::TCFTypeRef;
                 self.as_void_ptr()
             }

--- a/core-foundation/src/number.rs
+++ b/core-foundation/src/number.rs
@@ -9,9 +9,9 @@
 
 //! Immutable numbers.
 
+use core::ffi::c_void;
 use core_foundation_sys::base::kCFAllocatorDefault;
 pub use core_foundation_sys::number::*;
-use std::os::raw::c_void;
 
 use crate::base::TCFType;
 

--- a/core-foundation/src/propertylist.rs
+++ b/core-foundation/src/propertylist.rs
@@ -9,8 +9,8 @@
 
 //! Core Foundation property lists
 
+use core::ffi::c_void;
 use std::mem;
-use std::os::raw::c_void;
 use std::ptr;
 
 use crate::base::{CFType, TCFType, TCFTypeRef};

--- a/core-foundation/src/runloop.rs
+++ b/core-foundation/src/runloop.rs
@@ -195,8 +195,8 @@ mod test {
     use super::*;
     use crate::base::Boolean;
     use crate::date::{CFAbsoluteTime, CFDate};
+    use core::ffi::c_void;
     use std::mem;
-    use std::os::raw::c_void;
     use std::ptr::null_mut;
     use std::sync::mpsc;
     use std::thread::spawn;

--- a/core-foundation/src/set.rs
+++ b/core-foundation/src/set.rs
@@ -14,8 +14,8 @@ pub use core_foundation_sys::set::*;
 
 use crate::base::{CFIndexConvertible, TCFType};
 
+use core::ffi::c_void;
 use std::marker::PhantomData;
-use std::os::raw::c_void;
 
 /// An immutable bag of elements.
 pub struct CFSet<T = *const c_void>(CFSetRef, PhantomData<T>);

--- a/core-foundation/src/url.rs
+++ b/core-foundation/src/url.rs
@@ -14,12 +14,13 @@ pub use core_foundation_sys::url::*;
 use crate::base::{CFIndex, TCFType};
 use crate::string::CFString;
 
+use core::ffi::c_char;
 use core_foundation_sys::base::{kCFAllocatorDefault, Boolean};
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::ptr;
 
-use libc::{c_char, strlen, PATH_MAX};
+use libc::{strlen, PATH_MAX};
 
 #[cfg(unix)]
 use std::ffi::OsStr;

--- a/core-foundation/tests/use_macro_outside_crate.rs
+++ b/core-foundation/tests/use_macro_outside_crate.rs
@@ -1,6 +1,6 @@
+use core::ffi::c_void;
 use core_foundation::base::{CFComparisonResult, TCFType};
 use core_foundation::{declare_TCFType, impl_CFComparison, impl_CFTypeDescription, impl_TCFType};
-use std::os::raw::c_void;
 
 // sys equivalent stuff that must be declared
 

--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -12,7 +12,6 @@ rust-version = "1.65"
 [dependencies]
 bitflags = "2"
 core-foundation = { default-features = false, path = "../core-foundation", version = "0.10" }
-libc = "0.2"
 
 [features]
 default = ["link"]

--- a/core-graphics-types/src/base.rs
+++ b/core-graphics-types/src/base.rs
@@ -12,21 +12,19 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 
-use libc;
-
 #[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "aarch64"))]
-pub type boolean_t = libc::c_int;
+pub type boolean_t = core::ffi::c_int;
 #[cfg(target_arch = "x86_64")]
-pub type boolean_t = libc::c_uint;
+pub type boolean_t = core::ffi::c_uint;
 
 #[cfg(target_pointer_width = "64")]
-pub type CGFloat = libc::c_double;
+pub type CGFloat = core::ffi::c_double;
 #[cfg(not(target_pointer_width = "64"))]
-pub type CGFloat = libc::c_float;
+pub type CGFloat = core::ffi::c_float;
 
 pub type CGError = i32;
 
-pub type CGGlyph = libc::c_ushort;
+pub type CGGlyph = core::ffi::c_ushort;
 
 pub const kCGErrorSuccess: CGError = 0;
 pub const kCGErrorFailure: CGError = 1000;

--- a/core-graphics/src/context.rs
+++ b/core-graphics/src/context.rs
@@ -14,9 +14,8 @@ use crate::font::{CGFont, CGGlyph};
 use crate::geometry::{CGPoint, CGSize};
 use crate::gradient::{CGGradient, CGGradientDrawingOptions};
 use crate::path::CGPathRef;
+use core::ffi::{c_int, c_void};
 use core_foundation::base::{CFTypeID, TCFType};
-use libc::{c_int, size_t};
-use std::os::raw::c_void;
 
 use crate::geometry::{CGAffineTransform, CGRect};
 use crate::image::CGImage;
@@ -139,10 +138,10 @@ impl CGContext {
 
     pub fn create_bitmap_context(
         data: Option<*mut c_void>,
-        width: size_t,
-        height: size_t,
-        bits_per_component: size_t,
-        bytes_per_row: size_t,
+        width: usize,
+        height: usize,
+        bits_per_component: usize,
+        bytes_per_row: usize,
         space: &CGColorSpace,
         bitmap_info: u32,
     ) -> CGContext {
@@ -176,15 +175,15 @@ impl CGContextRef {
         unsafe { CGContextFlush(self.as_ptr()) }
     }
 
-    pub fn width(&self) -> size_t {
+    pub fn width(&self) -> usize {
         unsafe { CGBitmapContextGetWidth(self.as_ptr()) }
     }
 
-    pub fn height(&self) -> size_t {
+    pub fn height(&self) -> usize {
         unsafe { CGBitmapContextGetHeight(self.as_ptr()) }
     }
 
-    pub fn bytes_per_row(&self) -> size_t {
+    pub fn bytes_per_row(&self) -> usize {
         unsafe { CGBitmapContextGetBytesPerRow(self.as_ptr()) }
     }
 
@@ -622,17 +621,17 @@ extern "C" {
 
     fn CGBitmapContextCreate(
         data: *mut c_void,
-        width: size_t,
-        height: size_t,
-        bitsPerComponent: size_t,
-        bytesPerRow: size_t,
+        width: usize,
+        height: usize,
+        bitsPerComponent: usize,
+        bytesPerRow: usize,
         space: crate::sys::CGColorSpaceRef,
         bitmapInfo: u32,
     ) -> crate::sys::CGContextRef;
     fn CGBitmapContextGetData(context: crate::sys::CGContextRef) -> *mut c_void;
-    fn CGBitmapContextGetWidth(context: crate::sys::CGContextRef) -> size_t;
-    fn CGBitmapContextGetHeight(context: crate::sys::CGContextRef) -> size_t;
-    fn CGBitmapContextGetBytesPerRow(context: crate::sys::CGContextRef) -> size_t;
+    fn CGBitmapContextGetWidth(context: crate::sys::CGContextRef) -> usize;
+    fn CGBitmapContextGetHeight(context: crate::sys::CGContextRef) -> usize;
+    fn CGBitmapContextGetBytesPerRow(context: crate::sys::CGContextRef) -> usize;
     fn CGBitmapContextCreateImage(context: crate::sys::CGContextRef) -> crate::sys::CGImageRef;
     fn CGContextGetTypeID() -> CFTypeID;
     fn CGContextGetClipBoundingBox(c: crate::sys::CGContextRef) -> CGRect;
@@ -666,7 +665,7 @@ extern "C" {
         c: crate::sys::CGContextRef,
         phase: CGFloat,
         lengths: *const CGFloat,
-        count: size_t,
+        count: usize,
     );
     fn CGContextSetLineJoin(c: crate::sys::CGContextRef, join: CGLineJoin);
     fn CGContextSetLineWidth(c: crate::sys::CGContextRef, width: CGFloat);
@@ -717,7 +716,7 @@ extern "C" {
     fn CGContextSetGrayFillColor(context: crate::sys::CGContextRef, gray: CGFloat, alpha: CGFloat);
     fn CGContextClearRect(context: crate::sys::CGContextRef, rect: CGRect);
     fn CGContextFillRect(context: crate::sys::CGContextRef, rect: CGRect);
-    fn CGContextFillRects(context: crate::sys::CGContextRef, rects: *const CGRect, count: size_t);
+    fn CGContextFillRects(context: crate::sys::CGContextRef, rects: *const CGRect, count: usize);
     fn CGContextStrokeRect(context: crate::sys::CGContextRef, rect: CGRect);
     fn CGContextStrokeRectWithWidth(
         context: crate::sys::CGContextRef,
@@ -725,7 +724,7 @@ extern "C" {
         width: CGFloat,
     );
     fn CGContextClipToRect(context: crate::sys::CGContextRef, rect: CGRect);
-    fn CGContextClipToRects(context: crate::sys::CGContextRef, rects: *const CGRect, count: size_t);
+    fn CGContextClipToRects(context: crate::sys::CGContextRef, rects: *const CGRect, count: usize);
     fn CGContextClipToMask(
         ctx: crate::sys::CGContextRef,
         rect: CGRect,
@@ -737,7 +736,7 @@ extern "C" {
     fn CGContextStrokeLineSegments(
         context: crate::sys::CGContextRef,
         points: *const CGPoint,
-        count: size_t,
+        count: usize,
     );
     fn CGContextDrawImage(c: crate::sys::CGContextRef, rect: CGRect, image: crate::sys::CGImageRef);
     fn CGContextSetInterpolationQuality(
@@ -753,7 +752,7 @@ extern "C" {
         c: crate::sys::CGContextRef,
         glyphs: *const CGGlyph,
         positions: *const CGPoint,
-        count: size_t,
+        count: usize,
     );
 
     fn CGContextSaveGState(c: crate::sys::CGContextRef);

--- a/core-graphics/src/display.rs
+++ b/core-graphics/src/display.rs
@@ -10,7 +10,7 @@
 #![allow(non_upper_case_globals)]
 
 use bitflags::bitflags;
-use libc;
+use core::ffi::{c_double, c_void};
 use std::ops::Deref;
 use std::ptr;
 
@@ -101,7 +101,7 @@ pub use core_foundation::dictionary::{
     CFDictionary, CFDictionaryGetValueIfPresent, CFDictionaryRef,
 };
 
-pub type CGDisplayConfigRef = *mut libc::c_void;
+pub type CGDisplayConfigRef = *mut c_void;
 
 #[repr(u32)]
 #[derive(Clone, Copy)]
@@ -113,7 +113,7 @@ pub enum CGConfigureOption {
 
 /// A client-supplied callback function that’s invoked whenever the configuration of a local display is changed.
 pub type CGDisplayReconfigurationCallBack =
-    unsafe extern "C" fn(display: CGDirectDisplayID, flags: u32, user_info: *const libc::c_void);
+    unsafe extern "C" fn(display: CGDirectDisplayID, flags: u32, user_info: *const c_void);
 
 bitflags! {
     /// The configuration parameters that are passed to a display reconfiguration callback function.
@@ -703,7 +703,7 @@ extern "C" {
     pub fn CGDisplayIsStereo(display: CGDirectDisplayID) -> boolean_t;
     pub fn CGDisplayMirrorsDisplay(display: CGDirectDisplayID) -> CGDirectDisplayID;
     pub fn CGDisplayPrimaryDisplay(display: CGDirectDisplayID) -> CGDirectDisplayID;
-    pub fn CGDisplayRotation(display: CGDirectDisplayID) -> libc::c_double;
+    pub fn CGDisplayRotation(display: CGDirectDisplayID) -> c_double;
     pub fn CGDisplayScreenSize(display: CGDirectDisplayID) -> CGSize;
     pub fn CGDisplaySerialNumber(display: CGDirectDisplayID) -> u32;
     pub fn CGDisplayUnitNumber(display: CGDirectDisplayID) -> u32;
@@ -721,8 +721,8 @@ extern "C" {
         matching_display_count: *mut u32,
     ) -> CGError;
     pub fn CGDisplayModelNumber(display: CGDirectDisplayID) -> u32;
-    pub fn CGDisplayPixelsHigh(display: CGDirectDisplayID) -> libc::size_t;
-    pub fn CGDisplayPixelsWide(display: CGDirectDisplayID) -> libc::size_t;
+    pub fn CGDisplayPixelsHigh(display: CGDirectDisplayID) -> usize;
+    pub fn CGDisplayPixelsWide(display: CGDirectDisplayID) -> usize;
     pub fn CGDisplayBounds(display: CGDirectDisplayID) -> CGRect;
     pub fn CGDisplayCreateImage(display: CGDirectDisplayID) -> crate::sys::CGImageRef;
     pub fn CGDisplayCreateImageForRect(
@@ -762,19 +762,19 @@ extern "C" {
     pub fn CGRestorePermanentDisplayConfiguration();
     pub fn CGDisplayRegisterReconfigurationCallback(
         callback: CGDisplayReconfigurationCallBack,
-        user_info: *const libc::c_void,
+        user_info: *const c_void,
     ) -> CGError;
     pub fn CGDisplayRemoveReconfigurationCallback(
         callback: CGDisplayReconfigurationCallBack,
-        user_info: *const libc::c_void,
+        user_info: *const c_void,
     ) -> CGError;
 
     pub fn CGDisplayCopyDisplayMode(display: CGDirectDisplayID) -> crate::sys::CGDisplayModeRef;
-    pub fn CGDisplayModeGetHeight(mode: crate::sys::CGDisplayModeRef) -> libc::size_t;
-    pub fn CGDisplayModeGetWidth(mode: crate::sys::CGDisplayModeRef) -> libc::size_t;
-    pub fn CGDisplayModeGetPixelHeight(mode: crate::sys::CGDisplayModeRef) -> libc::size_t;
-    pub fn CGDisplayModeGetPixelWidth(mode: crate::sys::CGDisplayModeRef) -> libc::size_t;
-    pub fn CGDisplayModeGetRefreshRate(mode: crate::sys::CGDisplayModeRef) -> libc::c_double;
+    pub fn CGDisplayModeGetHeight(mode: crate::sys::CGDisplayModeRef) -> usize;
+    pub fn CGDisplayModeGetWidth(mode: crate::sys::CGDisplayModeRef) -> usize;
+    pub fn CGDisplayModeGetPixelHeight(mode: crate::sys::CGDisplayModeRef) -> usize;
+    pub fn CGDisplayModeGetPixelWidth(mode: crate::sys::CGDisplayModeRef) -> usize;
+    pub fn CGDisplayModeGetRefreshRate(mode: crate::sys::CGDisplayModeRef) -> c_double;
     pub fn CGDisplayModeGetIOFlags(mode: crate::sys::CGDisplayModeRef) -> u32;
     pub fn CGDisplayModeCopyPixelEncoding(mode: crate::sys::CGDisplayModeRef) -> CFStringRef;
     pub fn CGDisplayModeGetIODisplayModeID(mode: crate::sys::CGDisplayModeRef) -> i32;

--- a/core-graphics/src/event.rs
+++ b/core-graphics/src/event.rs
@@ -3,12 +3,12 @@ use crate::event_source::CGEventSource;
 use crate::geometry::CGPoint;
 
 use bitflags::bitflags;
+use core::ffi::{c_ulong, c_void};
 use core_foundation::{
     base::{CFRelease, CFRetain, CFTypeID, TCFType},
     mach_port::{CFMachPort, CFMachPortRef},
 };
 use foreign_types::{foreign_type, ForeignType};
-use libc::c_void;
 use std::mem::ManuallyDrop;
 
 pub type CGEventField = u32;
@@ -647,7 +647,7 @@ impl CGEvent {
     }
 
     pub fn set_string_from_utf16_unchecked(&self, buf: &[u16]) {
-        let buflen = buf.len() as libc::c_ulong;
+        let buflen = buf.len() as c_ulong;
         unsafe {
             CGEventKeyboardSetUnicodeString(self.as_ptr(), buflen, buf.as_ptr());
         }
@@ -775,7 +775,7 @@ extern "C" {
     /// keycode and perceived event state.
     fn CGEventKeyboardSetUnicodeString(
         event: crate::sys::CGEventRef,
-        length: libc::c_ulong,
+        length: c_ulong,
         string: *const u16,
     );
 

--- a/core-graphics/src/font.rs
+++ b/core-graphics/src/font.rs
@@ -19,7 +19,7 @@ use std::ptr::NonNull;
 
 use foreign_types::{foreign_type, ForeignType};
 
-use libc::{c_int, size_t};
+use core::ffi::c_int;
 
 pub use core_graphics_types::base::CGGlyph;
 
@@ -181,13 +181,13 @@ extern "C" {
     fn CGFontGetGlyphBBoxes(
         font: crate::sys::CGFontRef,
         glyphs: *const CGGlyph,
-        count: size_t,
+        count: usize,
         bboxes: *mut CGRect,
     ) -> bool;
     fn CGFontGetGlyphAdvances(
         font: crate::sys::CGFontRef,
         glyphs: *const CGGlyph,
-        count: size_t,
+        count: usize,
         advances: *mut c_int,
     ) -> bool;
 

--- a/core-graphics/src/gradient.rs
+++ b/core-graphics/src/gradient.rs
@@ -18,8 +18,6 @@ use core_foundation::array::{CFArray, CFArrayRef};
 use core_foundation::base::{CFRelease, CFRetain, TCFType};
 use foreign_types::{foreign_type, ForeignType};
 
-use libc::size_t;
-
 bitflags! {
     #[repr(C)]
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -80,7 +78,7 @@ extern "C" {
         color_space: crate::sys::CGColorSpaceRef,
         components: *const CGFloat,
         locations: *const CGFloat,
-        count: size_t,
+        count: usize,
     ) -> crate::sys::CGGradientRef;
     fn CGGradientCreateWithColors(
         color_space: crate::sys::CGColorSpaceRef,

--- a/core-graphics/src/image.rs
+++ b/core-graphics/src/image.rs
@@ -7,7 +7,6 @@ use crate::geometry::CGRect;
 use core_foundation::base::{CFRetain, CFTypeID};
 use core_foundation::data::CFData;
 use foreign_types::{foreign_type, ForeignType, ForeignTypeRef};
-use libc::size_t;
 
 #[repr(C)]
 pub enum CGImageAlphaInfo {
@@ -41,11 +40,11 @@ foreign_type! {
 
 impl CGImage {
     pub fn new(
-        width: size_t,
-        height: size_t,
-        bits_per_component: size_t,
-        bits_per_pixel: size_t,
-        bytes_per_row: size_t,
+        width: usize,
+        height: usize,
+        bits_per_component: usize,
+        bits_per_pixel: usize,
+        bytes_per_row: usize,
         colorspace: &CGColorSpace,
         bitmap_info: u32,
         provider: &CGDataProvider,
@@ -77,23 +76,23 @@ impl CGImage {
 }
 
 impl CGImageRef {
-    pub fn width(&self) -> size_t {
+    pub fn width(&self) -> usize {
         unsafe { CGImageGetWidth(self.as_ptr()) }
     }
 
-    pub fn height(&self) -> size_t {
+    pub fn height(&self) -> usize {
         unsafe { CGImageGetHeight(self.as_ptr()) }
     }
 
-    pub fn bits_per_component(&self) -> size_t {
+    pub fn bits_per_component(&self) -> usize {
         unsafe { CGImageGetBitsPerComponent(self.as_ptr()) }
     }
 
-    pub fn bits_per_pixel(&self) -> size_t {
+    pub fn bits_per_pixel(&self) -> usize {
         unsafe { CGImageGetBitsPerPixel(self.as_ptr()) }
     }
 
-    pub fn bytes_per_row(&self) -> size_t {
+    pub fn bytes_per_row(&self) -> usize {
         unsafe { CGImageGetBytesPerRow(self.as_ptr()) }
     }
 
@@ -128,20 +127,20 @@ impl CGImageRef {
 #[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     fn CGImageGetTypeID() -> CFTypeID;
-    fn CGImageGetWidth(image: crate::sys::CGImageRef) -> size_t;
-    fn CGImageGetHeight(image: crate::sys::CGImageRef) -> size_t;
-    fn CGImageGetBitsPerComponent(image: crate::sys::CGImageRef) -> size_t;
-    fn CGImageGetBitsPerPixel(image: crate::sys::CGImageRef) -> size_t;
-    fn CGImageGetBytesPerRow(image: crate::sys::CGImageRef) -> size_t;
+    fn CGImageGetWidth(image: crate::sys::CGImageRef) -> usize;
+    fn CGImageGetHeight(image: crate::sys::CGImageRef) -> usize;
+    fn CGImageGetBitsPerComponent(image: crate::sys::CGImageRef) -> usize;
+    fn CGImageGetBitsPerPixel(image: crate::sys::CGImageRef) -> usize;
+    fn CGImageGetBytesPerRow(image: crate::sys::CGImageRef) -> usize;
     fn CGImageGetColorSpace(image: crate::sys::CGImageRef) -> crate::sys::CGColorSpaceRef;
     fn CGImageGetDataProvider(image: crate::sys::CGImageRef) -> crate::sys::CGDataProviderRef;
     fn CGImageRelease(image: crate::sys::CGImageRef);
     fn CGImageCreate(
-        width: size_t,
-        height: size_t,
-        bitsPerComponent: size_t,
-        bitsPerPixel: size_t,
-        bytesPerRow: size_t,
+        width: usize,
+        height: usize,
+        bitsPerComponent: usize,
+        bitsPerPixel: usize,
+        bytesPerRow: usize,
         space: crate::sys::CGColorSpaceRef,
         bitmapInfo: u32,
         provider: crate::sys::CGDataProviderRef,

--- a/core-graphics/src/path.rs
+++ b/core-graphics/src/path.rs
@@ -10,9 +10,9 @@
 pub use crate::sys::CGPathRef as SysCGPathRef;
 
 use crate::geometry::{CGAffineTransform, CGPoint, CGRect};
+use core::ffi::c_void;
 use core_foundation::base::{CFRelease, CFRetain, CFTypeID};
 use foreign_types::{foreign_type, ForeignType};
-use libc::c_void;
 use std::fmt::{self, Debug, Formatter};
 use std::marker::PhantomData;
 use std::ops::Deref;

--- a/core-graphics/src/private.rs
+++ b/core-graphics/src/private.rs
@@ -12,7 +12,7 @@
 //! These are liable to change at any time. Use with caution!
 
 use crate::geometry::CGRect;
-use libc::{c_int, c_uint};
+use core::ffi::{c_int, c_uint};
 use std::ptr;
 
 pub struct CGSRegion {
@@ -87,7 +87,7 @@ impl CGSSurface {
 
 mod ffi {
     use crate::geometry::CGRect;
-    use libc::{c_int, c_uint};
+    use core::ffi::{c_int, c_uint};
 
     // This is an enum so that we can't easily make instances of this opaque type.
     pub enum CGSRegionObject {}

--- a/core-graphics/src/sys.rs
+++ b/core-graphics/src/sys.rs
@@ -1,4 +1,4 @@
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 pub enum CGImage {}
 pub type CGImageRef = *mut CGImage;

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -22,6 +22,5 @@ link = ["core-foundation/link", "core-graphics/link"]
 
 [dependencies]
 foreign-types = "0.5"
-libc = "0.2"
 core-foundation = { default-features = false, path = "../core-foundation", version = "0.10" }
 core-graphics = { default-features = false, path = "../core-graphics", version = "0.24" }

--- a/core-text/src/font.rs
+++ b/core-text/src/font.rs
@@ -31,8 +31,6 @@ use core_graphics::geometry::{CGAffineTransform, CGPoint, CGRect, CGSize};
 use core_graphics::path::CGPath;
 
 use foreign_types::ForeignType;
-use libc::{self, size_t};
-use std::os::raw::c_void;
 use std::ptr;
 
 type CGContextRef = *mut <CGContext as ForeignType>::CType;
@@ -130,7 +128,7 @@ impl From<CTFontNameSpecifier> for CFStringRef {
 }
 
 #[repr(C)]
-pub struct __CTFont(c_void);
+pub struct __CTFont(core::ffi::c_void);
 
 pub type CTFontRef = *const __CTFont;
 
@@ -394,7 +392,7 @@ impl CTFont {
         unsafe { CTFontGetLeading(self.0) }
     }
 
-    pub fn units_per_em(&self) -> libc::c_uint {
+    pub fn units_per_em(&self) -> core::ffi::c_uint {
         unsafe { CTFontGetUnitsPerEm(self.0) }
     }
 
@@ -489,7 +487,7 @@ impl CTFont {
                 self.as_concrete_TypeRef(),
                 glyphs.as_ptr(),
                 positions.as_ptr(),
-                glyphs.len() as size_t,
+                glyphs.len(),
                 context.as_ptr(),
             )
         }
@@ -724,7 +722,7 @@ extern "C" {
     fn CTFontGetAscent(font: CTFontRef) -> CGFloat;
     fn CTFontGetDescent(font: CTFontRef) -> CGFloat;
     fn CTFontGetLeading(font: CTFontRef) -> CGFloat;
-    fn CTFontGetUnitsPerEm(font: CTFontRef) -> libc::c_uint;
+    fn CTFontGetUnitsPerEm(font: CTFontRef) -> core::ffi::c_uint;
     fn CTFontGetGlyphCount(font: CTFontRef) -> CFIndex;
     fn CTFontGetBoundingBox(font: CTFontRef) -> CGRect;
     fn CTFontGetUnderlinePosition(font: CTFontRef) -> CGFloat;
@@ -753,7 +751,7 @@ extern "C" {
         glyphs: *const CGGlyph,
         advances: *mut CGSize,
         count: CFIndex,
-    ) -> libc::c_double;
+    ) -> core::ffi::c_double;
     fn CTFontGetVerticalTranslationsForGlyphs(
         font: CTFontRef,
         orientation: CTFontOrientation,
@@ -781,7 +779,7 @@ extern "C" {
         font: CTFontRef,
         glyphs: *const CGGlyph,
         positions: *const CGPoint,
-        count: size_t,
+        count: usize,
         context: CGContextRef,
     );
     //fn CTFontGetLigatureCaretPositions

--- a/core-text/src/font_collection.rs
+++ b/core-text/src/font_collection.rs
@@ -21,10 +21,8 @@ use core_foundation::set::CFSet;
 use core_foundation::string::{CFString, CFStringRef};
 use core_foundation::{declare_TCFType, impl_CFTypeDescription, impl_TCFType};
 
-use std::os::raw::c_void;
-
 #[repr(C)]
-pub struct __CTFontCollection(c_void);
+pub struct __CTFontCollection(core::ffi::c_void);
 
 pub type CTFontCollectionRef = *const __CTFontCollection;
 

--- a/core-text/src/font_descriptor.rs
+++ b/core-text/src/font_descriptor.rs
@@ -19,7 +19,6 @@ use core_foundation::url::{CFURLRef, CFURL};
 use core_foundation::{declare_TCFType, impl_CFTypeDescription, impl_TCFType};
 use core_graphics::base::CGFloat;
 
-use std::os::raw::c_void;
 use std::path::PathBuf;
 
 /*
@@ -199,7 +198,7 @@ pub const kCTFontPriorityDynamic: CTFontPriority = 50000;
 pub const kCTFontPriorityProcess: CTFontPriority = 60000;
 
 #[repr(C)]
-pub struct __CTFontDescriptor(c_void);
+pub struct __CTFontDescriptor(core::ffi::c_void);
 
 pub type CTFontDescriptorRef = *const __CTFontDescriptor;
 

--- a/core-text/src/frame.rs
+++ b/core-text/src/frame.rs
@@ -15,10 +15,9 @@ use core_graphics::context::{CGContext, CGContextRef};
 use core_graphics::geometry::CGPoint;
 use core_graphics::path::{CGPath, SysCGPathRef};
 use foreign_types::{ForeignType, ForeignTypeRef};
-use std::os::raw::c_void;
 
 #[repr(C)]
-pub struct __CTFrame(c_void);
+pub struct __CTFrame(core::ffi::c_void);
 
 pub type CTFrameRef = *const __CTFrame;
 

--- a/core-text/src/framesetter.rs
+++ b/core-text/src/framesetter.rs
@@ -15,11 +15,10 @@ use core_foundation::{declare_TCFType, impl_CFTypeDescription, impl_TCFType};
 use core_graphics::geometry::CGSize;
 use core_graphics::path::{CGPath, CGPathRef};
 use foreign_types::{ForeignType, ForeignTypeRef};
-use std::os::raw::c_void;
 use std::ptr::null;
 
 #[repr(C)]
-pub struct __CTFramesetter(c_void);
+pub struct __CTFramesetter(core::ffi::c_void);
 
 pub type CTFramesetterRef = *const __CTFramesetter;
 
@@ -83,7 +82,7 @@ extern "C" {
         framesetter: CTFramesetterRef,
         string_range: CFRange,
         path: *mut <CGPath as ForeignType>::CType,
-        attributes: *const c_void,
+        attributes: *const core::ffi::c_void,
     ) -> CTFrameRef;
     fn CTFramesetterSuggestFrameSizeWithConstraints(
         framesetter: CTFramesetterRef,

--- a/core-text/src/line.rs
+++ b/core-text/src/line.rs
@@ -16,10 +16,9 @@ use core_graphics::base::CGFloat;
 use core_graphics::context::CGContext;
 use core_graphics::geometry::{CGPoint, CGRect};
 use foreign_types::ForeignType;
-use std::os::raw::c_void;
 
 #[repr(C)]
-pub struct __CTLine(c_void);
+pub struct __CTLine(core::ffi::c_void);
 
 pub type CTLineRef = *const __CTLine;
 

--- a/core-text/src/run.rs
+++ b/core-text/src/run.rs
@@ -15,13 +15,12 @@ use core_graphics::base::CGFloat;
 use core_graphics::font::CGGlyph;
 use core_graphics::geometry::CGPoint;
 use std::borrow::Cow;
-use std::os::raw::c_void;
 use std::slice;
 
 use crate::line::TypographicBounds;
 
 #[repr(C)]
-pub struct __CTRun(c_void);
+pub struct __CTRun(core::ffi::c_void);
 
 pub type CTRunRef = *const __CTRun;
 

--- a/io-surface/Cargo.toml
+++ b/io-surface/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = "1.65"
 default-target = "x86_64-apple-darwin"
 
 [dependencies]
-libc = "0.2"
 core-foundation = { default-features = false, path = "../core-foundation", version = "0.10" }
 core-foundation-sys = { default-features = false, path = "../core-foundation-sys", version = "0.8" }
 cgl = "0.3"

--- a/io-surface/src/lib.rs
+++ b/io-surface/src/lib.rs
@@ -13,14 +13,13 @@
 // Rust bindings to the IOSurface framework on macOS.
 
 use cgl::{kCGLNoError, CGLErrorString, CGLGetCurrentContext, CGLTexImageIOSurface2D, GLenum};
+use core::ffi::{c_int, c_void};
 use core_foundation::base::{CFRelease, CFRetain, CFType, CFTypeID, CFTypeRef, TCFType};
 use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::string::{CFString, CFStringRef};
 use core_foundation_sys::base::mach_port_t;
 use leaky_cow::LeakyCow;
-use libc::{c_int, size_t};
 use std::ffi::CStr;
-use std::os::raw::c_void;
 use std::slice;
 
 const BGRA: GLenum = 0x80E1;
@@ -125,7 +124,7 @@ impl IOSurface {
                 height,
                 BGRA as GLenum,
                 UNSIGNED_INT_8_8_8_8_REV,
-                self.as_concrete_TypeRef() as *mut libc::c_void,
+                self.as_concrete_TypeRef() as *mut c_void,
                 0,
             );
 
@@ -196,9 +195,9 @@ extern "C" {
     pub fn IOSurfaceUnlock(buffer: IOSurfaceRef, options: u32, seed: *mut u32) -> IOReturn;
     pub fn IOSurfaceGetSeed(buffer: IOSurfaceRef) -> u32;
 
-    pub fn IOSurfaceGetHeight(buffer: IOSurfaceRef) -> size_t;
+    pub fn IOSurfaceGetHeight(buffer: IOSurfaceRef) -> usize;
     pub fn IOSurfaceGetWidth(buffer: IOSurfaceRef) -> usize;
-    pub fn IOSurfaceGetBytesPerRow(buffer: IOSurfaceRef) -> size_t;
+    pub fn IOSurfaceGetBytesPerRow(buffer: IOSurfaceRef) -> usize;
     pub fn IOSurfaceGetBaseAddress(buffer: IOSurfaceRef) -> *mut c_void;
     pub fn IOSurfaceGetElementHeight(buffer: IOSurfaceRef) -> usize;
     pub fn IOSurfaceGetElementWidth(buffer: IOSurfaceRef) -> usize;


### PR DESCRIPTION
`core::ffi` is the preferred way to access these type definitions. Begin removing uses of the versions from `libc`.

`libc::c_void` is not exactly the same as `core::ffi::c_void` but some code has tried using them interchangeably (like in io-surface).

`libc::size_t` is `usize` on all current platforms.