### PR TITLE
core-graphics-types: Remove dep on `bitflags`

### DIFF
--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 rust-version = "1.65"
 
 [dependencies]
-bitflags = "2"
 core-foundation = { default-features = false, path = "../core-foundation", version = "0.10" }
 libc = "0.2"
 


### PR DESCRIPTION
This is unused.