### PR TITLE
Publish core-text 22.0.0.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
         toolchain: [stable]
         include:
           - os: macos-14
-            toolchain: "1.68.0"
+            toolchain: "1.71.0"
     steps:
     - uses: actions/checkout@v4
     - name: Install toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["The Servo Project Developers"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/core-foundation-rs"
-rust-version = "1.68"
+rust-version = "1.71"
 
 [workspace.lints]
 clippy.doc_markdown = "warn"

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-text"
-version = "21.1.0"
+version = "22.0.0"
 description = "Bindings to the Core Text framework."
 
 authors.workspace = true

--- a/core-text/src/font_collection.rs
+++ b/core-text/src/font_collection.rs
@@ -44,7 +44,7 @@ impl CTFontCollection {
                 // This returns null if there are no matching font descriptors.
                 None
             } else {
-               Some(CFArray::wrap_under_create_rule(font_descriptors))
+                Some(CFArray::wrap_under_create_rule(font_descriptors))
             }
         }
     }


### PR DESCRIPTION
Per https://github.com/servo/core-foundation-rs/issues/750 the previous minor bump was incorrect.