### PR TITLE
Fix unwrap panic in `extract_number_for_key` in `impl TraitAccessorPrivate for CTFontTraits` on macOS Ventura.

### DIFF
--- a/core-text/src/font_descriptor.rs
+++ b/core-text/src/font_descriptor.rs
@@ -19,8 +19,8 @@ use core_foundation::url::{CFURLRef, CFURL};
 use core_foundation::{declare_TCFType, impl_CFTypeDescription, impl_TCFType};
 use core_graphics::base::CGFloat;
 
-use std::path::PathBuf;
 use core_foundation::boolean::CFBoolean;
+use std::path::PathBuf;
 
 /*
 * CTFontTraits.h
@@ -154,7 +154,11 @@ impl TraitAccessorPrivate for CTFontTraits {
                 // but can occur in practice with certain fonts in MacOS 13 (Ventura). When this
                 // does occur in Ventura, the value returned is always a CFBoolean, so we attempt to
                 // convert into a boolean and create a number from there.
-                let value_as_bool = bool::from(cftype.downcast::<CFBoolean>().expect("Should be able to convert value into CFBoolean"));
+                let value_as_bool = bool::from(
+                    cftype
+                        .downcast::<CFBoolean>()
+                        .expect("Should be able to convert value into CFBoolean"),
+                );
                 CFNumber::from(value_as_bool as i32)
             }
         }


### PR DESCRIPTION
This splits out the final chunk of https://github.com/servo/core-foundation-rs/pull/517 to be reviewed and merged.

As discussed on that PR, in an ideal world, we'd have a test we could write to prove that this is required.

In practice, Warp has been using the logic in that PR for the past 3 years without issues.  We did attempt, 6 months ago, to switch over to upstream (without the patch here) and had to revert that change due to this still being an issue for users running Ventura.

Given the above, we have confidence that:
1. This patch is still required for proper behavior on macOS Ventura, and
2. It is sufficiently well-tested, in production, that it is safe to merge.