### PR TITLE
Bump `cocoa` to 0.27 version

### DIFF
--- a/cocoa/Cargo.toml
+++ b/cocoa/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cocoa"
 description = "Bindings to Cocoa for macOS"
-version = "0.26.1"
+version = "0.27.0"
 
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
The version of cocoa published on crates.io was never updated to use the latest version of core-graphics. This is just a version bump to pick up the core graphics 0.24 -> 0.25 update so that cocoa is then aligned with the other dependencies using it.

Fixes #737.