### PR TITLE
[breaking][core-graphics] Fix unsoundness in CGEventTap API

### DIFF
--- a/core-graphics/src/event.rs
+++ b/core-graphics/src/event.rs
@@ -443,44 +443,75 @@ unsafe extern "C" fn cg_event_tap_callback_internal(
 }
 
 /// ```no_run
-///use core_foundation::runloop::{kCFRunLoopCommonModes, CFRunLoop};
-///use core_graphics::event::{CGEventTap, CGEventTapLocation, CGEventTapPlacement, CGEventTapOptions, CGEventType};
-///let current = CFRunLoop::get_current();
-///match CGEventTap::new(
+/// use core_foundation::runloop::{kCFRunLoopCommonModes, CFRunLoop};
+/// use core_graphics::event::{CGEventTap, CGEventTapLocation, CGEventTapPlacement, CGEventTapOptions, CGEventType};
+/// let current = CFRunLoop::get_current();
+///
+/// CGEventTap::with(
 ///     CGEventTapLocation::HID,
 ///     CGEventTapPlacement::HeadInsertEventTap,
 ///     CGEventTapOptions::Default,
 ///     vec![CGEventType::MouseMoved],
-///     |_a, _b, d| {
-///         println!("{:?}", d.location());
+///     |_proxy, _type, event| {
+///         println!("{:?}", event.location());
 ///         None
 ///     },
-/// ) {
-///     Ok(tap) => unsafe {
+///     |tap| {
 ///         let loop_source = tap
 ///             .mach_port()
 ///             .create_runloop_source(0)
 ///             .expect("Runloop source creation failed");
-///         current.add_source(&loop_source, kCFRunLoopCommonModes);
+///         current.add_source(&loop_source, unsafe { kCFRunLoopCommonModes });
 ///         tap.enable();
 ///         CFRunLoop::run_current();
 ///     },
-///     Err(_) => (assert!(false)),
-/// }
+/// ).expect("Failed to install event tap");
 /// ```
 pub struct CGEventTap<'tap_life> {
     mach_port: CFMachPort,
     _callback: Box<CGEventTapCallBackFn<'tap_life>>,
 }
 
-impl<'tap_life> CGEventTap<'tap_life> {
-    pub fn new<F: Fn(CGEventTapProxy, CGEventType, &CGEvent) -> Option<CGEvent> + 'tap_life>(
+impl CGEventTap<'static> {
+    pub fn new<F: Fn(CGEventTapProxy, CGEventType, &CGEvent) -> Option<CGEvent> + 'static>(
         tap: CGEventTapLocation,
         place: CGEventTapPlacement,
         options: CGEventTapOptions,
         events_of_interest: std::vec::Vec<CGEventType>,
         callback: F,
-    ) -> Result<CGEventTap<'tap_life>, ()> {
+    ) -> Result<Self, ()> {
+        // SAFETY: callback is 'static so even if this object is forgotten it
+        // will be valid to call.
+        unsafe { Self::new_unchecked(tap, place, options, events_of_interest, callback) }
+    }
+}
+
+impl<'tap_life> CGEventTap<'tap_life> {
+    pub fn with<R>(
+        tap: CGEventTapLocation,
+        place: CGEventTapPlacement,
+        options: CGEventTapOptions,
+        events_of_interest: std::vec::Vec<CGEventType>,
+        callback: impl Fn(CGEventTapProxy, CGEventType, &CGEvent) -> Option<CGEvent> + 'tap_life,
+        with_fn: impl FnOnce(&Self) -> R,
+    ) -> Result<R, ()> {
+        // SAFETY: We are okay to bypass the 'static restriction because the
+        // event tap is dropped before returning. The callback therefore cannot
+        // be called after its lifetime expires.
+        let event_tap: Self =
+            unsafe { Self::new_unchecked(tap, place, options, events_of_interest, callback)? };
+        Ok(with_fn(&event_tap))
+    }
+
+    /// Caller is responsible for ensuring that this object is dropped before
+    /// `'tap_life` expires.
+    pub unsafe fn new_unchecked(
+        tap: CGEventTapLocation,
+        place: CGEventTapPlacement,
+        options: CGEventTapOptions,
+        events_of_interest: std::vec::Vec<CGEventType>,
+        callback: impl Fn(CGEventTapProxy, CGEventType, &CGEvent) -> Option<CGEvent> + 'tap_life,
+    ) -> Result<Self, ()> {
         let event_mask: CGEventMask = events_of_interest
             .iter()
             .fold(CGEventType::Null as CGEventMask, |mask, &etype| {


### PR DESCRIPTION
The user callback can be dropped while it is still referenced by the run loop. This PR fixes that by invaliding the event tap's mach port which prevents it from sending further events.

The `callback_ref` field was the wrong type. Of course it should never have been public, no one wants to access the callback to call it (and if they did they would probably segfault). In practice this just meant the "intermediate" box would leak on deallocation.

Both fields have to be made private for the API to remain sound, because their lifetimes are tied together: the port holds a pointer to the callback. Otherwise the mach port can be swapped out and we would invalidate the wrong one. This led to the first actually unfortunate breakage, which is that everyone needs to call `.mach_port()` now.

The second is that the callback passed to `CGEventTap::new()` must be `'static` because otherwise the CGEventTap struct can be forgotten and the scope it references exited. An alternate `CGEventTap::with()` API has been added that accepts a non-`'static` callback.

Below is a test case that segfaults with the existing API and does nothing with the new one.

```rust
use core_foundation::runloop::{kCFRunLoopCommonModes, CFRunLoop};
use core_graphics::{
    event::{
        CGEvent, CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventTapPlacement,
        CGEventType, CGMouseButton,
    },
    event_source::CGEventSource,
    event_source::CGEventSourceStateID,
    geometry::CG_ZERO_POINT,
};

fn main() {
    let current = CFRunLoop::get_current();
    match CGEventTap::new(
        CGEventTapLocation::AnnotatedSession,
        CGEventTapPlacement::HeadInsertEventTap,
        CGEventTapOptions::ListenOnly,
        vec![CGEventType::LeftMouseUp],
        |_, _, _| {
            println!("Mouse up");
            CFRunLoop::get_current().stop();
            None
        },
    ) {
        Ok(tap) => unsafe {
            let loop_source = tap.mach_port.create_runloop_source(0).unwrap();
            // let loop_source = tap.mach_port().create_runloop_source(0).unwrap();
            current.add_source(&loop_source, kCFRunLoopCommonModes);
            tap.enable();

            CGEvent::new_mouse_event(
                CGEventSource::new(CGEventSourceStateID::CombinedSessionState).unwrap(),
                CGEventType::LeftMouseUp,
                CG_ZERO_POINT,
                CGMouseButton::Left,
            )
            .unwrap()
            .post(CGEventTapLocation::AnnotatedSession);

            // tap is dropped here
        },
        Err(_) => panic!("Could not create mouse event tap"),
    };

    CFRunLoop::run_current();
}
```