### PR TITLE
fix: update NSWindowTabbingMode enum values

### DIFF
--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -250,8 +250,8 @@ pub enum NSWindowTitleVisibility {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum NSWindowTabbingMode {
     NSWindowTabbingModeAutomatic = 0,
-    NSWindowTabbingModeDisallowed = 1,
-    NSWindowTabbingModePreferred = 2,
+    NSWindowTabbingModePreferred = 1,
+    NSWindowTabbingModeDisallowed = 2,
 }
 
 #[repr(u64)]


### PR DESCRIPTION
The enum values for `NSWindowTabbingModeDisallowed` and `NSWindowTabbingModePreferred` are incorrect, according to https://developer.apple.com/documentation/appkit/nswindow/tabbingmode