### PR TITLE
Bump core-foundation to 0.10.1

### DIFF
--- a/core-foundation/Cargo.toml
+++ b/core-foundation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "core-foundation"
 description = "Bindings to Core Foundation for macOS"
-version = "0.10.0"
+version = "0.10.1"
 
 categories = ["os::macos-apis"]
 keywords = ["macos", "framework", "objc"]


### PR DESCRIPTION
- #688 
- #694 
- #692
- #691 (minor breakage)
- #652 

Other crates in the workspace shouldn't need to bump their requirements for this crate, as far as I know.