### PR TITLE
cocoa: Add NSRunningApplication.processIdentifier

### DIFF
--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -679,11 +679,17 @@ pub trait NSRunningApplication: Sized {
             runningApplicationWithProcessIdentifier: pid
         ]
     }
+
+    unsafe fn processIdentifier(self) -> libc::pid_t;
 }
 
 impl NSRunningApplication for id {
     unsafe fn activateWithOptions_(self, options: NSApplicationActivationOptions) -> BOOL {
         msg_send![self, activateWithOptions: options as NSUInteger]
+    }
+
+    unsafe fn processIdentifier(self) -> libc::pid_t {
+        msg_send![self, processIdentifier]
     }
 }
 


### PR DESCRIPTION
This PR adds support for accessing the `processIdentifier` field of an `NSRunningApplication`: https://developer.apple.com/documentation/appkit/nsrunningapplication/processidentifier?language=objc