### PR TITLE
Bump version in deprecated crates

### DIFF
--- a/cocoa-foundation/Cargo.toml
+++ b/cocoa-foundation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cocoa-foundation"
 description = "Bindings to Cocoa Foundation for macOS"
-version = "0.2.0"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cocoa"
 description = "Bindings to Cocoa for macOS"
-version = "0.26.0"
+version = "0.26.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/io-surface/Cargo.toml
+++ b/io-surface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "io-surface"
 description = "Bindings to IO Surface for macOS"
-version = "0.16.0"
+version = "0.16.1"
 
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
I looked at the diff to figure out the things that changed in each crate:

[`io-surface` changes](https://github.com/servo/core-foundation-rs/compare/io-surface-v0.16.0...61b90e72da0f37f63509b1f43d752caea56b7a9e):
- https://github.com/servo/core-foundation-rs/pull/692
- https://github.com/servo/core-foundation-rs/pull/731

[`cocoa-foundation` changes](https://github.com/servo/core-foundation-rs/compare/cocoa-foundation-v0.2.0...61b90e72da0f37f63509b1f43d752caea56b7a9e):
- https://github.com/servo/core-foundation-rs/pull/692
- https://github.com/servo/core-foundation-rs/pull/702
- https://github.com/servo/core-foundation-rs/pull/730
- https://github.com/servo/core-foundation-rs/pull/731

[`cocoa` changes](https://github.com/servo/core-foundation-rs/compare/cocoa-v0.26.0...61b90e72da0f37f63509b1f43d752caea56b7a9e):
- https://github.com/servo/core-foundation-rs/pull/692
- https://github.com/servo/core-foundation-rs/pull/702
- https://github.com/servo/core-foundation-rs/pull/714
- https://github.com/servo/core-foundation-rs/pull/731

These are all either bugfixes or stylistic fixes, so it should be safe to release in a patch version.