### PR TITLE
Correct screen capture access return values.

### DIFF
--- a/core-graphics/src/access.rs
+++ b/core-graphics/src/access.rs
@@ -1,5 +1,3 @@
-pub use crate::base::boolean_t;
-
 #[derive(Default)]
 pub struct ScreenCaptureAccess;
 
@@ -8,19 +6,19 @@ impl ScreenCaptureAccess {
     /// Return the same result as preflight.
     #[inline]
     pub fn request(&self) -> bool {
-        unsafe { CGRequestScreenCaptureAccess() == 1 }
+        unsafe { CGRequestScreenCaptureAccess() }
     }
 
     /// Return `true` if has access
     #[inline]
     pub fn preflight(&self) -> bool {
-        unsafe { CGPreflightScreenCaptureAccess() == 1 }
+        unsafe { CGPreflightScreenCaptureAccess() }
     }
 }
 
 #[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 extern "C" {
     // Screen Capture Access
-    fn CGRequestScreenCaptureAccess() -> boolean_t;
-    fn CGPreflightScreenCaptureAccess() -> boolean_t;
+    fn CGRequestScreenCaptureAccess() -> bool;
+    fn CGPreflightScreenCaptureAccess() -> bool;
 }


### PR DESCRIPTION
Both `CGRequestScreenCaptureAccess` and `CGPreflightScreenCaptureAccess` return `bool`, not `boolean_t`.

Fixes #677.
Replaces #678.