### PR TITLE
chore: remove redundant word in comment from `core-foundation-sys/src/number.rs`

### DIFF
--- a/core-foundation-sys/src/number.rs
+++ b/core-foundation-sys/src/number.rs
@@ -97,7 +97,7 @@ mod test {
             _ => panic!("should not happen"),
         };
 
-        // this is new new style of matching for consts
+        // this is new style of matching for consts
         match type_id {
             kCFNumberFloat32Type => assert!(true),
             _ => panic!("should not happen"),


### PR DESCRIPTION
remove redundant word in comment