### PR TITLE
cocoa: Add NSRunningApplication.runningApplicationsWithBundleIdentifier

### DIFF
--- a/cocoa/src/appkit.rs
+++ b/cocoa/src/appkit.rs
@@ -679,6 +679,16 @@ pub trait NSRunningApplication: Sized {
             runningApplicationWithProcessIdentifier: pid
         ]
     }
+
+    unsafe fn runningApplicationsWithBundleIdentifier(
+        _: Self,
+        bundleIdentifier: id, /* NSString */
+    ) -> id /* (NSArray<NSRunningApplication> *) */ {
+        msg_send![
+            class!(NSRunningApplication),
+            runningApplicationsWithBundleIdentifier: bundleIdentifier
+        ]
+    }
 }
 
 impl NSRunningApplication for id {


### PR DESCRIPTION
This PR adds support for accessing the `runningApplicationsWithBundleIdentifier ` type method of an `NSRunningApplication`: https://developer.apple.com/documentation/appkit/nsrunningapplication/runningapplications(withbundleidentifier:)?language=objc