### PR TITLE
Enable clippy, suppress lots, fix a couple.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   rustfmt:
@@ -46,6 +47,9 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run clippy
+      if: matrix.os == 'macos-14' && matrix.toolchain == 'stable'
+      run: cargo clippy --all-targets --workspace
   typos:
     # If this fails, consider changing your text or adding something to .typos.toml
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,20 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/core-foundation-rs"
 rust-version = "1.65"
 
+# TODO: Remove most of these by fixing the actual issues.
+[workspace.lints]
+clippy.assertions_on_constants = "allow"
+clippy.len_without_is_empty = "allow"
+clippy.manual_range_contains = "allow"
+clippy.missing_safety_doc = "allow"
+clippy.new_ret_no_self = "allow"
+clippy.new_without_default = "allow"
+clippy.non_canonical_partial_ord_impl = "allow"
+clippy.not_unsafe_ptr_arg_deref = "allow"
+clippy.result_unit_err = "allow"
+clippy.too_many_arguments = "allow"
+clippy.type_complexity = "allow"
+
 [workspace.dependencies]
 cocoa-foundation = { default-features = false, path = "cocoa-foundation", version = "0.2" }
 core-foundation = { default-features = false, path = "core-foundation", version = "0.10" }

--- a/cocoa-foundation/Cargo.toml
+++ b/cocoa-foundation/Cargo.toml
@@ -12,6 +12,9 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 
+[lints]
+workspace = true
+
 [dependencies]
 core-foundation.workspace = true
 core-graphics-types.workspace = true

--- a/cocoa-foundation/src/foundation.rs
+++ b/cocoa-foundation/src/foundation.rs
@@ -26,7 +26,7 @@ pub type NSInteger = core::ffi::c_long;
 #[cfg(target_pointer_width = "64")]
 pub type NSUInteger = core::ffi::c_ulong;
 
-pub const NSIntegerMax: NSInteger = NSInteger::max_value();
+pub const NSIntegerMax: NSInteger = NSInteger::MAX;
 pub const NSNotFound: NSInteger = NSIntegerMax;
 
 const UTF8_ENCODING: usize = 4;

--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -12,6 +12,9 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 
+[lints]
+workspace = true
+
 [dependencies]
 cocoa-foundation.workspace = true
 core-foundation.workspace = true

--- a/core-foundation-sys/Cargo.toml
+++ b/core-foundation-sys/Cargo.toml
@@ -13,6 +13,9 @@ rust-version.workspace = true
 all-features = true
 default-target = "x86_64-apple-darwin"
 
+[lints]
+workspace = true
+
 [dependencies]
 
 [features]

--- a/core-foundation/Cargo.toml
+++ b/core-foundation/Cargo.toml
@@ -16,6 +16,9 @@ rust-version.workspace = true
 all-features = true
 default-target = "x86_64-apple-darwin"
 
+[lints]
+workspace = true
+
 [dependencies]
 core-foundation-sys.workspace = true
 

--- a/core-foundation/src/dictionary.rs
+++ b/core-foundation/src/dictionary.rs
@@ -471,7 +471,7 @@ pub mod test {
         assert_eq!(mut_dict.retain_count(), 2);
         assert_eq!(dict.retain_count(), 2);
         assert_eq!(
-            *dict.get(&CFString::from_static_string("Bar")),
+            *dict.get(CFString::from_static_string("Bar")),
             CFBoolean::false_value()
         );
 

--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -12,6 +12,9 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 
+[lints]
+workspace = true
+
 [dependencies]
 core-foundation.workspace = true
 

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -13,6 +13,9 @@ rust-version.workspace = true
 all-features = true
 default-target = "x86_64-apple-darwin"
 
+[lints]
+workspace = true
+
 [dependencies]
 core-foundation.workspace = true
 core-graphics-types.workspace = true

--- a/core-graphics/src/data_provider.rs
+++ b/core-graphics/src/data_provider.rs
@@ -58,7 +58,7 @@ impl CGDataProvider {
     pub fn from_buffer<T: AsRef<[u8]> + Sync + Send>(buffer: Arc<T>) -> Self {
         unsafe {
             let ptr = (*buffer).as_ref().as_ptr() as *const c_void;
-            let len = (*buffer).as_ref().len() as usize;
+            let len = (*buffer).as_ref().len();
             let info = Arc::into_raw(buffer) as *mut c_void;
             let result = CGDataProviderCreateWithData(info, ptr, len, Some(release::<T>));
             return CGDataProvider::from_ptr(result);
@@ -69,11 +69,11 @@ impl CGDataProvider {
         }
     }
 
-    /// Creates a data prvider from a given slice. The data provider does not own the slice in this
+    /// Creates a data provider from a given slice. The data provider does not own the slice in this
     /// case, so it's up to the user to ensure the memory safety here.
     pub unsafe fn from_slice(buffer: &[u8]) -> Self {
         let ptr = buffer.as_ptr() as *const c_void;
-        let len = buffer.len() as usize;
+        let len = buffer.len();
         let result = CGDataProviderCreateWithData(ptr::null_mut(), ptr, len, None);
         CGDataProvider::from_ptr(result)
     }

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -13,6 +13,9 @@ rust-version.workspace = true
 all-features = true
 default-target = "x86_64-apple-darwin"
 
+[lints]
+workspace = true
+
 [dependencies]
 core-foundation.workspace = true
 core-graphics.workspace = true

--- a/core-text/src/font.rs
+++ b/core-text/src/font.rs
@@ -841,13 +841,13 @@ fn macos_version() -> (i32, i32, i32) {
     let k = unsafe { propertylist::CFPropertyList::wrap_under_create_rule(list) };
 
     let dict = unsafe {
-        std::mem::transmute::<_, CFDictionary<CFType, CFType>>(
+        std::mem::transmute::<CFDictionary, CFDictionary<CFType, CFType>>(
             k.downcast::<CFDictionary>().unwrap(),
         )
     };
 
     let version = dict
-        .find(&CFString::new("ProductVersion").as_CFType())
+        .find(CFString::new("ProductVersion").as_CFType())
         .as_ref()
         .unwrap()
         .downcast::<CFString>()

--- a/io-surface/Cargo.toml
+++ b/io-surface/Cargo.toml
@@ -12,6 +12,9 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 
+[lints]
+workspace = true
+
 [dependencies]
 core-foundation.workspace = true
 core-foundation-sys.workspace = true


### PR DESCRIPTION
This enables clippy in CI and suppresses most of the existing warnings. We can drill down and fix those later, but this will help start getting things under control.