### PR TITLE
Upgrade MSRV to 1.68 and remove `macos-13` builder

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,11 +34,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, macos-14, macos-15]
+        os: [macos-14, macos-15, macos-15-intel]
         toolchain: [stable]
         include:
           - os: macos-14
-            toolchain: "1.65.0"
+            toolchain: "1.68.0"
     steps:
     - uses: actions/checkout@v4
     - name: Install toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["The Servo Project Developers"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/core-foundation-rs"
-rust-version = "1.65"
+rust-version = "1.68"
 
 [workspace.lints]
 clippy.doc_markdown = "warn"

--- a/core-foundation/src/filedescriptor.rs
+++ b/core-foundation/src/filedescriptor.rs
@@ -134,6 +134,7 @@ mod test {
     }
 
     #[test]
+    #[allow(unused_assignments)]
     fn test_callback() {
         let mut info = TestInfo { value: 0 };
         let context = CFFileDescriptorContext {


### PR DESCRIPTION
This should fix the build on CI. This also incorporate #744
as that is required to get the CI working again.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
