### PR TITLE
Add fallible try_wrap methods to TCFType trait

### DIFF
--- a/core-foundation/src/base.rs
+++ b/core-foundation/src/base.rs
@@ -192,6 +192,32 @@ pub trait TCFType {
     /// when following Core Foundation's "Get Rule". The reference count *is* bumped.
     unsafe fn wrap_under_get_rule(reference: Self::Ref) -> Self;
 
+    /// Like `wrap_under_create_rule`, but returns `None` if the reference is null instead of
+    /// panicking.
+    unsafe fn try_wrap_under_create_rule(obj: Self::Ref) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if obj.as_void_ptr().is_null() {
+            None
+        } else {
+            Some(Self::wrap_under_create_rule(obj))
+        }
+    }
+
+    /// Like `wrap_under_get_rule`, but returns `None` if the reference is null instead of
+    /// panicking.
+    unsafe fn try_wrap_under_get_rule(reference: Self::Ref) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if reference.as_void_ptr().is_null() {
+            None
+        } else {
+            Some(Self::wrap_under_get_rule(reference))
+        }
+    }
+
     /// Returns the reference count of the object. It is unwise to do anything other than test
     /// whether the return value of this method is greater than zero.
     #[inline]


### PR DESCRIPTION
## Summary

- Adds `try_wrap_under_create_rule` and `try_wrap_under_get_rule` as default methods on the `TCFType` trait
- These return `Option<Self>` instead of panicking when given a NULL reference
- Enables downstream crates (e.g. `system-configuration-rs`) to gracefully handle NULL returns from CoreFoundation APIs in sandboxed macOS environments

## Motivation

CoreFoundation API calls can return NULL pointers in sandboxed environments (e.g. macOS App Sandbox, `sandbox-exec`). The existing `wrap_under_create_rule` and `wrap_under_get_rule` methods contain `assert!(!reference.is_null())` which panics on NULL. This makes it impossible for downstream users to gracefully handle sandbox restrictions — the process simply aborts.

Adding fallible `try_` variants as default trait methods is a backwards-compatible change that requires no modifications to the `impl_TCFType!` macro or existing implementations.

## Test plan

- [x] `cargo build` passes
- [x] All 39 existing `core-foundation` tests pass
- [x] Doc-tests pass
- [x] Verified downstream usage in `system-configuration-rs` compiles and handles NULL gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)