### PR TITLE
Use `CFIndex::MAX` rather than `CFIndex::max_value()`

### DIFF
--- a/core-foundation/src/base.rs
+++ b/core-foundation/src/base.rs
@@ -29,8 +29,7 @@ pub trait CFIndexConvertible {
 impl CFIndexConvertible for usize {
     #[inline]
     fn to_CFIndex(self) -> CFIndex {
-        let max_CFIndex = CFIndex::max_value();
-        if self > (max_CFIndex as usize) {
+        if self > (CFIndex::MAX as usize) {
             panic!("value out of range")
         }
         self as CFIndex


### PR DESCRIPTION
Since `CFIndex` is just `isize`, we can use the `CFIndex::MAX` constant. The `max_value` and other functions are pending deprecation and cause a clippy lint warning.