### PR TITLE
Use latest CI workflow from other servo repos.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,14 +62,15 @@ jobs:
   build_result:
     name: Result
     runs-on: ubuntu-latest
+    if: always()
     needs:
       - "build"
       - "semver"
       - "typos"
     steps:
-      - name: Mark the job as successful
+      - name: Success
         run: exit 0
-        if: success()
-      - name: Mark the job as unsuccessful
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+      - name: Failure
         run: exit 1
-        if: "!success()"
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')


### PR DESCRIPTION
The current implementation allows failing PRs to merge for reasons that aren't entirely clear to me. I've copied these changes from https://github.com/servo/ipc-channel/blob/main/.github/workflows/main.yml, which I remember also hitting this problem in the past.