### PR TITLE
Bump core-graphics to v0.25.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,5 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-cli
 cocoa-foundation = { default-features = false, path = "cocoa-foundation", version = "0.2" }
 core-foundation = { default-features = false, path = "core-foundation", version = "0.10" }
 core-foundation-sys = { default-features = false, path = "core-foundation-sys", version = "0.8" }
-core-graphics = { default-features = false, path = "core-graphics", version = "0.24" }
+core-graphics = { default-features = false, path = "core-graphics", version = "0.25" }
 core-graphics-types = { default-features = false, path = "core-graphics-types", version = "0.2" }

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "core-graphics"
 description = "Bindings to Core Graphics for macOS"
-version = "0.24.0"
+version = "0.25.0"
 
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This release contains two breaking changes (#709 and #710), including one unsoundness fix for CGEventTap, as well as an MSRV bump.

- Bump MSRV to 1.65 (#694)
- Use core::ffi over std::os::raw and libc::c_* (#692)
- Correct screen capture access return values. (#698)
- feat(CGDisplay): add displays_with_point and displays_with_rect (#657)
- Fix clippy::doc_markdown lints. (#705)
- core-graphics: remove set_font_smoothing_style API, closes #707 (#709)
- [breaking][core-graphics] Fix unsoundness in CGEventTap API (#710)
- core-graphics: add event set_location (#713)
- core-graphics: Add CGKeyCodes for numpad keys (#712)
- core-graphics: add binding for CGColorCreateSRGB (#716)