### PR TITLE
Fix `isEqualToString` memory leak

### DIFF
--- a/cocoa-foundation/src/foundation.rs
+++ b/cocoa-foundation/src/foundation.rs
@@ -649,6 +649,7 @@ impl NSString for id {
     unsafe fn isEqualToString(self, other: &str) -> bool {
         let other = NSString::alloc(nil).init_str(other);
         let rv: BOOL = msg_send![self, isEqualToString: other];
+        let _: () = msg_send![other, release];
         rv != NO
     }
 


### PR DESCRIPTION
`NSString::alloc(nil).init_str(other)` was not released. Not using `autorelease` because we may not be in an autorelease pool.