### PR TITLE
Fix `get_descriptors` memory leak

### DIFF
--- a/core-text/src/font_collection.rs
+++ b/core-text/src/font_collection.rs
@@ -38,15 +38,13 @@ impl_CFTypeDescription!(CTFontCollection);
 
 impl CTFontCollection {
     pub fn get_descriptors(&self) -> Option<CFArray<CTFontDescriptor>> {
-        // surprise! this function follows the Get rule, despite being named *Create*.
-        // So we have to addRef it to avoid CTFontCollection from double freeing it later.
         unsafe {
             let font_descriptors = CTFontCollectionCreateMatchingFontDescriptors(self.0);
             if font_descriptors.is_null() {
                 // This returns null if there are no matching font descriptors.
                 None
             } else {
-                Some(CFArray::wrap_under_get_rule(font_descriptors))
+               Some(CFArray::wrap_under_create_rule(font_descriptors))
             }
         }
     }


### PR DESCRIPTION
This function incorrectly assumed that
`CTFontCollectionCreateMatchingFontDescriptors` doesn't follow the *Create* rule which is false.

From [Apple's docs](https://leopard-adc.pepas.com/documentation/Carbon/Reference/CTFontCollectionRef/Reference/reference.html#//apple_ref/c/func/CTFontCollectionCreateMatchingFontDescriptors)

> A retained reference to an array of normalized font descriptors
  matching the collection definition.

I also confirmed using instruments that this was causing a memory leak in Zed.