### PR TITLE
Use workspace inheritance.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,16 @@
 [workspace]
 members = ["core-foundation", "core-foundation-sys", "core-graphics-types", "core-graphics", "core-text", "cocoa", "cocoa-foundation", "io-surface"]
+
+[workspace.package]
+authors = ["The Servo Project Developers"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/servo/core-foundation-rs"
+rust-version = "1.65"
+
+[workspace.dependencies]
+cocoa-foundation = { default-features = false, path = "cocoa-foundation", version = "0.2" }
+core-foundation = { default-features = false, path = "core-foundation", version = "0.10" }
+core-foundation-sys = { default-features = false, path = "core-foundation-sys", version = "0.8" }
+core-graphics = { default-features = false, path = "core-graphics", version = "0.24" }
+core-graphics-types = { default-features = false, path = "core-graphics-types", version = "0.2" }

--- a/cocoa-foundation/Cargo.toml
+++ b/cocoa-foundation/Cargo.toml
@@ -1,23 +1,23 @@
-
 [package]
 name = "cocoa-foundation"
 description = "Bindings to Cocoa Foundation for macOS"
-homepage = "https://github.com/servo/core-foundation-rs"
-repository = "https://github.com/servo/core-foundation-rs"
 version = "0.2.0"
-authors = ["The Servo Project Developers"]
-license = "MIT OR Apache-2.0"
-edition = "2018"
-rust-version = "1.65"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 
 [dependencies]
-block = "0.1"
+core-foundation.workspace = true
+core-graphics-types.workspace = true
+
 bitflags = "2"
-core-foundation = { default-features = false, path = "../core-foundation", version = "0.10" }
-core-graphics-types = { default-features = false, path = "../core-graphics-types", version = "0.2" }
+block = "0.1"
 objc = "0.2.3"
 
 [features]

--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -1,26 +1,26 @@
-
 [package]
 name = "cocoa"
 description = "Bindings to Cocoa for macOS"
-homepage = "https://github.com/servo/core-foundation-rs"
-repository = "https://github.com/servo/core-foundation-rs"
 version = "0.26.0"
-authors = ["The Servo Project Developers"]
-license = "MIT OR Apache-2.0"
-edition = "2018"
-rust-version = "1.65"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 
 [dependencies]
-block = "0.1"
+cocoa-foundation.workspace = true
+core-foundation.workspace = true
+core-graphics.workspace = true
+
 bitflags = "2"
-libc = "0.2"
-cocoa-foundation = { default-features = false, path = "../cocoa-foundation", version = "0.2" }
-core-foundation = { default-features = false, path = "../core-foundation", version = "0.10" }
-core-graphics = { default-features = false, path = "../core-graphics", version = "0.24" }
+block = "0.1"
 foreign-types = "0.5"
+libc = "0.2"
 objc = "0.2.3"
 
 [features]

--- a/core-foundation-sys/Cargo.toml
+++ b/core-foundation-sys/Cargo.toml
@@ -1,13 +1,17 @@
 [package]
 name = "core-foundation-sys"
 description = "Bindings to Core Foundation for macOS"
-homepage = "https://github.com/servo/core-foundation-rs"
-repository = "https://github.com/servo/core-foundation-rs"
 version = "0.8.7"
-authors = ["The Servo Project Developers"]
-license = "MIT OR Apache-2.0"
-edition = "2018"
-rust-version = "1.65"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-apple-darwin"
 
 [dependencies]
 
@@ -17,7 +21,3 @@ mac_os_10_7_support = [] # backwards compatibility
 mac_os_10_8_features = [] # enables new features
 # Disable to manually link. Enabled by default.
 link = []
-
-[package.metadata.docs.rs]
-all-features = true
-default-target = "x86_64-apple-darwin"

--- a/core-foundation/Cargo.toml
+++ b/core-foundation/Cargo.toml
@@ -1,22 +1,24 @@
 [package]
 name = "core-foundation"
 description = "Bindings to Core Foundation for macOS"
-homepage = "https://github.com/servo/core-foundation-rs"
-repository = "https://github.com/servo/core-foundation-rs"
 version = "0.10.0"
-authors = ["The Servo Project Developers"]
-license = "MIT OR Apache-2.0"
+
 categories = ["os::macos-apis"]
 keywords = ["macos", "framework", "objc"]
-edition = "2018"
-rust-version = "1.65"
 
-[dependencies.core-foundation-sys]
-path = "../core-foundation-sys"
-default-features = false
-version = "0.8.7"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-apple-darwin"
 
 [dependencies]
+core-foundation-sys.workspace = true
+
 libc = "0.2"
 uuid = { version = "1", optional = true }
 
@@ -28,8 +30,3 @@ mac_os_10_8_features = ["core-foundation-sys/mac_os_10_8_features"] # enables ne
 with-uuid = ["dep:uuid"]
 # Disable to manually link. Enabled by default.
 link = ["core-foundation-sys/link"]
-
-
-[package.metadata.docs.rs]
-all-features = true
-default-target = "x86_64-apple-darwin"

--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "core-graphics-types"
 description = "Bindings for some fundamental Core Graphics types"
-homepage = "https://github.com/servo/core-foundation-rs"
-repository = "https://github.com/servo/core-foundation-rs"
 version = "0.2.0"
-authors = ["The Servo Project Developers"]
-license = "MIT OR Apache-2.0"
-edition = "2018"
-rust-version = "1.65"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[package.metadata.docs.rs]
+default-target = "x86_64-apple-darwin"
 
 [dependencies]
-core-foundation = { default-features = false, path = "../core-foundation", version = "0.10" }
+core-foundation.workspace = true
 
 [features]
 default = ["link"]
 # Disable to manually link. Enabled by default.
 link = ["core-foundation/link"]
-
-[package.metadata.docs.rs]
-default-target = "x86_64-apple-darwin"

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -1,13 +1,25 @@
 [package]
 name = "core-graphics"
 description = "Bindings to Core Graphics for macOS"
-homepage = "https://github.com/servo/core-foundation-rs"
-repository = "https://github.com/servo/core-foundation-rs"
 version = "0.24.0"
-authors = ["The Servo Project Developers"]
-license = "MIT OR Apache-2.0"
-edition = "2018"
-rust-version = "1.65"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-apple-darwin"
+
+[dependencies]
+core-foundation.workspace = true
+core-graphics-types.workspace = true
+
+bitflags = "2"
+foreign-types = "0.5.0"
+libc = "0.2"
 
 [features]
 default = ["link"]
@@ -15,14 +27,3 @@ elcapitan = []
 highsierra = []
 # Disable to manually link. Enabled by default.
 link = ["core-foundation/link", "core-graphics-types/link"]
-
-[dependencies]
-bitflags = "2"
-core-foundation = { default-features = false, path = "../core-foundation", version = "0.10" }
-core-graphics-types = { default-features = false, path = "../core-graphics-types", version = "0.2" }
-foreign-types = "0.5.0"
-libc = "0.2"
-
-[package.metadata.docs.rs]
-all-features = true
-default-target = "x86_64-apple-darwin"

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -1,16 +1,23 @@
 [package]
 name = "core-text"
 version = "21.0.0"
-authors = ["The Servo Project Developers"]
 description = "Bindings to the Core Text framework."
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/servo/core-foundation-rs"
-edition = "2018"
-rust-version = "1.65"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
 default-target = "x86_64-apple-darwin"
+
+[dependencies]
+core-foundation.workspace = true
+core-graphics.workspace = true
+
+foreign-types = "0.5"
 
 [features]
 default = ["mountainlion", "link"]
@@ -19,8 +26,3 @@ default = ["mountainlion", "link"]
 mountainlion = []
 # Disable to manually link. Enabled by default.
 link = ["core-foundation/link", "core-graphics/link"]
-
-[dependencies]
-foreign-types = "0.5"
-core-foundation = { default-features = false, path = "../core-foundation", version = "0.10" }
-core-graphics = { default-features = false, path = "../core-graphics", version = "0.24" }

--- a/io-surface/Cargo.toml
+++ b/io-surface/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
 name = "io-surface"
 description = "Bindings to IO Surface for macOS"
-homepage = "https://github.com/servo/core-foundation-rs"
-repository = "https://github.com/servo/core-foundation-rs"
 version = "0.16.0"
-authors = ["The Servo Project Developers"]
-license = "MIT OR Apache-2.0"
-edition = "2018"
-rust-version = "1.65"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 
 [dependencies]
-core-foundation = { default-features = false, path = "../core-foundation", version = "0.10" }
-core-foundation-sys = { default-features = false, path = "../core-foundation-sys", version = "0.8" }
+core-foundation.workspace = true
+core-foundation-sys.workspace = true
+
 cgl = "0.3"
 leaky-cow = "0.1.1"
 


### PR DESCRIPTION
Consolidate package configuration where possible. This also removes the `homepage` key as it only points to the repository so isn't providing anything additional.

Use workspace dependencies for the crates provided by the workspace and used within the workspace. This centralizes the version number maintenance a bit.