### PR TITLE
Add target vendor configuration for Apple

### DIFF
--- a/cocoa-foundation/Cargo.toml
+++ b/cocoa-foundation/Cargo.toml
@@ -15,7 +15,7 @@ default-target = "x86_64-apple-darwin"
 [lints]
 workspace = true
 
-[dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 core-foundation.workspace = true
 core-graphics-types.workspace = true
 

--- a/cocoa-foundation/src/base.rs
+++ b/cocoa-foundation/src/base.rs
@@ -6,6 +6,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
 #![deprecated = "use the objc2 crate instead"]
 
 use objc::runtime;

--- a/cocoa-foundation/src/foundation.rs
+++ b/cocoa-foundation/src/foundation.rs
@@ -6,6 +6,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
 #![deprecated = "use the objc2-foundation crate instead"]
 #![allow(non_upper_case_globals)]
 

--- a/cocoa-foundation/src/lib.rs
+++ b/cocoa-foundation/src/lib.rs
@@ -8,6 +8,7 @@
 // except according to those terms.
 
 //! This crate has been deprecated in favour of the `objc2-foundation` crate.
+
 #![allow(non_snake_case, deprecated)]
 
 pub mod base;

--- a/cocoa-foundation/src/lib.rs
+++ b/cocoa-foundation/src/lib.rs
@@ -9,6 +9,7 @@
 
 //! This crate has been deprecated in favour of the `objc2-foundation` crate.
 
+#![cfg(target_vendor = "apple")]
 #![allow(non_snake_case, deprecated)]
 
 pub mod base;

--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -15,7 +15,7 @@ default-target = "x86_64-apple-darwin"
 [lints]
 workspace = true
 
-[dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 cocoa-foundation.workspace = true
 core-foundation.workspace = true
 core-graphics.workspace = true

--- a/cocoa/src/lib.rs
+++ b/cocoa/src/lib.rs
@@ -11,6 +11,7 @@
 
 #![crate_name = "cocoa"]
 #![crate_type = "rlib"]
+#![cfg(target_vendor = "apple")]
 #![allow(non_snake_case, deprecated)]
 
 #[cfg(target_os = "macos")]

--- a/cocoa/src/lib.rs
+++ b/cocoa/src/lib.rs
@@ -8,6 +8,7 @@
 // except according to those terms.
 
 //! This crate has been deprecated in favour of the `objc2` crates.
+
 #![crate_name = "cocoa"]
 #![crate_type = "rlib"]
 #![allow(non_snake_case, deprecated)]

--- a/core-foundation-sys/Cargo.toml
+++ b/core-foundation-sys/Cargo.toml
@@ -16,7 +16,7 @@ default-target = "x86_64-apple-darwin"
 [lints]
 workspace = true
 
-[dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 
 [features]
 default = ["link"]

--- a/core-foundation-sys/src/lib.rs
+++ b/core-foundation-sys/src/lib.rs
@@ -6,6 +6,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
 #![allow(
     non_snake_case,
     non_camel_case_types,

--- a/core-foundation-sys/src/lib.rs
+++ b/core-foundation-sys/src/lib.rs
@@ -7,6 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![cfg(target_vendor = "apple")]
 #![allow(
     non_snake_case,
     non_camel_case_types,

--- a/core-foundation/Cargo.toml
+++ b/core-foundation/Cargo.toml
@@ -19,7 +19,7 @@ default-target = "x86_64-apple-darwin"
 [lints]
 workspace = true
 
-[dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 core-foundation-sys.workspace = true
 
 libc = "0.2"

--- a/core-foundation/src/lib.rs
+++ b/core-foundation/src/lib.rs
@@ -7,6 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![cfg(target_vendor = "apple")]
 #![allow(non_snake_case)]
 
 //! This crate provides wrappers around the underlying CoreFoundation

--- a/core-graphics-types/Cargo.toml
+++ b/core-graphics-types/Cargo.toml
@@ -15,7 +15,7 @@ default-target = "x86_64-apple-darwin"
 [lints]
 workspace = true
 
-[dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 core-foundation.workspace = true
 
 [features]

--- a/core-graphics-types/src/lib.rs
+++ b/core-graphics-types/src/lib.rs
@@ -7,5 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![cfg(target_vendor = "apple")]
+
 pub mod base;
 pub mod geometry;

--- a/core-graphics/Cargo.toml
+++ b/core-graphics/Cargo.toml
@@ -16,7 +16,7 @@ default-target = "x86_64-apple-darwin"
 [lints]
 workspace = true
 
-[dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 core-foundation.workspace = true
 core-graphics-types.workspace = true
 

--- a/core-graphics/src/lib.rs
+++ b/core-graphics/src/lib.rs
@@ -7,6 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![cfg(target_vendor = "apple")]
+
 #[cfg(target_os = "macos")]
 pub mod access;
 pub mod base;

--- a/core-text/Cargo.toml
+++ b/core-text/Cargo.toml
@@ -16,7 +16,7 @@ default-target = "x86_64-apple-darwin"
 [lints]
 workspace = true
 
-[dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 core-foundation.workspace = true
 core-graphics.workspace = true
 

--- a/core-text/src/lib.rs
+++ b/core-text/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![crate_name = "core_text"]
 #![crate_type = "rlib"]
+#![cfg(target_vendor = "apple")]
 #![allow(non_snake_case)]
 
 /*!

--- a/io-surface/Cargo.toml
+++ b/io-surface/Cargo.toml
@@ -15,7 +15,7 @@ default-target = "x86_64-apple-darwin"
 [lints]
 workspace = true
 
-[dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 core-foundation.workspace = true
 core-foundation-sys.workspace = true
 

--- a/io-surface/src/lib.rs
+++ b/io-surface/src/lib.rs
@@ -12,6 +12,7 @@
 #![deprecated = "use the objc2-io-surface crate instead"]
 #![crate_name = "io_surface"]
 #![crate_type = "rlib"]
+#![cfg(target_vendor = "apple")]
 
 // Rust bindings to the IOSurface framework on macOS.
 

--- a/io-surface/src/lib.rs
+++ b/io-surface/src/lib.rs
@@ -8,6 +8,7 @@
 // except according to those terms.
 
 //! This crate has been deprecated in favour of the `objc2-io-surface` crate.
+
 #![deprecated = "use the objc2-io-surface crate instead"]
 #![crate_name = "io_surface"]
 #![crate_type = "rlib"]


### PR DESCRIPTION
Add `target_vendor = "apple"` configuration consistently across the workspace.

These crates provide bindings to Apple frameworks, so they should only be built for Apple targets.

Previously, the dependencies and crate contents were not gated on the target platform. This meant Cargo could attempt to compile the crates, even when the target was not an Apple platform.

Closes https://github.com/servo/core-foundation-rs/pull/506