### PR TITLE
Bump MSRV to 1.65

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
         toolchain: [stable]
         include:
           - os: macos-14
-            toolchain: 1.56.1
+            toolchain: "1.65.0"
     steps:
     - uses: actions/checkout@v4
     - name: Install toolchain

--- a/cocoa-foundation/Cargo.toml
+++ b/cocoa-foundation/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.2.0"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.26.0"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/core-foundation-sys/Cargo.toml
+++ b/core-foundation-sys/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.8.7"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+rust-version = "1.65"
 
 [dependencies]
 

--- a/core-foundation/Cargo.toml
+++ b/core-foundation/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 categories = ["os::macos-apis"]
 keywords = ["macos", "framework", "objc"]
 edition = "2018"
+rust-version = "1.65"
 
 [dependencies.core-foundation-sys]
 path = "../core-foundation-sys"

--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.2.0"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+rust-version = "1.65"
 
 [dependencies]
 bitflags = "2"

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.24.0"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+rust-version = "1.65"
 
 [features]
 default = ["link"]

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -6,6 +6,7 @@ description = "Bindings to the Core Text framework."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/core-foundation-rs"
 edition = "2018"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/io-surface/Cargo.toml
+++ b/io-surface/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.16.0"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"


### PR DESCRIPTION
This will allow us to use `dep:` syntax and also move to using types from `core::ffi` as well as some other more modern constructs.